### PR TITLE
feat: Long-running workers on Android devices

### DIFF
--- a/workmanager/android/build.gradle
+++ b/workmanager/android/build.gradle
@@ -42,7 +42,6 @@ android {
 }
 
 dependencies {
-    implementation 'androidx.core:core:1.6.0'
     def work_version = "2.9.0"
     implementation "androidx.work:work-runtime:$work_version"
     implementation "androidx.concurrent:concurrent-futures:1.1.0"

--- a/workmanager/android/build.gradle
+++ b/workmanager/android/build.gradle
@@ -42,6 +42,7 @@ android {
 }
 
 dependencies {
+    implementation 'androidx.core:core:1.6.0'
     def work_version = "2.9.0"
     implementation "androidx.work:work-runtime:$work_version"
     implementation "androidx.concurrent:concurrent-futures:1.1.0"

--- a/workmanager/android/src/main/kotlin/dev/fluttercommunity/workmanager/BackgroundWorker.kt
+++ b/workmanager/android/src/main/kotlin/dev/fluttercommunity/workmanager/BackgroundWorker.kt
@@ -1,11 +1,17 @@
 package dev.fluttercommunity.workmanager
 
+import android.app.NotificationChannel
+import android.app.NotificationManager
 import android.content.Context
+import android.os.Build
 import android.os.Handler
 import android.os.Looper
 import android.util.Log
 import androidx.concurrent.futures.CallbackToFutureAdapter
+import androidx.core.app.NotificationCompat
+import androidx.work.ForegroundInfo
 import androidx.work.ListenableWorker
+import androidx.work.WorkManager
 import androidx.work.WorkerParameters
 import com.google.common.util.concurrent.ListenableFuture
 import io.flutter.embedding.engine.FlutterEngine
@@ -14,7 +20,8 @@ import io.flutter.embedding.engine.loader.FlutterLoader
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 import io.flutter.view.FlutterCallbackInformation
-import java.util.Random
+import java.util.*
+
 
 /***
  * A simple worker that will post your input back to your Flutter application.
@@ -37,6 +44,7 @@ class BackgroundWorker(
         const val BACKGROUND_CHANNEL_NAME =
             "be.tramckrijte.workmanager/background_channel_work_manager"
         const val BACKGROUND_CHANNEL_INITIALIZED = "backgroundChannelInitialized"
+        const val SET_FOREGROUND = "setForeground"
 
         private val flutterLoader = FlutterLoader()
     }
@@ -62,6 +70,49 @@ class BackgroundWorker(
             this.completer = completer
             null
         }
+
+    private fun createForegroundInfo(
+        setForegroundOptions: SetForeground
+    ): ForegroundInfo {
+        // This PendingIntent can be used to cancel the worker
+        val intent = WorkManager.getInstance(applicationContext)
+            .createCancelPendingIntent(getId())
+
+        // Create a Notification channel if necessary
+        createNotificationChannel(
+            setForegroundOptions.notificationChannelId,
+            setForegroundOptions.notificationChannelName,
+            setForegroundOptions.notificationChannelDescription,
+            setForegroundOptions.notificationChannelImportance
+        )
+        val notification = NotificationCompat.Builder(applicationContext, setForegroundOptions.notificationChannelId)
+            .setContentTitle(setForegroundOptions.notificationTitle)
+            .setTicker(setForegroundOptions.notificationTitle)
+            .setContentText(setForegroundOptions.notificationDescription)
+            .setOngoing(true)
+            .setSmallIcon(android.R.drawable.ic_dialog_info)
+            // Add the cancel action to the notification which can
+            // be used to cancel the worker
+            .addAction(android.R.drawable.ic_delete, "Cancel", intent)
+            .build()
+
+        return ForegroundInfo(
+            setForegroundOptions.notificationId,
+            notification,
+            setForegroundOptions.foregroundServiceType
+        )
+    }
+
+    fun createNotificationChannel(id: String, name: String, description: String, importance: Int) {
+        // Create a Notification channel
+        // Notification channels are only available in OREO and higher.
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val mChannel = NotificationChannel(id, name, importance)
+            mChannel.description = description
+            val notificationManager = applicationContext.getSystemService(NotificationManager::class.java)
+            notificationManager.createNotificationChannel(mChannel)
+        }
+    }
 
     override fun startWork(): ListenableFuture<Result> {
         startTime = System.currentTimeMillis()
@@ -141,35 +192,46 @@ class BackgroundWorker(
         }
     }
 
+    fun onBackgroundChannelInitialized() {
+        backgroundChannel.invokeMethod(
+            "onResultSend",
+            mapOf(DART_TASK_KEY to dartTask, PAYLOAD_KEY to payload),
+            object : MethodChannel.Result {
+                override fun notImplemented() {
+                    stopEngine(Result.failure())
+                }
+
+                override fun error(
+                    errorCode: String,
+                    errorMessage: String?,
+                    errorDetails: Any?,
+                ) {
+                    Log.e(TAG, "errorCode: $errorCode, errorMessage: $errorMessage")
+                    stopEngine(Result.failure())
+                }
+
+                override fun success(receivedResult: Any?) {
+                    val wasSuccessFul = receivedResult?.let { it as Boolean? } == true
+                    stopEngine(if (wasSuccessFul) Result.success() else Result.retry())
+                }
+            },
+        )
+    }
+
+    fun onSetForeground(setForegroundOptions: SetForeground) {
+        setForegroundAsync(createForegroundInfo(setForegroundOptions))
+    }
+
     override fun onMethodCall(
         call: MethodCall,
         r: MethodChannel.Result,
     ) {
         when (call.method) {
             BACKGROUND_CHANNEL_INITIALIZED ->
-                backgroundChannel.invokeMethod(
-                    "onResultSend",
-                    mapOf(DART_TASK_KEY to dartTask, PAYLOAD_KEY to payload),
-                    object : MethodChannel.Result {
-                        override fun notImplemented() {
-                            stopEngine(Result.failure())
-                        }
+                onBackgroundChannelInitialized()
 
-                        override fun error(
-                            errorCode: String,
-                            errorMessage: String?,
-                            errorDetails: Any?,
-                        ) {
-                            Log.e(TAG, "errorCode: $errorCode, errorMessage: $errorMessage")
-                            stopEngine(Result.failure())
-                        }
-
-                        override fun success(receivedResult: Any?) {
-                            val wasSuccessFul = receivedResult?.let { it as Boolean? } == true
-                            stopEngine(if (wasSuccessFul) Result.success() else Result.retry())
-                        }
-                    },
-                )
+            SET_FOREGROUND -> onSetForeground(Extractor.parseSetForegroundCall(call))
         }
+        r.success(null)
     }
 }

--- a/workmanager/android/src/main/kotlin/dev/fluttercommunity/workmanager/BackgroundWorker.kt
+++ b/workmanager/android/src/main/kotlin/dev/fluttercommunity/workmanager/BackgroundWorker.kt
@@ -11,7 +11,6 @@ import androidx.concurrent.futures.CallbackToFutureAdapter
 import androidx.core.app.NotificationCompat
 import androidx.work.ForegroundInfo
 import androidx.work.ListenableWorker
-import androidx.work.WorkManager
 import androidx.work.WorkerParameters
 import com.google.common.util.concurrent.ListenableFuture
 import io.flutter.embedding.engine.FlutterEngine
@@ -74,10 +73,6 @@ class BackgroundWorker(
     private fun createForegroundInfo(
         setForegroundOptions: SetForeground
     ): ForegroundInfo {
-        // This PendingIntent can be used to cancel the worker
-        val intent = WorkManager.getInstance(applicationContext)
-            .createCancelPendingIntent(getId())
-
         // Create a Notification channel if necessary
         createNotificationChannel(
             setForegroundOptions.notificationChannelId,
@@ -91,9 +86,6 @@ class BackgroundWorker(
             .setContentText(setForegroundOptions.notificationDescription)
             .setOngoing(true)
             .setSmallIcon(android.R.drawable.ic_dialog_info)
-            // Add the cancel action to the notification which can
-            // be used to cancel the worker
-            .addAction(android.R.drawable.ic_delete, "Cancel", intent)
             .build()
 
         return ForegroundInfo(
@@ -103,7 +95,7 @@ class BackgroundWorker(
         )
     }
 
-    fun createNotificationChannel(id: String, name: String, description: String, importance: Int) {
+    private fun createNotificationChannel(id: String, name: String, description: String, importance: Int) {
         // Create a Notification channel
         // Notification channels are only available in OREO and higher.
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
@@ -192,7 +184,7 @@ class BackgroundWorker(
         }
     }
 
-    fun onBackgroundChannelInitialized() {
+    private fun onBackgroundChannelInitialized() {
         backgroundChannel.invokeMethod(
             "onResultSend",
             mapOf(DART_TASK_KEY to dartTask, PAYLOAD_KEY to payload),
@@ -218,7 +210,7 @@ class BackgroundWorker(
         )
     }
 
-    fun onSetForeground(setForegroundOptions: SetForeground) {
+    private fun onSetForeground(setForegroundOptions: SetForeground) {
         setForegroundAsync(createForegroundInfo(setForegroundOptions))
     }
 

--- a/workmanager/android/src/main/kotlin/dev/fluttercommunity/workmanager/WorkmanagerCallHandler.kt
+++ b/workmanager/android/src/main/kotlin/dev/fluttercommunity/workmanager/WorkmanagerCallHandler.kt
@@ -1,6 +1,7 @@
 package dev.fluttercommunity.workmanager
 
 import android.content.Context
+import android.content.pm.ServiceInfo
 import androidx.work.Constraints
 import androidx.work.Data
 import androidx.work.ExistingPeriodicWorkPolicy

--- a/workmanager/lib/src/workmanager.dart
+++ b/workmanager/lib/src/workmanager.dart
@@ -75,8 +75,8 @@ typedef BackgroundTaskHandler = Future<bool> Function(
 class Workmanager {
   factory Workmanager() => _instance;
 
-  Workmanager._internal(
-      MethodChannel backgroundChannel, MethodChannel foregroundChannel)
+  Workmanager._internal(MethodChannel backgroundChannel,
+      MethodChannel foregroundChannel)
       : _backgroundChannel = backgroundChannel,
         _foregroundChannel = foregroundChannel;
 
@@ -150,14 +150,13 @@ class Workmanager {
   /// [callbackDispatcher] is a top level function which will be invoked by
   /// Android or iOS. See the discussion on [BackgroundTaskHandler] for details.
   /// [isInDebugMode] true will post debug notifications with information about when a task should have run
-  Future<void> initialize(
-    final Function callbackDispatcher, {
+  Future<void> initialize(final Function callbackDispatcher, {
     final bool isInDebugMode = false,
   }) async {
     Workmanager._isInDebugMode = isInDebugMode;
     final callback = PluginUtilities.getCallbackHandle(callbackDispatcher);
     assert(callback != null,
-        "The callbackDispatcher needs to be either a static function or a top level function to be accessible as a Flutter entry point.");
+    "The callbackDispatcher needs to be either a static function or a top level function to be accessible as a Flutter entry point.");
     if (callback != null) {
       final int handle = callback.toRawHandle();
       await _foregroundChannel.invokeMethod<void>(
@@ -179,31 +178,32 @@ class Workmanager {
   /// The [taskName] is the value that will be returned in the [BackgroundTaskHandler]
   /// The [inputData] is the input data for task. Valid value types are: int, bool, double, String and their list
   Future<void> registerOneOffTask(
-    /// Only supported on Android.
-    final String uniqueName,
 
-    /// Only supported on Android.
-    final String taskName, {
-    /// Only supported on Android.
-    final String? tag,
+      /// Only supported on Android.
+      final String uniqueName,
 
-    /// Only supported on Android.
-    final ExistingWorkPolicy? existingWorkPolicy,
+      /// Only supported on Android.
+      final String taskName, {
+        /// Only supported on Android.
+        final String? tag,
 
-    /// Configures a initial delay.
-    ///
-    /// The delay configured here is not guaranteed. The underlying system may
-    /// decide to schedule the ask a lot later.
-    final Duration initialDelay = Duration.zero,
+        /// Only supported on Android.
+        final ExistingWorkPolicy? existingWorkPolicy,
 
-    /// Fully supported on Android, but only partially supported on iOS.
-    /// See [Constraints] for details.
-    final Constraints? constraints,
-    final BackoffPolicy? backoffPolicy,
-    final Duration backoffPolicyDelay = Duration.zero,
-    final OutOfQuotaPolicy? outOfQuotaPolicy,
-    final Map<String, dynamic>? inputData,
-  }) async =>
+        /// Configures a initial delay.
+        ///
+        /// The delay configured here is not guaranteed. The underlying system may
+        /// decide to schedule the ask a lot later.
+        final Duration initialDelay = Duration.zero,
+
+        /// Fully supported on Android, but only partially supported on iOS.
+        /// See [Constraints] for details.
+        final Constraints? constraints,
+        final BackoffPolicy? backoffPolicy,
+        final Duration backoffPolicyDelay = Duration.zero,
+        final OutOfQuotaPolicy? outOfQuotaPolicy,
+        final Map<String, dynamic>? inputData,
+      }) async =>
       await _foregroundChannel.invokeMethod(
         "registerOneOffTask",
         JsonMapperHelper.toRegisterMethodArgument(
@@ -242,20 +242,19 @@ class Workmanager {
   /// [iOS 13+ Using background tasks to update your app](https://developer.apple.com/documentation/uikit/app_and_environment/scenes/preparing_your_ui_to_run_in_the_background/using_background_tasks_to_update_your_app/)
   ///
   /// [iOS 13+ BGAppRefreshTask](https://developer.apple.com/documentation/backgroundtasks/bgapprefreshtask/)
-  Future<void> registerPeriodicTask(
-    final String uniqueName,
-    final String taskName, {
-    final Duration? frequency,
-    final Duration? flexInterval,
-    final String? tag,
-    final ExistingWorkPolicy? existingWorkPolicy,
-    final Duration initialDelay = Duration.zero,
-    final Constraints? constraints,
-    final BackoffPolicy? backoffPolicy,
-    final Duration backoffPolicyDelay = Duration.zero,
-    final OutOfQuotaPolicy? outOfQuotaPolicy,
-    final Map<String, dynamic>? inputData,
-  }) async =>
+  Future<void> registerPeriodicTask(final String uniqueName,
+      final String taskName, {
+        final Duration? frequency,
+        final Duration? flexInterval,
+        final String? tag,
+        final ExistingWorkPolicy? existingWorkPolicy,
+        final Duration initialDelay = Duration.zero,
+        final Constraints? constraints,
+        final BackoffPolicy? backoffPolicy,
+        final Duration backoffPolicyDelay = Duration.zero,
+        final OutOfQuotaPolicy? outOfQuotaPolicy,
+        final Map<String, dynamic>? inputData,
+      }) async =>
       await _foregroundChannel.invokeMethod(
         "registerPeriodicTask",
         JsonMapperHelper.toRegisterMethodArgument(
@@ -299,15 +298,14 @@ class Workmanager {
   /// [iOS 13+ Using background tasks to update your app](https://developer.apple.com/documentation/uikit/app_and_environment/scenes/preparing_your_ui_to_run_in_the_background/using_background_tasks_to_update_your_app/)
   ///
   /// [iOS 13+ BGProcessingTask](https://developer.apple.com/documentation/backgroundtasks/bgprocessingtask/)
-  Future<void> registerProcessingTask(
-    final String uniqueName,
-    final String taskName, {
-    final Duration initialDelay = Duration.zero,
+  Future<void> registerProcessingTask(final String uniqueName,
+      final String taskName, {
+        final Duration initialDelay = Duration.zero,
 
-    /// Only partially supported on iOS.
-    /// See [Constraints] for details.
-    final Constraints? constraints,
-  }) async =>
+        /// Only partially supported on iOS.
+        /// See [Constraints] for details.
+        final Constraints? constraints,
+      }) async =>
       await _foregroundChannel.invokeMethod(
         "registerProcessingTask",
         JsonMapperHelper.toRegisterMethodArgument(
@@ -336,6 +334,10 @@ class Workmanager {
   /// Cancels all tasks
   Future<void> cancelAll() async =>
       await _foregroundChannel.invokeMethod("cancelAllTasks");
+
+  /// Sets the foreground options for the task.
+  Future<void> setForeground(SetForegroundOptions options) async =>
+      await _backgroundChannel.invokeMethod("setForeground", options.toMap());
 
   /// Prints details of un-executed scheduled tasks to console. To be used during
   /// development/debugging.
@@ -416,5 +418,98 @@ class JsonMapperHelper {
   }
 
   static String? _enumToString(final dynamic enumeration) =>
-      enumeration?.toString().split('.').last;
+      enumeration
+          ?.toString()
+          .split('.')
+          .last;
+}
+
+class SetForegroundOptions {
+  final int foregroundServiceType;
+  final int notificationId;
+
+  final String notificationChannelId;
+  final String notificationChannelName;
+  final String notificationChannelDescription;
+  final int notificationChannelImportance;
+
+  final String notificationTitle;
+  final String notificationDescription;
+
+  SetForegroundOptions({required this.foregroundServiceType,
+    required this.notificationId,
+    required this.notificationChannelId,
+    required this.notificationChannelName,
+    required this.notificationChannelDescription,
+    required this.notificationChannelImportance,
+    required this.notificationTitle,
+    required this.notificationDescription});
+
+  Map<String, dynamic> toMap() {
+    return {
+      "foregroundServiceType": foregroundServiceType,
+      "notificationId": notificationId,
+      "notificationChannelId": notificationChannelId,
+      "notificationChannelName": notificationChannelName,
+      "notificationChannelDescription": notificationChannelDescription,
+      "notificationChannelImportance": notificationChannelImportance,
+      "notificationTitle": notificationTitle,
+      "notificationDescription": notificationDescription,
+    };
+  }
+
+  SetForegroundOptions copyWith({
+    int? foregroundServiceType,
+    int? notificationId,
+    String? notificationChannelId,
+    String? notificationChannelName,
+    String? notificationChannelDescription,
+    int? notificationChannelImportance,
+    String? notificationTitle,
+    String? notificationDescription,
+  }) {
+    return SetForegroundOptions(
+      foregroundServiceType:
+      foregroundServiceType ?? this.foregroundServiceType,
+      notificationId: notificationId ?? this.notificationId,
+      notificationChannelId:
+      notificationChannelId ?? this.notificationChannelId,
+      notificationChannelName:
+      notificationChannelName ?? this.notificationChannelName,
+      notificationChannelDescription:
+      notificationChannelDescription ?? this.notificationChannelDescription,
+      notificationChannelImportance:
+      notificationChannelImportance ?? this.notificationChannelImportance,
+      notificationTitle: notificationTitle ?? this.notificationTitle,
+      notificationDescription:
+      notificationDescription ?? this.notificationDescription,
+    );
+  }
+}
+
+class ForegroundServiceType {
+  static const int dataSync = 1 << 0;
+  static const int mediaPlayback = 1 << 1;
+  static const int phoneCall = 1 << 2;
+  static const int location = 1 << 3;
+  static const int connectedDevice = 1 << 4;
+  static const int mediaProjection = 1 << 5;
+  static const int camera = 1 << 6;
+  static const int microphone = 1 << 7;
+  static const int health = 1 << 8;
+  static const int remoteMessaging = 1 << 9;
+  static const int systemExempted = 1 << 10;
+  static const int shortService = 1 << 11;
+  static const int fileManagement = 1 << 12;
+  static const int specialUse = 1 << 30;
+  static const int manifest = -1;
+}
+
+class NotificationImportance {
+  static const int none = 0;
+  static const int min = 1;
+  static const int low = 2;
+  static const int defaultImportance = 3;
+  static const int high = 4;
+  static const int max = 5;
 }

--- a/workmanager/lib/workmanager.dart
+++ b/workmanager/lib/workmanager.dart
@@ -2,3 +2,6 @@ library workmanager;
 
 export 'src/options.dart';
 export 'src/workmanager.dart' show Workmanager;
+export 'src/workmanager.dart' show SetForegroundOptions;
+export 'src/workmanager.dart' show ForegroundServiceType;
+export 'src/workmanager.dart' show NotificationImportance;


### PR DESCRIPTION
This pull request introduces foreground service support on Android devices as per Android workmanager docs [Support for long-running workers](https://developer.android.com/develop/background-work/background-tasks/persistent/how-to/long-running).

Foreground service support:

* Added new methods `createForegroundInfo` and `createNotificationChannel` in `BackgroundWorker.kt` to handle the creation of foreground notifications and channels.
* Introduced `SetForeground` data class and `parseSetForegroundCall` method in `Extractor.kt` to parse method calls related to setting foreground options. [[1]](diffhunk://#diff-69804aac1d3932e93197f3a7069163aa47520bfeb86e6cc809c205c51cb90e84L162-R175) [[2]](diffhunk://#diff-69804aac1d3932e93197f3a7069163aa47520bfeb86e6cc809c205c51cb90e84R206-R233)
* Added `setForeground` method and `SetForegroundOptions` class in `workmanager.dart` to set foreground options from Dart code. [[1]](diffhunk://#diff-a9b50d6d6364e7d5bcbd6a6bd19c593490ee9ed567f305d0801d4875d9d9be22R338-R341) [[2]](diffhunk://#diff-a9b50d6d6364e7d5bcbd6a6bd19c593490ee9ed567f305d0801d4875d9d9be22L419-R514)

Code refactoring and improvements:

* Refactored `onMethodCall` method in `BackgroundWorker.kt` to handle the new `SET_FOREGROUND` method call.
* Updated imports and removed redundant imports in `BackgroundWorker.kt` and `Extractor.kt`. [[1]](diffhunk://#diff-da81545df156aafd48ee64975899de898bbc1f0e58df797206853f32dc22dea0R3-R12) [[2]](diffhunk://#diff-69804aac1d3932e93197f3a7069163aa47520bfeb86e6cc809c205c51cb90e84L5-R5)

These changes allows tasks to run as foreground services.

This PR addresses issue https://github.com/fluttercommunity/flutter_workmanager/issues/236, but goes against the recomendation on https://github.com/fluttercommunity/flutter_workmanager/pull/511 of using `Workmanager.registerProcessingTask`  to implement long-running wokers on android.
Since the implementation of long-running workers on Android tightly depends on specific requirements such as handling notifications and activating a foreground service on the run, a decision was made to create a dedicated API which laverages [ListenableWorker.serForegroundAsync](https://developer.android.com/reference/androidx/work/ListenableWorker#setProgressAsync(androidx.work.Data)) and minimally handles notification management in order to implement long-running workers while following android guidelines. 