### PR TITLE
fix(ios): pass taskName to callback and honor initialDelay for one-off tasks

### DIFF
--- a/example/integration_test/workmanager_integration_test.dart
+++ b/example/integration_test/workmanager_integration_test.dart
@@ -10,6 +10,10 @@ import 'package:workmanager/workmanager.dart';
 const String dataTransferTaskName =
     'dev.fluttercommunity.integrationTest.dataTransferTask';
 const String retryTaskName = 'dev.fluttercommunity.integrationTest.retryTask';
+const String oneOffUniqueName =
+    'dev.fluttercommunity.integrationTest.oneOffUniqueName';
+const String oneOffTaskName =
+    'dev.fluttercommunity.integrationTest.oneOffTaskName';
 
 /// One retry is enough to test the retry logic
 const int kMaxRetryAttempts = 1;
@@ -53,6 +57,12 @@ void callbackDispatcher() {
           print('Unsupported data type for key $key: $value');
         }
       }
+    }
+    if (task == oneOffTaskName) {
+      // Verifies that the callback receives the `taskName` (not the
+      // `uniqueName`) when they differ, matching Android behavior.
+      SharedPreferences prefs = await SharedPreferences.getInstance();
+      await prefs.setString(inputData!['result_key'], task);
     }
     return true;
   });
@@ -196,6 +206,32 @@ void main() {
           rethrow;
         }
       }
