### PR TITLE
fix: Charging and network constraints being swapped when scheduling IOS BGProcessingTask

### DIFF
--- a/workmanager/ios/Classes/SwiftWorkmanagerPlugin.swift
+++ b/workmanager/ios/Classes/SwiftWorkmanagerPlugin.swift
@@ -395,8 +395,8 @@ extension SwiftWorkmanagerPlugin: FlutterPlugin {
             SwiftWorkmanagerPlugin.scheduleBackgroundProcessingTask(
                 withIdentifier: uniqueTaskIdentifier,
                 earliestBeginInSeconds: delaySeconds,
-                requiresNetworkConnectivity: requiresCharging,
-                requiresExternalPower: requiresNetwork)
+                requiresNetworkConnectivity: requiresNetwork,
+                requiresExternalPower: requiresCharging)
 
             result(true)
             return


### PR DESCRIPTION
copy https://github.com/fluttercommunity/flutter_workmanager/pull/562/files