### PR TITLE
feat: support typed Lists/Maps in inputData (fixes #426)

### DIFF
--- a/workmanager/lib/src/workmanager_impl.dart
+++ b/workmanager/lib/src/workmanager_impl.dart
@@ -299,19 +299,65 @@ class Workmanager {
   Future<String> printScheduledTasks() async => _platform.printScheduledTasks();
 }
 
-/// Converts inputData from Pigeon format, filtering out null keys
+/// Converts inputData from Pigeon format, filtering out null keys and
+/// normalizing nested containers.
+///
+/// The platform channel codec delivers nested lists as `List<dynamic>` and
+/// nested maps as `Map<dynamic, dynamic>`, which makes re-passing `inputData`
+/// into other tasks error-prone (e.g. `inputData['keys'] as List<String>`
+/// fails). This conversion:
+/// - turns nested maps into `Map<String, dynamic>`,
+/// - keeps the element type of homogeneous nested lists (e.g. `List<String>`),
+/// - leaves heterogeneous lists as `List<dynamic>`.
 @visibleForTesting
 Map<String, dynamic>? convertPigeonInputData(Map<String?, Object?>? inputData) {
-  Map<String, dynamic>? convertedInputData;
-  if (inputData != null) {
-    convertedInputData = <String, dynamic>{};
-    for (final entry in inputData.entries) {
-      if (entry.key != null) {
-        convertedInputData[entry.key!] = entry.value;
-      }
+  if (inputData == null) {
+    return null;
+  }
+  final convertedInputData = <String, dynamic>{};
+  for (final entry in inputData.entries) {
+    final key = entry.key;
+    if (key != null) {
+      convertedInputData[key] = normalizeInputDataValue(entry.value);
     }
   }
   return convertedInputData;
+}
+
+/// Recursively normalizes a single `inputData` value for delivery to the
+/// background task callback. See [convertPigeonInputData].
+@visibleForTesting
+Object? normalizeInputDataValue(Object? value) {
+  if (value is Map) {
+    final normalized = <String, dynamic>{};
+    for (final entry in value.entries) {
+      final key = entry.key;
+      if (key is String) {
+        normalized[key] = normalizeInputDataValue(entry.value);
+      }
+    }
+    return normalized;
+  }
+  if (value is List) {
+    final normalized = value.map(normalizeInputDataValue).toList();
+    if (normalized.isEmpty) {
+      return normalized;
+    }
+    if (normalized.every((element) => element is String)) {
+      return List<String>.from(normalized);
+    }
+    if (normalized.every((element) => element is int)) {
+      return List<int>.from(normalized);
+    }
+    if (normalized.every((element) => element is double)) {
+      return List<double>.from(normalized);
+    }
+    if (normalized.every((element) => element is bool)) {
+      return List<bool>.from(normalized);
+    }
+    return normalized;
+  }
+  return value;
 }
 
 /// Implementation of WorkmanagerFlutterApi for handling background task execution

--- a/workmanager/test/pigeon_input_data_conversion_test.dart
+++ b/workmanager/test/pigeon_input_data_conversion_test.dart
@@ -137,7 +137,9 @@ void main() {
       final Map<String?, Object?> inputData = {
         'outer': <dynamic, dynamic>{
           'innerList': ['x', 'y'],
-          'innerMap': <dynamic, dynamic>{'deep': [1, 2, 3]},
+          'innerMap': <dynamic, dynamic>{
+            'deep': [1, 2, 3]
+          },
         },
       };
 

--- a/workmanager/test/pigeon_input_data_conversion_test.dart
+++ b/workmanager/test/pigeon_input_data_conversion_test.dart
@@ -91,5 +91,62 @@ void main() {
       expect(result['nullKey'], null);
       expect(result.containsKey(null), false);
     });
+
+    test('normalizes nested maps to Map<String, dynamic>', () {
+      final Map<String?, Object?> inputData = {
+        'nested': <dynamic, dynamic>{'string': 'value', 'int': 42},
+      };
+
+      final result = convertPigeonInputData(inputData);
+
+      final nested = result!['nested'];
+      expect(nested, isA<Map<String, dynamic>>());
+      expect(nested, {'string': 'value', 'int': 42});
+    });
+
+    test('keeps the element type of homogeneous nested lists', () {
+      final Map<String?, Object?> inputData = {
+        'strings': ['a', 'b'],
+        'ints': [1, 2],
+        'doubles': [1.5, 2.5],
+        'bools': [true, false],
+      };
+
+      final result = convertPigeonInputData(inputData);
+
+      expect(result!['strings'], isA<List<String>>());
+      expect(result['ints'], isA<List<int>>());
+      expect(result['doubles'], isA<List<double>>());
+      expect(result['bools'], isA<List<bool>>());
+    });
+
+    test('leaves heterogeneous or empty lists as List<dynamic>', () {
+      final Map<String?, Object?> inputData = {
+        'mixed': ['a', 1, true],
+        'empty': <Object?>[],
+      };
+
+      final result = convertPigeonInputData(inputData);
+
+      expect(result!['mixed'], isA<List<dynamic>>());
+      expect(result['empty'], isA<List<dynamic>>());
+      expect(result['empty'], isEmpty);
+    });
+
+    test('normalizes nested containers recursively', () {
+      final Map<String?, Object?> inputData = {
+        'outer': <dynamic, dynamic>{
+          'innerList': ['x', 'y'],
+          'innerMap': <dynamic, dynamic>{'deep': [1, 2, 3]},
+        },
+      };
+
+      final result = convertPigeonInputData(inputData);
+
+      final outer = result!['outer'] as Map<String, dynamic>;
+      expect(outer['innerList'], isA<List<String>>());
+      final innerMap = outer['innerMap'] as Map<String, dynamic>;
+      expect(innerMap['deep'], isA<List<int>>());
+    });
   });
 }

