### PR TITLE
fix(android): honor initialDelay for periodic tasks without a flex window (fixes #594)

### DIFF
--- a/workmanager_android/android/src/main/kotlin/dev/fluttercommunity/workmanager/WorkManagerUtils.kt
+++ b/workmanager_android/android/src/main/kotlin/dev/fluttercommunity/workmanager/WorkManagerUtils.kt
@@ -16,14 +16,73 @@ import java.util.concurrent.TimeUnit
 
 // Constants
 const val DEFAULT_INITIAL_DELAY_SECONDS = 0L
-const val DEFAULT_FLEX_INTERVAL_SECONDS =
-    PeriodicWorkRequest.MIN_PERIODIC_FLEX_MILLIS / 1000
 
 // Default values
 val defaultOneOffExistingWorkPolicy = ExistingWorkPolicy.KEEP
 val defaultPeriodExistingWorkPolicy = ExistingPeriodicWorkPolicy.UPDATE
 val defaultConstraints: Constraints = Constraints.NONE
 val defaultOutOfQuotaPolicy: OutOfQuotaPolicy? = null
+
+/**
+ * Builds the [PeriodicWorkRequest] for a periodic task.
+ *
+ * A flex window is only applied when the caller explicitly provides
+ * [flexIntervalSeconds]. Without an explicit flex, WorkManager defaults
+ * flex to the full interval, which means the first run is scheduled at
+ * `enqueueTime + initialDelay` exactly as requested. Applying a default
+ * flex window would push the first run to
+ * `initialDelay + (interval - flex)` and look like the initial delay is
+ * being ignored.
+ */
+internal fun createPeriodicWorkRequest(
+    taskName: String,
+    inputData: Map<String, Any?>?,
+    frequencySeconds: Long,
+    flexIntervalSeconds: Long?,
+    initialDelaySeconds: Long?,
+    constraints: Constraints,
+    backoffPolicy: dev.fluttercommunity.workmanager.pigeon.BackoffPolicyConfig?,
+    tag: String?,
+): PeriodicWorkRequest {
+    val builder =
+        if (flexIntervalSeconds != null) {
+            PeriodicWorkRequest
+                .Builder(
+                    BackgroundWorker::class.java,
+                    frequencySeconds,
+                    TimeUnit.SECONDS,
+                    flexIntervalSeconds,
+                    TimeUnit.SECONDS,
+                )
+        } else {
+            PeriodicWorkRequest
+                .Builder(
+                    BackgroundWorker::class.java,
+                    frequencySeconds,
+                    TimeUnit.SECONDS,
+                )
+        }
+    return builder
+        .setInputData(buildTaskInputData(taskName, inputData))
+        .setInitialDelay(
+            initialDelaySeconds ?: DEFAULT_INITIAL_DELAY_SECONDS,
+            TimeUnit.SECONDS,
+        ).setConstraints(constraints)
+        .apply {
+            backoffPolicy?.let { backoffConfig ->
+                if (backoffConfig.backoffPolicy != null && backoffConfig.backoffDelayMillis != null) {
+                    setBackoffCriteria(
+                        backoffConfig.backoffPolicy.toAndroidBackoffPolicy(),
+                        backoffConfig.backoffDelayMillis.toLong(),
+                        TimeUnit.MILLISECONDS,
+                    )
+                }
+            }
+        }.apply {
+            tag?.let(::addTag)
+            // Note: outOfQuotaPolicy is not supported for periodic tasks
+        }.build()
+}
 
 // Extension functions to convert Pigeon types to Android WorkManager types
 private fun dev.fluttercommunity.workmanager.pigeon.ExistingWorkPolicy.toAndroidWorkPolicy(): ExistingWorkPolicy =
@@ -149,36 +208,16 @@ class WorkManagerWrapper(
 
     fun enqueuePeriodicTask(request: dev.fluttercommunity.workmanager.pigeon.PeriodicTaskRequest) {
         val periodicTaskRequest =
-            PeriodicWorkRequest
-                .Builder(
-                    BackgroundWorker::class.java,
-                    request.frequencySeconds,
-                    TimeUnit.SECONDS,
-                    request.flexIntervalSeconds ?: DEFAULT_FLEX_INTERVAL_SECONDS,
-                    TimeUnit.SECONDS,
-                ).setInputData(
-                    buildTaskInputData(
-                        request.taskName,
-                        request.inputData?.filterNotNullKeys(),
-                    ),
-                ).setInitialDelay(
-                    request.initialDelaySeconds ?: DEFAULT_INITIAL_DELAY_SECONDS,
-                    TimeUnit.SECONDS,
-                ).setConstraints(request.constraints?.toAndroidConstraints() ?: defaultConstraints)
-                .apply {
-                    request.backoffPolicy?.let { backoffConfig ->
-                        if (backoffConfig.backoffPolicy != null && backoffConfig.backoffDelayMillis != null) {
-                            setBackoffCriteria(
-                                backoffConfig.backoffPolicy.toAndroidBackoffPolicy(),
-                                backoffConfig.backoffDelayMillis.toLong(),
-                                TimeUnit.MILLISECONDS,
-                            )
-                        }
-                    }
-                }.apply {
-                    request.tag?.let(::addTag)
-                    // Note: outOfQuotaPolicy is not supported for periodic tasks
-                }.build()
+            createPeriodicWorkRequest(
+                taskName = request.taskName,
+                inputData = request.inputData?.filterNotNullKeys(),
+                frequencySeconds = request.frequencySeconds,
+                flexIntervalSeconds = request.flexIntervalSeconds,
+                initialDelaySeconds = request.initialDelaySeconds,
+                constraints = request.constraints?.toAndroidConstraints() ?: defaultConstraints,
+                backoffPolicy = request.backoffPolicy,
+                tag = request.tag,
+            )
         workManager.enqueueUniquePeriodicWork(
             request.uniqueName,
             request.existingWorkPolicy?.toAndroidPeriodicWorkPolicy()

--- a/workmanager_android/android/src/test/kotlin/dev/fluttercommunity/workmanager/PeriodicWorkRequestTest.kt
+++ b/workmanager_android/android/src/test/kotlin/dev/fluttercommunity/workmanager/PeriodicWorkRequestTest.kt
@@ -1,0 +1,47 @@
+package dev.fluttercommunity.workmanager
+
+import androidx.work.Constraints
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class PeriodicWorkRequestTest {
+    @Test
+    fun `without explicit flex the first run honors the initial delay`() {
+        val request =
+            createPeriodicWorkRequest(
+                taskName = "task",
+                inputData = null,
+                frequencySeconds = 900,
+                flexIntervalSeconds = null,
+                initialDelaySeconds = 120,
+                constraints = Constraints.NONE,
+                backoffPolicy = null,
+                tag = null,
+            )
+
+        // flex == interval means no flex window, so the first run is scheduled
+        // at enqueueTime + initialDelay (instead of being shifted by
+        // interval - flex).
+        assertEquals(900_000L, request.workSpec.intervalDuration)
+        assertEquals(request.workSpec.intervalDuration, request.workSpec.flexDuration)
+        assertEquals(120_000L, request.workSpec.initialDelay)
+    }
+
+    @Test
+    fun `explicit flex interval is applied`() {
+        val request =
+            createPeriodicWorkRequest(
+                taskName = "task",
+                inputData = null,
+                frequencySeconds = 900,
+                flexIntervalSeconds = 300,
+                initialDelaySeconds = 0,
+                constraints = Constraints.NONE,
+                backoffPolicy = null,
+                tag = null,
+            )
+
+        assertEquals(900_000L, request.workSpec.intervalDuration)
+        assertEquals(300_000L, request.workSpec.flexDuration)
+    }
+}


### PR DESCRIPTION
## What

Periodic tasks without an explicit `flexInterval` no longer get a hidden 5-minute flex window, so `initialDelay` is honored for the first run again.

## Root cause

Since 0.6.0 the plugin passed `flexIntervalSeconds ?: DEFAULT_FLEX_INTERVAL_SECONDS` (5 min) to `PeriodicWorkRequest.Builder`. Upstream WorkManager (2.9.0+) computes the first periodic run as:

```
lastEnqueueTime + initialDelay + (interval - flex)   // when flex != interval
lastEnqueueTime + initialDelay                       // when flex == interval (no window)
```

So with the default 5-minute flex, a 15-minute task with a 2-minute `initialDelay` first ran at ~12-15 minutes instead of 2. Before 0.6.0 the plugin used the two-argument builder (flex == interval), which is why this regressed from 0.5.x.

## Fix

Use the two-argument `PeriodicWorkRequest.Builder` when `flexIntervalSeconds` is null (flex defaults to the full interval), and the four-argument builder only when the caller explicitly asks for a flex window. The request builder is extracted into a pure, testable function with unit tests covering both cases.

## Verification

- `./gradlew :workmanager_android:test` green (incl. new `PeriodicWorkRequestTest`)
- ktlint 1.7.1 clean