### PR TITLE
feat: Add privacy manifest

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -38,11 +38,11 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
   integration_test: 13825b8a9334a850581300559b8839134b124670
-  path_provider_foundation: 29f094ae23ebbca9d3d0cec13889cd9060c0e943
+  path_provider_foundation: 3784922295ac71e43754bd15e0653ccfd36a147c
   permission_handler_apple: 9878588469a2b0d0fc1e048d9f43605f92e6cec2
-  shared_preferences_foundation: 5b919d13b803cadd15ed2dc053125c68730e5126
+  shared_preferences_foundation: fcdcbc04712aee1108ac7fda236f363274528f78
   workmanager: 0afdcf5628bbde6924c21af7836fed07b42e30e6
 
 PODFILE CHECKSUM: b63d507eb7cc768afa26646638aaf07f371f6370
 
-COCOAPODS: 1.14.3
+COCOAPODS: 1.15.2

--- a/workmanager/CHANGELOG.md
+++ b/workmanager/CHANGELOG.md
@@ -1,7 +1,8 @@
-# next
+# 0.5.3
 
 * Android: Removed jetifier
 * Android: Removed V1 plugin APIs - this is now a Android V2 plugin only
+* iOS: Added a PrivacyManifest
 
 # 0.5.2
 

--- a/workmanager/ios/Resources/PrivacyInfo.xcprivacy
+++ b/workmanager/ios/Resources/PrivacyInfo.xcprivacy
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>CA92.1</string>
+			</array>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+		</dict>
+	</array>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyTracking</key>
+	<false/>
+</dict>
+</plist>

--- a/workmanager/ios/workmanager.podspec
+++ b/workmanager/ios/workmanager.podspec
@@ -18,5 +18,6 @@ Flutter Android Workmanager
 
   s.ios.deployment_target = '10.0'
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'VALID_ARCHS[sdk=iphonesimulator*]' => 'x86_64' }
+  s.resource_bundles = { 'flutter_workmanager_privacy' => ['Resources/PrivacyInfo.xcprivacy'] }
 end
 

--- a/workmanager/pubspec.yaml
+++ b/workmanager/pubspec.yaml
@@ -1,6 +1,6 @@
 name: workmanager
 description: Flutter Workmanager. This plugin allows you to schedule background work on Android and iOS.
-version: 0.5.2
+version: 0.5.3
 homepage: https://github.com/fluttercommunity/flutter_workmanager
 repository: https://github.com/fluttercommunity/flutter_workmanager
 issue_tracker: https://github.com/fluttercommunity/flutter_workmanager/issues


### PR DESCRIPTION
This PR adds a Privacy Manifest for iOS. It includes the Required Reason key for `UserDefaults`, as that is the only API that the package uses.

I declared reason `CA92.1` as I don't think workmanager tasks go across App Groups.

See also: https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api

Fixes #554 

cc @ened 