--- a/workmanager_android/android/build.gradle
+++ b/workmanager_android/android/build.gradle
@@ -56,4 +56,6 @@ dependencies {
     testImplementation "org.jetbrains.kotlin:kotlin-test"
     testImplementation "org.mockito:mockito-core:4.11.0"
     testImplementation "org.mockito.kotlin:mockito-kotlin:4.1.0"
+    // Real org.json implementation for JVM unit tests (android.jar only stubs it).
+    testImplementation 'org.json:json:20240303'
 }

--- a/workmanager_android/android/src/main/kotlin/dev/fluttercommunity/workmanager/BackgroundWorker.kt
+++ b/workmanager_android/android/src/main/kotlin/dev/fluttercommunity/workmanager/BackgroundWorker.kt
@@ -33,16 +33,7 @@ class BackgroundWorker(
     }
 
     private val payload
-        get() =
-            workerParams.inputData.keyValueMap
-                .filter { it.key.startsWith("payload_") }
-                .mapKeys { it.key.replace("payload_", "") }
-                .mapValues {
-                    when (it.value) {
-                        is Array<*> -> (it.value as Array<*>).asList()
-                        else -> it.value
-                    }
-                }
+        get() = decodePayload(workerParams.inputData.keyValueMap)
 
     private val dartTask
         get() = workerParams.inputData.getString(DART_TASK_KEY)

