### PR TITLE
fix: NullPointerException by replacing companion FlutterLoader with FlutterInjector singleton

### DIFF
--- a/workmanager_android/CHANGELOG.md
+++ b/workmanager_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.9.1
+
+- **FIX**: NullPointerException on io.flutter.embedding.engine.loader.FlutterApplicationInfo.flutterAssetsDir, when App and WorkManager task triggers at the same time
+
 ## 0.9.0+2
 
  - **FIX**: Android initialization bug and iOS 14 availability annotations (#647).

--- a/workmanager_android/android/src/main/kotlin/dev/fluttercommunity/workmanager/BackgroundWorker.kt
+++ b/workmanager_android/android/src/main/kotlin/dev/fluttercommunity/workmanager/BackgroundWorker.kt
@@ -9,6 +9,7 @@ import androidx.work.WorkerParameters
 import com.google.common.util.concurrent.ListenableFuture
 import dev.fluttercommunity.workmanager.pigeon.TaskStatus
 import dev.fluttercommunity.workmanager.pigeon.WorkmanagerFlutterApi
+import io.flutter.FlutterInjector
 import io.flutter.embedding.engine.FlutterEngine
 import io.flutter.embedding.engine.dart.DartExecutor
 import io.flutter.embedding.engine.loader.FlutterLoader
@@ -29,8 +30,6 @@ class BackgroundWorker(
     companion object {
         const val PAYLOAD_KEY = "dev.fluttercommunity.workmanager.INPUT_DATA"
         const val DART_TASK_KEY = "dev.fluttercommunity.workmanager.DART_TASK"
-
-        private val flutterLoader = FlutterLoader()
     }
 
     private val payload
@@ -65,7 +64,7 @@ class BackgroundWorker(
     override fun startWork(): ListenableFuture<Result> {
         startTime = System.currentTimeMillis()
 
-        engine = FlutterEngine(applicationContext)
+        val flutterLoader: FlutterLoader = FlutterInjector.instance().flutterLoader()
 
         if (!flutterLoader.initialized()) {
             flutterLoader.startInitialization(applicationContext)
@@ -76,6 +75,7 @@ class BackgroundWorker(
             null,
             Handler(Looper.getMainLooper()),
         ) {
+            engine = FlutterEngine(applicationContext)
             val callbackHandle = SharedPreferenceHelper.getCallbackHandle(applicationContext)
             val callbackInfo = FlutterCallbackInformation.lookupCallbackInformation(callbackHandle)
 

--- a/workmanager_android/pubspec.yaml
+++ b/workmanager_android/pubspec.yaml
@@ -1,6 +1,6 @@
 name: workmanager_android
 description: Android implementation of the workmanager plugin.
-version: 0.9.0+2
+version: 0.9.1
 # publish_to: none
 homepage: https://github.com/fluttercommunity/flutter_workmanager
 repository: https://github.com/fluttercommunity/flutter_workmanager


### PR DESCRIPTION
Replace companion `FlutterLoader` with FlutterInjector singleton `FlutterInjector.instance().flutterLoader` and defer `FlutterEngine` creation to fix NullPointerException on io.flutter.embedding.engine.loader.FlutterApplicationInfo.flutterAssetsDir, when App and workmanager triggers at the same time.

**Change 1:** Remove the separate companion FlutterLoader:
The private val flutterLoader = FlutterLoader() in the companion object created a second FlutterLoader instance independent of FlutterInjector.instance().flutterLoader(). This meant the worker initialized one loader while FlutterEngine and the main app used a different one, causing flutterApplicationInfo to be null on the injector's loader when findAppBundlePath() was called. It also caused two separate FlutterJNI.loadLibrary calls, producing the repeated "called more than once" warnings.
The fix uses FlutterInjector.instance().flutterLoader() directly in startWork(), ensuring the worker, the FlutterEngine, and the main app's Activity delegate all operate on the exact same loader instance throughout the process lifetime.

**Change 2:** Move FlutterEngine creation inside the ensureInitializationCompleteAsync callback:
Previously engine = FlutterEngine(applicationContext) was called before startInitialization, meaning the engine's internal initialization raced with the subsequent loader init. Moving the engine creation inside the callback guarantees the loader is fully initialized before the engine is constructed, eliminating the race entirely.

Fixes: #671
Closes: #671