### PR TITLE
fix(android): prevent crash if callbackInfo is null in BackgroundWorker (fixes #527)

### DIFF
--- a/workmanager_android/android/src/main/kotlin/dev/fluttercommunity/workmanager/BackgroundWorker.kt
+++ b/workmanager_android/android/src/main/kotlin/dev/fluttercommunity/workmanager/BackgroundWorker.kt
@@ -90,6 +90,13 @@ class BackgroundWorker(
         ) {
             val callbackHandle = SharedPreferenceHelper.getCallbackHandle(applicationContext)
             val callbackInfo = FlutterCallbackInformation.lookupCallbackInformation(callbackHandle)
+
+            if (callbackInfo == null) {
+                Log.e(TAG, "Failed to resolve Dart callback for handle $callbackHandle.")
+                completer?.set(Result.failure())
+                return@ensureInitializationCompleteAsync
+            }
+
             val dartBundlePath = flutterLoader.findAppBundlePath()
 
             if (isInDebug) {


### PR DESCRIPTION
Fixes #527 and also properly compile.

The previously opened PR #615 is currently having [the following issue](https://github.com/fluttercommunity/flutter_workmanager/pull/615#issuecomment-3083342493).

@jonathanduke let me know if you commit a fix on your PR; I'll close this one then.