### PR TITLE
Flutter Beta Result Method Channel Fix

### DIFF
--- a/android/src/main/kotlin/be/tramckrijte/workmanager/BackgroundWorker.kt
+++ b/android/src/main/kotlin/be/tramckrijte/workmanager/BackgroundWorker.kt
@@ -151,7 +151,7 @@ class BackgroundWorker(
                         }
 
                         override fun error(
-                            errorCode: String?,
+                            errorCode: String,
                             errorMessage: String?,
                             errorDetails: Any?
                         ) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: workmanager
 description: Flutter Workmanager. This plugin allows you to schedule background work on Android and iOS.
-version: 0.5.0-dev.8-enfold
+version: 0.5.0-dev.8
 homepage: https://github.com/fluttercommunity/flutter_workmanager
 repository: https://github.com/fluttercommunity/flutter_workmanager
 issue_tracker: https://github.com/fluttercommunity/flutter_workmanager/issues

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: workmanager
 description: Flutter Workmanager. This plugin allows you to schedule background work on Android and iOS.
-version: 0.5.0-dev.8
+version: 0.5.0-dev.8-enfold
 homepage: https://github.com/fluttercommunity/flutter_workmanager
 repository: https://github.com/fluttercommunity/flutter_workmanager
 issue_tracker: https://github.com/fluttercommunity/flutter_workmanager/issues


### PR DESCRIPTION
A minor change in the latest beta flutter version (2.12.0-4.2.pre) was preventing our app to be built when depending on workmanager. A change to the Results method channel's error function removed the nullability of the errorCode parameter. This PR changes errorCode to be non-nullable and allowed our app to build properly.  