### PR TITLE
fix: Failed host lookup, by bumping androidx.work:work-runtime to 2.11.2 and Android minSdkVersion to 23

### DIFF
--- a/workmanager_android/CHANGELOG.md
+++ b/workmanager_android/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.10.0
+
+- **FIX**: Failed host lookup when WorkManager initiates network calls in a background task on Android 15+
+- **BREAKING** Bumps Android minSdkVersion to 23 due to androidx.work:work-runtime:2.11.2
+
 ## 0.9.0+2
 
  - **FIX**: Android initialization bug and iOS 14 availability annotations (#647).

--- a/workmanager_android/android/build.gradle
+++ b/workmanager_android/android/build.gradle
@@ -23,7 +23,7 @@ android {
     }
     defaultConfig {
         compileSdk 35
-        minSdkVersion 19
+        minSdkVersion 23
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     lintOptions {
@@ -43,7 +43,7 @@ android {
 }
 
 dependencies {
-    def work_version = "2.10.2"
+    def work_version = "2.11.2"
     implementation "androidx.work:work-runtime:$work_version"
     implementation "androidx.concurrent:concurrent-futures:1.1.0"
 

--- a/workmanager_android/pubspec.yaml
+++ b/workmanager_android/pubspec.yaml
@@ -1,6 +1,6 @@
 name: workmanager_android
 description: Android implementation of the workmanager plugin.
-version: 0.9.0+2
+version: 0.10.0
 # publish_to: none
 homepage: https://github.com/fluttercommunity/flutter_workmanager
 repository: https://github.com/fluttercommunity/flutter_workmanager


### PR DESCRIPTION
- **FIX**: Failed host lookup when flutter_workmanager calls APIs in a background task on Android 15+
- **BREAKING** Bumps Android minSdkVersion to 23 since the fix is in androidx.work:work-runtime:2.11.2 where minSdkVersion is 23

Fixes: #666
Closes: #666