### PR TITLE
Android: load Flutter engine asynchronously 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.5.0-dev.1
+
+* Android: Load Flutter environment asynchronously in the Worker task
+
 # 0.4.1
 
 * Bumps Android dependencies (Kotlin, AGP, workmanager 2.5.0)

--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -2,4 +2,3 @@ org.gradle.jvmargs=-Xmx1536M
 
 android.useAndroidX=true
 android.enableJetifier=true
-android.enableR8=true

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: workmanager
 description: Flutter Workmanager. This plugin allows you to schedule background work on Android and iOS.
-version: 0.4.1
+version: 0.5.0-dev.1
 homepage: https://github.com/fluttercommunity/flutter_workmanager
 repository: https://github.com/fluttercommunity/flutter_workmanager
 issue_tracker: https://github.com/fluttercommunity/flutter_workmanager/issues


### PR DESCRIPTION
This will reduce main thread jank by a little bit and reduce some deprecated API warnings.