--- a/workmanager_android/android/src/main/kotlin/dev/fluttercommunity/workmanager/InputDataUtils.kt
+++ b/workmanager_android/android/src/main/kotlin/dev/fluttercommunity/workmanager/InputDataUtils.kt
@@ -1,0 +1,163 @@
+package dev.fluttercommunity.workmanager
+
+import androidx.work.Data
+import org.json.JSONArray
+import org.json.JSONObject
+import org.json.JSONTokener
+
+/** Prefix for payload keys stored as native WorkManager [Data] values. */
+const val PAYLOAD_PREFIX = "payload_"
+
+/**
+ * Prefix for payload keys stored as JSON strings.
+ *
+ * WorkManager [Data] cannot store nested maps, lists of non-primitive or mixed
+ * element types, or null values. Those values are JSON-encoded under this
+ * prefix. Keeping a separate prefix (rather than reusing [PAYLOAD_PREFIX])
+ * keeps the encoding backward compatible with previously enqueued jobs.
+ */
+const val JSON_PAYLOAD_PREFIX = "json_payload_"
+
+/**
+ * Serializes [dartTask] and [payload] into WorkManager [Data].
+ *
+ * - Scalars are stored natively under `payload_<key>` (same keys as before).
+ * - Homogeneous lists are stored as typed primitive arrays under
+ *   `payload_<key>`, replacing the previous behavior that silently dropped
+ *   non-String elements.
+ * - Nested maps, heterogeneous lists, and null values are JSON-encoded under
+ *   `json_payload_<key>` and decoded again when the task runs.
+ */
+fun buildTaskInputData(
+    dartTask: String,
+    payload: Map<String, Any?>?,
+): Data {
+    val builder = Data.Builder().putString(BackgroundWorker.DART_TASK_KEY, dartTask)
+
+    payload?.forEach { (key, value) ->
+        when (value) {
+            null -> builder.putJsonPayload(key, null)
+            is String -> builder.putString("$PAYLOAD_PREFIX$key", value)
+            is Boolean -> builder.putBoolean("$PAYLOAD_PREFIX$key", value)
+            is Int -> builder.putInt("$PAYLOAD_PREFIX$key", value)
+            is Long -> builder.putLong("$PAYLOAD_PREFIX$key", value)
+            is Float -> builder.putFloat("$PAYLOAD_PREFIX$key", value)
+            is Double -> builder.putDouble("$PAYLOAD_PREFIX$key", value)
+            is ByteArray -> builder.putByteArray("$PAYLOAD_PREFIX$key", value)
+            is List<*> -> builder.putListPayload(key, value)
+            is Map<*, *> -> builder.putJsonPayload(key, value)
+            else ->
+                throw IllegalArgumentException(
+                    "Unsupported payload type for key '$key': ${value::class.java.simpleName}. " +
+                        "Consider converting it to a supported type.",
+                )
+        }
+    }
+
+    return builder.build()
+}
+
+/**
+ * Converts a WorkManager [Data] key-value map back into the payload map that
+ * is delivered to the Dart callback.
+ *
+ * JSON-encoded entries (`json_payload_*`) are decoded back into nested maps and
+ * lists; typed arrays are converted to lists.
+ */
+fun decodePayload(keyValueMap: Map<String, Any?>): Map<String, Any?> {
+    val result = LinkedHashMap<String, Any?>()
+    keyValueMap.forEach { (key, value) ->
+        when {
+            key.startsWith(JSON_PAYLOAD_PREFIX) ->
+                result[key.removePrefix(JSON_PAYLOAD_PREFIX)] = decodeJson(value)
+            key.startsWith(PAYLOAD_PREFIX) ->
+                result[key.removePrefix(PAYLOAD_PREFIX)] = normalizeDataValue(value)
+        }
+    }
+    return result
+}
+
+private fun Data.Builder.putJsonPayload(
+    key: String,
+    value: Any?,
+): Data.Builder {
+    putString("$JSON_PAYLOAD_PREFIX$key", toJsonString(value))
+    return this
+}
+
+private fun Data.Builder.putListPayload(
+    key: String,
+    value: List<*>,
+): Data.Builder {
+    val payloadKey = "$PAYLOAD_PREFIX$key"
+    when {
+        value.all { it is String } ->
+            putStringArray(payloadKey, value.filterIsInstance<String>().toTypedArray())
+        value.all { it is Boolean } ->
+            putBooleanArray(payloadKey, value.filterIsInstance<Boolean>().toBooleanArray())
+        value.all { it is Int } ->
+            putIntArray(payloadKey, value.filterIsInstance<Int>().toIntArray())
+        value.all { it is Long } ->
+            putLongArray(payloadKey, value.filterIsInstance<Long>().toLongArray())
+        value.all { it is Float } ->
+            putFloatArray(payloadKey, value.filterIsInstance<Float>().toFloatArray())
+        value.all { it is Double } ->
+            putDoubleArray(payloadKey, value.filterIsInstance<Double>().toDoubleArray())
+        else -> putJsonPayload(key, value)
+    }
+    return this
+}
+
+private fun toJsonString(value: Any?): String = jsonValue(value).toString()
+
+private fun jsonValue(value: Any?): Any? =
+    when (value) {
+        null, is Boolean, is Int, is Long, is Float, is Double, is String -> value
+        is Map<*, *> ->
+            JSONObject().apply {
+                value.forEach { (key, nested) -> put(key.toString(), jsonValue(nested)) }
+            }
+        is List<*> ->
+            JSONArray().apply {
+                value.forEach { put(jsonValue(it)) }
+            }
+        is ByteArray ->
+            JSONArray().apply {
+                value.forEach { put(it.toInt() and 0xFF) }
+            }
+        else ->
+            throw IllegalArgumentException(
+                "Unsupported payload type: ${value::class.java.simpleName}. " +
+                    "Consider converting it to a supported type.",
+            )
+    }
+
+private fun decodeJson(value: Any?): Any? {
+    if (value !is String) {
+        return value
+    }
+    return decodeJsonValue(JSONTokener(value).nextValue())
+}
+
+private fun decodeJsonValue(value: Any?): Any? =
+    when (value) {
+        null, JSONObject.NULL -> null
+        is JSONObject -> {
+            val map = LinkedHashMap<String, Any?>()
+            value.keys().asSequence().forEach { key -> map[key] = decodeJsonValue(value.get(key)) }
+            map
+        }
+        is JSONArray -> (0 until value.length()).map { decodeJsonValue(value.get(it)) }
+        else -> value
+    }
+
+private fun normalizeDataValue(value: Any?): Any? =
+    when (value) {
+        is Array<*> -> value.asList()
+        is IntArray -> value.toList()
+        is LongArray -> value.toList()
+        is FloatArray -> value.toList()
+        is DoubleArray -> value.toList()
+        is BooleanArray -> value.toList()
+        else -> value
+    }

