### PR TITLE
Documentation and example update to fix #374

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# next
+
+* Documentation and example update to fix (#374) WorkManager not working when App is obfuscated or using Flutter 3.1+
+
 # 0.5.0
 
 * Android: Remove jetifier from example

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ See sample folder for a complete working example.
 Before registering any task, the WorkManager plugin must be initialized.
 
 ```dart
+@pragma('vm:entry-point') // Mandatory if the App is obfuscated or using Flutter 3.1+
 void callbackDispatcher() {
   Workmanager().executeTask((task, inputData) {
     print("Native called background task: $backgroundTask"); //simpleTask will be emitted here.

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -18,6 +18,7 @@ const simplePeriodicTask =
 const simplePeriodic1HourTask =
     "be.tramckrijte.workmanagerExample.simplePeriodic1HourTask";
 
+@pragma('vm:entry-point') // Mandatory if the App is obfuscated or using Flutter 3.1+
 void callbackDispatcher() {
   Workmanager().executeTask((task, inputData) async {
     switch (task) {


### PR DESCRIPTION
Documentation and example update to fix (#374) WorkManager not working when App is obfuscated or using Flutter 3.1+