+    });
+
+    testWidgets(
+        'registerOneOffTask passes taskName (not uniqueName) to callback',
+        (WidgetTester tester) async {
+      await workmanager.initialize(callbackDispatcher);
+
+      final resultKey = Uuid().v4().toString();
+
+      await workmanager.registerOneOffTask(
+        oneOffUniqueName,
+        oneOffTaskName,
+        inputData: {'result_key': resultKey},
+      );
+
+      // The task runs immediately; poll for the callback result.
+      for (int i = 0; i < 20; i++) {
+        await Future.delayed(const Duration(seconds: 1));
+        SharedPreferences prefs = await SharedPreferences.getInstance();
+        await prefs.reload();
+        if (prefs.getString(resultKey) == oneOffTaskName) {
+          return;
+        }
+      }
+      fail(
+          'Callback did not receive the taskName (received uniqueName instead).');
     });
 
     testWidgets('registerOneOffTask with all parameters (Android)',

--- a/workmanager/lib/src/workmanager_impl.dart
+++ b/workmanager/lib/src/workmanager_impl.dart
@@ -138,6 +138,9 @@ class Workmanager {
   /// This is used by iOS and Android to identify which task was selected to run in the background.
   /// The [BackgroundTaskHandler] will provide you with the [taskName] and the [inputData].
   /// The [taskName] will always be the value you provided when registering the task.
+  /// On iOS, periodic and processing tasks are identified by the BGTaskScheduler
+  /// identifier, so for those task types the handler receives the [uniqueName]
+  /// you registered the task with.
   /// The [inputData] will contain all the data you registered the task with.
   ///
   /// You need to return a [Future<bool>] that will tell the OS if the task was successful or not.
@@ -161,9 +164,13 @@ class Workmanager {
   ///
   /// Calling this method again with the same [uniqueName] will update the current pending task, unless an [ExistingWorkPolicy] is provided.
   ///
-  /// - [taskName]: is the value that will be returned in the [BackgroundTaskHandler], ignored on iOS where you should use [uniqueName].
+  /// - [taskName]: is the value that will be returned in the [BackgroundTaskHandler]. Supported on both Android and iOS.
   /// - [inputData]: is the input data for task. Valid value types are: int, bool, double, String and their list
-  /// - [initialDelay]: is an [Duration] after which the task will run. Ignored on iOS where you should schedule the task in AppDelegate.swift
+  /// - [initialDelay]: is an [Duration] after which the task will run.
+  ///   On Android the task is scheduled by the OS and survives app restarts.
+  ///   On iOS the delay is honored while the app stays alive, but iOS may
+  ///   terminate the app before the task can run (background execution is
+  ///   limited to a short budget). Use a processing task for long-running work.
   /// - [constraints]: are the requirements that need to be met before the task runs.
   /// - [backoffPolicy]: is the backoff policy to use when retrying work.
   /// - [backoffPolicyDelay]: is the delay for the backoff policy.
@@ -203,14 +210,16 @@ class Workmanager {
   /// it's frequency if it takes more than 30 seconds.
   ///
   /// A [uniqueName] is required so only one task can be registered.
-  /// The [taskName] is the value that will be returned in the [BackgroundTaskHandler], ignored on iOS where you should use [uniqueName].
+  /// The [taskName] is the value that will be returned in the [BackgroundTaskHandler].
+  /// On iOS the handler receives the BGTaskScheduler identifier (the [uniqueName]),
+  /// because the identifier is what you register in Info.plist and AppDelegate.
   /// a [frequency] is not required and will be defaulted to 15 minutes if not provided.
   /// a [frequency] has a minimum of 15 min. Android will automatically change your frequency to 15 min if you have configured a lower frequency.
   /// the [flexInterval] If the nature of the work is time-sensitive, you can configure the PeriodicWorkRequest to run in a flexible period at each interval.
   /// The [inputData] is the input data for task. Valid value types are: int, bool, double, String and their list
   ///
   /// Unlike Android, you cannot set [frequency] for iOS here rather you have to set in `AppDelegate.swift` while registering the task.
-  /// The [inputData] is the input data for task. Valid value types are: int, bool, double, String and their list. It is not supported on iOS.
+  /// The [inputData] is the input data for task. Valid value types are: int, bool, double, String and their list.
   ///
   /// For iOS see Apple docs:
   /// [iOS 13+ Using background tasks to update your app](https://developer.apple.com/documentation/uikit/app_and_environment/scenes/preparing_your_ui_to_run_in_the_background/using_background_tasks_to_update_your_app/)

--- a/workmanager_apple/ios/workmanager_apple/Sources/workmanager_apple/WorkmanagerPlugin.swift
+++ b/workmanager_apple/ios/workmanager_apple/Sources/workmanager_apple/WorkmanagerPlugin.swift
@@ -77,7 +77,7 @@ public class WorkmanagerPlugin: FlutterPluginAppLifeCycleDelegate, FlutterPlugin
     /// Starts a one-off background task with the specified input data.
     ///
     /// - Parameters:
-    ///   - identifier: Task identifier
+    ///   - identifier: Task identifier (used for the task name passed to the Dart callback)
     ///   - taskIdentifier: iOS background task identifier for lifecycle management
     ///   - inputData: Input data to pass to the Flutter task
     ///   - delaySeconds: Delay before task execution
@@ -91,7 +91,13 @@ public class WorkmanagerPlugin: FlutterPluginAppLifeCycleDelegate, FlutterPlugin
         )
 
         operation.completionBlock = { UIApplication.shared.endBackgroundTask(taskIdentifier) }
-        operationQueue.addOperation(operation)
+        if delaySeconds > 0 {
+            DispatchQueue.global().asyncAfter(deadline: .now() + Double(delaySeconds)) {
+                operationQueue.addOperation(operation)
+            }
+        } else {
+            operationQueue.addOperation(operation)
+        }
     }
 
     /// Registers a periodic background task with iOS BGTaskScheduler.
@@ -226,7 +232,10 @@ public class WorkmanagerPlugin: FlutterPluginAppLifeCycleDelegate, FlutterPlugin
             })
 
             WorkmanagerPlugin.startOneOffTask(
-                identifier: request.uniqueName,
+                // The callback task name must match the `taskName` provided from Dart
+                // (Android already forwards `taskName`). The `uniqueName` is still
+                // used for the background task debug name above.
+                identifier: request.taskName,
                 taskIdentifier: taskIdentifier,
                 inputData: request.inputData as? [String: Any],
                 delaySeconds: delaySeconds


### PR DESCRIPTION
## What changed

Two related iOS one-off task bugs, both in the `registerOneOffTask` path:

1. **Callback received `uniqueName` instead of `taskName`** (#670). `startOneOffTask` was called with `request.uniqueName` as the operation identifier, which is what the native bridge forwards to the Dart callback. It now forwards `request.taskName`, matching Android behavior. The `uniqueName` is still used for the `beginBackgroundTask` debug name and lifecycle.
2. **`initialDelay` was ignored** (#661). `startOneOffTask` accepted `delaySeconds` but never used it, so one-off tasks executed immediately. The operation is now enqueued after the requested delay.

Also:
- Updated the `registerOneOffTask`/`executeTask` doc comments in `workmanager_impl.dart` to reflect the fixed behavior (and removed the stale “inputData is not supported on iOS” note on periodic tasks, which was fixed by #648).
- Added an integration test asserting the callback receives `taskName` when it differs from `uniqueName`.

## Verification

- `dart analyze` clean on `workmanager` and `example`
- `dart format --set-exit-if-changed` clean
- `flutter test` passes in `workmanager`
- swiftlint: no new violations (repo baseline is 12 pre-existing warnings)

Note on iOS limits: `beginBackgroundTask`-based one-off tasks only run while the app is alive; iOS may terminate the app before a long delay elapses. The delay is honored while the app stays alive. This is documented in the updated doc comments.

Fixes #670
Fixes #661