--- a/workmanager_android/android/src/main/kotlin/dev/fluttercommunity/workmanager/WorkManagerUtils.kt
+++ b/workmanager_android/android/src/main/kotlin/dev/fluttercommunity/workmanager/WorkManagerUtils.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import android.os.Build
 import androidx.work.BackoffPolicy
 import androidx.work.Constraints
-import androidx.work.Data
 import androidx.work.ExistingPeriodicWorkPolicy
 import androidx.work.ExistingWorkPolicy
 import androidx.work.NetworkType
@@ -12,7 +11,6 @@ import androidx.work.OneTimeWorkRequest
 import androidx.work.OutOfQuotaPolicy
 import androidx.work.PeriodicWorkRequest
 import androidx.work.WorkManager
-import dev.fluttercommunity.workmanager.BackgroundWorker.Companion.DART_TASK_KEY
 import dev.fluttercommunity.workmanager.pigeon.TaskStatus
 import java.util.concurrent.TimeUnit
 
@@ -196,50 +194,6 @@ class WorkManagerWrapper(
                 startTime = System.currentTimeMillis(),
             )
         WorkmanagerDebug.onTaskStatusUpdate(context, taskInfo, TaskStatus.SCHEDULED)
-    }
-
-    private fun buildTaskInputData(
-        dartTask: String,
-        payload: Map<String, Any>?,
-    ): Data {
-        val builder =
-            Data
-                .Builder()
-                .putString(DART_TASK_KEY, dartTask)
-
-        // Add payload data if provided
-        payload?.forEach { (key, value) ->
-            when (value) {
-                is String -> builder.putString("payload_$key", value)
-                is Boolean -> builder.putBoolean("payload_$key", value)
-                is Int -> builder.putInt("payload_$key", value)
-                is Long -> builder.putLong("payload_$key", value)
-                is Float -> builder.putFloat("payload_$key", value)
-                is Double -> builder.putDouble("payload_$key", value)
-                is Array<*> ->
-                    builder.putStringArray(
-                        "payload_$key",
-                        value.filterIsInstance<String>().toTypedArray(),
-                    )
-
-                is List<*> ->
-                    builder.putStringArray(
-                        "payload_$key",
-                        value.filterIsInstance<String>().toTypedArray(),
-                    )
-
-                is ByteArray -> builder.putByteArray("payload_$key", value)
-
-                else -> {
-                    throw IllegalArgumentException(
-                        "Unsupported payload type for key '$key': ${value::class.java.simpleName}. " +
-                            "Consider converting it to a supported type.",
-                    )
-                }
-            }
-        }
-
-        return builder.build()
     }
 
     fun getWorkInfoByUniqueName(uniqueWorkName: String) = workManager.getWorkInfosForUniqueWork(uniqueWorkName)

