### PR TITLE
docs: Changed ext.kotlin_version version

### DIFF
--- a/ANDROID_SETUP.md
+++ b/ANDROID_SETUP.md
@@ -1,10 +1,10 @@
 # Update build.gradle
 
-Make sure that your kotlin_version to `1.5.0` or greater:
+Make sure that your kotlin_version to `1.8.0` or greater:
 
 ```
 buildscript {
-    ext.kotlin_version = '1.5.+'
+    ext.kotlin_version = '1.8.0+'
     repositories {
         google()
         mavenCentral()


### PR DESCRIPTION
The minimum `ext.kotlin_version` for WorkManager to **work** wasn't updated in the
[ANDROID_SETUP.md ](https://github.com/fluttercommunity/flutter_workmanager/blob/main/ANDROID_SETUP.md)  file. 

Apps (android) crash with the version set to < 1.8.0.  The [example](https://github.com/fluttercommunity/flutter_workmanager/blob/main/example/android/build.gradle) given uses 1.8.10