### PR TITLE
fix(android): prevent PlatformException after initialize on first run (fixes #645)

### DIFF
--- a/workmanager_android/android/src/main/kotlin/dev/fluttercommunity/workmanager/WorkmanagerPlugin.kt
+++ b/workmanager_android/android/src/main/kotlin/dev/fluttercommunity/workmanager/WorkmanagerPlugin.kt
@@ -11,6 +11,9 @@ private const val INIT_REQUIRED =
     "You have not properly initialized the Flutter WorkManager Package. " +
         "You should ensure you have called the 'initialize' function first!"
 
+private const val INIT_FAILED =
+    "Workmanager.initialize failed because 'callbackHandle' was invalid."
+
 /**
  * Pigeon-based implementation of WorkmanagerHostApi for Android.
  * Replaces the manual method channel and data extraction approach.
@@ -47,7 +50,14 @@ class WorkmanagerPlugin :
         callback: (Result<Unit>) -> Unit,
     ) {
         try {
-            preferenceManager.saveCallbackDispatcherHandleKey(request.callbackHandle)
+            val handle = request.callbackHandle
+            if (handle <= 0L) {
+                callback(Result.failure(Exception(INIT_FAILED)))
+                return
+            }
+
+            preferenceManager.saveCallbackDispatcherHandleKey(handle)
+            currentDispatcherHandle = handle
             callback(Result.success(Unit))
         } catch (e: Exception) {
             callback(Result.failure(e))


### PR DESCRIPTION
Fixes fluttercommunity/flutter_workmanager#645

### Cause
The SharedPrefs value for the dispatcher handle is set during initialize, but the local `currentDispatcherHandle` variable was not updated.

### Fix
```kotlin
override fun initialize(
    request: InitializeRequest,
    callback: (Result<Unit>) -> Unit,
) {
    try {
        // get the handle first
        val handle = request.callbackHandle

        // make sure it's not invalid
        if (handle <= 0L) {
            callback(Result.failure(Exception(INIT_FAILED)))
            return
        }

        // store in SharedPrefs as before
        preferenceManager.saveCallbackDispatcherHandleKey(handle)

        // additionally, set the local variable to match
        currentDispatcherHandle = handle

        // continue as before
        callback(Result.success(Unit))
    } catch (e: Exception) {
        callback(Result.failure(e))
    }
}

```