--- a/workmanager_android/android/src/test/kotlin/dev/fluttercommunity/workmanager/InputDataUtilsTest.kt
+++ b/workmanager_android/android/src/test/kotlin/dev/fluttercommunity/workmanager/InputDataUtilsTest.kt
@@ -1,0 +1,146 @@
+package dev.fluttercommunity.workmanager
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class InputDataUtilsTest {
+    @Test
+    fun `scalar payload values are stored and decoded natively`() {
+        val payload =
+            mapOf<String, Any?>(
+                "string" to "value",
+                "boolean" to true,
+                "int" to 42,
+                "long" to 9_000_000_000L,
+                "double" to 3.14,
+                "float" to 1.5f,
+            )
+
+        val data = buildTaskInputData("task", payload)
+        val decoded = decodePayload(data.keyValueMap)
+
+        assertEquals(payload, decoded)
+    }
+
+    @Test
+    fun `homogeneous string list keeps legacy key and round-trips`() {
+        val payload = mapOf<String, Any?>("list" to listOf("a", "b", "c"))
+
+        val data = buildTaskInputData("task", payload)
+
+        // Migration care: string lists keep the legacy payload_ key, so
+        // previously enqueued jobs behave exactly as before.
+        assertTrue(data.keyValueMap.containsKey("payload_list"))
+        assertTrue(data.keyValueMap.keys.none { it.startsWith(JSON_PAYLOAD_PREFIX) })
+        assertEquals(listOf("a", "b", "c"), decodePayload(data.keyValueMap)["list"])
+    }
+
+    @Test
+    fun `homogeneous int list round-trips without data loss`() {
+        val payload = mapOf<String, Any?>("list" to listOf(1, 2, 3))
+
+        val data = buildTaskInputData("task", payload)
+        val decoded = decodePayload(data.keyValueMap)
+
+        assertTrue(data.keyValueMap.keys.none { it.startsWith(JSON_PAYLOAD_PREFIX) })
+        assertEquals(listOf(1, 2, 3), decoded["list"])
+    }
+
+    @Test
+    fun `homogeneous long list round-trips without data loss`() {
+        val payload = mapOf<String, Any?>("list" to listOf(1L, 2L, 3L))
+
+        val data = buildTaskInputData("task", payload)
+
+        assertEquals(listOf(1L, 2L, 3L), decodePayload(data.keyValueMap)["list"])
+    }
+
+    @Test
+    fun `homogeneous double and boolean lists round-trip`() {
+        val payload =
+            mapOf<String, Any?>(
+                "doubles" to listOf(1.5, 2.5),
+                "bools" to listOf(true, false),
+            )
+
+        val data = buildTaskInputData("task", payload)
+        val decoded = decodePayload(data.keyValueMap)
+
+        assertEquals(listOf(1.5, 2.5), decoded["doubles"])
+        assertEquals(listOf(true, false), decoded["bools"])
+    }
+
+    @Test
+    fun `mixed lists are JSON-encoded and decoded without data loss`() {
+        val payload =
+            mapOf<String, Any?>(
+                "mixed" to listOf("a", 1, true, 2.5),
+                "empty" to emptyList<String>(),
+            )
+
+        val data = buildTaskInputData("task", payload)
+
+        assertTrue(data.keyValueMap.containsKey("json_payload_mixed"))
+        val mixed = decodePayload(data.keyValueMap)["mixed"] as List<*>
+        assertEquals(4, mixed.size)
+        assertEquals("a", mixed[0])
+        assertEquals(1, (mixed[1] as Number).toInt())
+        assertEquals(true, mixed[2])
+        assertEquals(2.5, (mixed[3] as Number).toDouble(), 0.0001)
+        assertEquals(emptyList<Any>(), decodePayload(data.keyValueMap)["empty"])
+    }
+
+    @Test
+    fun `nested maps are JSON-encoded and decoded back into maps`() {
+        val payload =
+            mapOf<String, Any?>(
+                "user" to
+                    mapOf(
+                        "name" to "Ada",
+                        "roles" to listOf("admin", "dev"),
+                        "meta" to mapOf("active" to true),
+                    ),
+            )
+
+        val data = buildTaskInputData("task", payload)
+
+        assertTrue(data.keyValueMap.containsKey("json_payload_user"))
+        assertEquals(payload, decodePayload(data.keyValueMap))
+    }
+
+    @Test
+    fun `null values are preserved through JSON encoding`() {
+        val payload = mapOf<String, Any?>("nullable" to null)
+
+        val data = buildTaskInputData("task", payload)
+        val decoded = decodePayload(data.keyValueMap)
+
+        assertTrue(decoded.containsKey("nullable"))
+        assertEquals(null, decoded["nullable"])
+    }
+
+    @Test
+    fun `byte arrays round-trip`() {
+        val payload = mapOf<String, Any?>("bytes" to byteArrayOf(1, 2, 3))
+
+        val data = buildTaskInputData("task", payload)
+        val decoded = decodePayload(data.keyValueMap)["bytes"]
+
+        when (decoded) {
+            is ByteArray -> assertTrue(decoded.contentEquals(byteArrayOf(1, 2, 3)))
+            is List<*> -> assertEquals(listOf<Byte>(1, 2, 3), decoded)
+            else -> throw AssertionError("Unexpected decoded byte value: $decoded")
+        }
+    }
+
+    @Test
+    fun `unsupported payload values still fail fast with a clear message`() {
+        val payload = mapOf<String, Any?>("obj" to Any())
+
+        val exception = runCatching { buildTaskInputData("task", payload) }.exceptionOrNull()
+
+        assertTrue(exception is IllegalArgumentException)
+        assertTrue(exception!!.message!!.contains("Unsupported payload type for key 'obj'"))
+    }
+}


