### PR TITLE
Add kotlin_version requirements to ANDROID_SETUP.md (0.5.0-dev.7)

### DIFF
--- a/ANDROID_SETUP.md
+++ b/ANDROID_SETUP.md
@@ -1,7 +1,20 @@
+# Update build.gradle
+
+Make sure that your `kotlin_version to `1.4.0` or greater:
+
+```
+buildscript {
+    ext.kotlin_version = '1.4.+'
+    repositories {
+        google()
+        mavenCentral()
+    }
+    // ...
+```
+
 # Check your AndroidManifest.xml   
 
 Check if you have the following in your `AndroidManifest.xml` file.  
-You don't have to do anything else.    
 
 ```xml
 <meta-data


### PR DESCRIPTION
I ran into a Kotlin exception after running `flutter create` and adding this package to my pubspec. This [StackOverflow answer](https://stackoverflow.com/a/69555318/5859156) is the problem I ran into - it recommends setting the Kotlin version to 1.5.31.

This updates the ANDROID_SETUP.md to  recommend setting your project to use `1.4.+`, since that's smallest version upgrade that worked for me. 1.5.31 is the latest version so maybe we could recommend that.

`flutter create` specifies `1.3.50` stable channel. Maybe Flutter should be more flexible here - or there's a way to make this plugin compatible with this version?  