### PR TITLE
fix ios build pngData() to UIImagePNGRepresentation

### DIFF
--- a/ios/Classes/ThumbnailGenerator.swift
+++ b/ios/Classes/ThumbnailGenerator.swift
@@ -82,7 +82,7 @@ private extension UIImage {
         let directoryURL = directory.appendingPathComponent(SwiftWorkmanagerPlugin.identifier, isDirectory: true)
         let fileURL = directoryURL.appendingPathComponent("\(fileName).png")
         try FileManager.default.createDirectory(at: directoryURL, withIntermediateDirectories: true, attributes: nil)
-        guard let imageData = self.pngData() else {
+        guard let imageData = UIImagePNGRepresentation(self) else {
             throw error.cannotRepresentAsPNG(self)
         }
         try imageData.write(to: fileURL)


### PR DESCRIPTION
fixing error: 'pngData()' has been renamed to 'UIImagePNGRepresentation(_:)'
when build in ios