### PR DESCRIPTION
## What changed

Fixes #426: typed `List`/`Map` values in `inputData` now survive the round-trip from Dart → native → background isolate → back into other tasks, with backward-compatible storage on Android.

### Dart (`workmanager`)

`convertPigeonInputData` now recursively normalizes nested containers delivered over the platform channel:

- nested maps become `Map<String, dynamic>` (previously `Map<dynamic, dynamic>`, which broke `as Map<String, dynamic>` casts and re-registration),
- homogeneous nested lists keep their element type (`List<String>`, `List<int>`, `List<double>`, `List<bool>` — previously always `List<dynamic>`, which broke `as List<String>` casts),
- heterogeneous/empty lists stay `List<dynamic>`.

This is what lets the callback re-pass `inputData` straight into `registerOneOffTask`/`registerPeriodicTask`, the scenario from the issue.

### Android (`workmanager_android`)

`buildTaskInputData` is extracted into `InputDataUtils` and now supports:

- **typed homogeneous lists** — stored as native `StringArray`/`IntArray`/`LongArray`/`FloatArray`/`DoubleArray`/`BooleanArray` instead of the old behavior that silently dropped non-String elements,
- **nested maps, heterogeneous lists, and null values** — JSON-encoded under a separate `json_payload_` prefix and decoded back when the task runs,
- **migration care** — scalars and String lists keep the legacy `payload_` keys exactly as before, so previously enqueued jobs are unaffected; the JSON prefix only applies to types that were previously unsupported (they used to throw `IllegalArgumentException`).

`BackgroundWorker` decodes both prefixes when building the payload sent to the Dart callback.

### Tests

- `InputDataUtilsTest` (Android unit tests): 10 cases covering scalars, typed arrays, JSON-encoded maps/mixed lists, nulls, and legacy-key migration. ✅ `./gradlew :workmanager_android:test`
- `pigeon_input_data_conversion_test.dart`: nested-map/list typing, heterogeneous lists, recursive normalization. ✅

## Verification

`flutter analyze` ✅ (all packages) · `melos run test` ✅ · `melos run generate` (zero diff) ✅ · `ktlint 1.7.1` ✅ · `./gradlew :workmanager_android:test` ✅

Fixes #426
