### PR TITLE
fix(android): prevent crash if callbackInfo is null in BackgroundWorker (fixes #527)

### DIFF
--- a/workmanager_android/android/src/main/kotlin/dev/fluttercommunity/workmanager/BackgroundWorker.kt
+++ b/workmanager_android/android/src/main/kotlin/dev/fluttercommunity/workmanager/BackgroundWorker.kt
@@ -93,7 +93,8 @@ class BackgroundWorker(
 
             if (callbackInfo == null) {
                 Log.e(TAG, "Failed to resolve Dart callback for handle $callbackHandle.")
-                return Result.failure()
+                completer?.set(Result.failure())
+                return@ensureInitializationCompleteAsync
             }
 
             val dartBundlePath = flutterLoader.findAppBundlePath()

--- a/workmanager_android/android/src/main/kotlin/dev/fluttercommunity/workmanager/BackgroundWorker.kt
+++ b/workmanager_android/android/src/main/kotlin/dev/fluttercommunity/workmanager/BackgroundWorker.kt
@@ -90,6 +90,12 @@ class BackgroundWorker(
         ) {
             val callbackHandle = SharedPreferenceHelper.getCallbackHandle(applicationContext)
             val callbackInfo = FlutterCallbackInformation.lookupCallbackInformation(callbackHandle)
+
+            if (callbackInfo == null) {
+                Log.e(TAG, "Failed to resolve Dart callback for handle $callbackHandle.")
+                return Result.failure()
+            }
+
             val dartBundlePath = flutterLoader.findAppBundlePath()
 
             if (isInDebug) {


### PR DESCRIPTION
Fixes https://github.com/fluttercommunity/flutter_workmanager/issues/527

This PR prevents a `NullPointerException` when `FlutterCallbackInformation.lookupCallbackInformation(...)` returns `null` in `BackgroundWorker.kt`.

### Cause

If the stored callback handle (retrieved from `SharedPreferences`) is invalid or stale, `lookupCallbackInformation(...)` returns `null`. The existing code attempts to access `callbackInfo.callbackLibraryPath` without checking for null, which crashes the app.

### Fix

Add a null check for `callbackInfo` and fail gracefully:

```kotlin
if (callbackInfo == null) {
    Log.e(TAG, "Failed to resolve Dart callback for handle $callbackHandle.")
    completer?.set(Result.failure())
    return@ensureInitializationCompleteAsync
}
```

This should prevent the app from terminating with an error such as those mentioned in the linked issue:
`Attempt to read from field 'java.lang.String io.flutter.view.FlutterCallbackInformation.callbackLibraryPath'`

EDIT: fixed compilation error on return thanks to @Tulleb