### PR TITLE
fix(ios): auto-register BGTask launch handlers for scheduled tasks (fixes #660)

### DIFF
--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -82,7 +82,7 @@ WorkmanagerPlugin.registerBGProcessingTask(
 </Warning>
 
 <Info>
-**Why BGTaskScheduler registration is needed:** iOS requires explicit registration of background task identifiers for security and system resource management. The task identifier in Info.plist tells iOS which background tasks your app can schedule, while the AppDelegate registration connects the identifier to the actual task handler. Background Fetch (Option A) doesn't require this since it uses the simpler, system-managed approach.
+**Why BGTaskScheduler registration is needed:** iOS requires every background task identifier to be listed in Info.plist for security and system resource management. The plugin registers the task handler automatically (at schedule time and again on the next app launch), so no manual AppDelegate code is required. Background Fetch (Option A) doesn't require this since it uses the simpler, system-managed approach.
 </Info>
 
 #### Option C: Periodic Tasks with Custom Frequency
@@ -101,7 +101,7 @@ For periodic tasks with more control than Background Fetch - uses BGTaskSchedule
 </array>
 ```
 
-2. **Configure AppDelegate.swift** (with frequency control):
+2. **(Optional) Configure AppDelegate.swift** for custom frequency control:
 ```swift
 import workmanager_apple
 
@@ -111,6 +111,9 @@ WorkmanagerPlugin.registerPeriodicTask(
   frequency: NSNumber(value: 20 * 60) // 20 minutes (15 min minimum)
 )
 ```
+The plugin re-registers launch handlers for scheduled task identifiers on app
+launch, so this step is only needed if you want to pre-register the task or
+control the scheduling hint from native code.
 
 <Warning>
 **iOS Task Identifier Matching:** The task name in your Dart code must **exactly match** the identifier in Info.plist and AppDelegate. Using short names like `"cleanup"` in Dart while having `com.yourapp.periodic_task` in native code will cause `BGTaskSchedulerErrorDomain Code 3` errors.
@@ -278,11 +281,11 @@ Workmanager().registerPeriodicTask(
 <Warning>
 **iOS: `registerPeriodicTask` requires BGTaskScheduler setup.** On iOS the
 `uniqueName` you pass here is submitted to BGTaskScheduler, so it must appear in
-`BGTaskSchedulerPermittedIdentifiers` in Info.plist **and** be registered in
-AppDelegate via `WorkmanagerPlugin.registerPeriodicTask(withIdentifier:)`
-(see Option C above). Without that you'll get `BGTaskSchedulerErrorDomain
-Code 3` ("not advertised in the application's Info.plist"). On Android no
-native setup is needed.
+`BGTaskSchedulerPermittedIdentifiers` in Info.plist. The launch handler is
+registered automatically by the plugin (at schedule time and on the next app
+launch), so no AppDelegate code is required. Without the Info.plist entry
+you'll get `BGTaskSchedulerErrorDomain Code 3` ("not advertised in the
+application's Info.plist"). On Android no native setup is needed.
 </Warning>
 
 ## Task Results
@@ -298,7 +301,7 @@ Your background tasks can return:
 
 - **Callback Dispatcher**: Must be a top-level function (not inside a class)
 - **Separate Isolate**: Background tasks run in isolation - initialize dependencies inside the task
-- **iOS Task Identifiers**: When using BGTaskScheduler (Options B & C), task names in Dart must exactly match identifiers in Info.plist and AppDelegate
+- **iOS Task Identifiers**: When using BGTaskScheduler (Options B & C), task names in Dart must exactly match the identifiers in `BGTaskSchedulerPermittedIdentifiers` in Info.plist
 - **Platform Differences**: 
   - Android: Reliable background execution, 15-minute minimum frequency
   - iOS: 30-second limit, execution depends on user patterns and device state

--- a/workmanager/lib/src/workmanager_impl.dart
+++ b/workmanager/lib/src/workmanager_impl.dart
@@ -217,13 +217,16 @@ class Workmanager {
   /// A [uniqueName] is required so only one task can be registered.
   /// The [taskName] is the value that will be returned in the [BackgroundTaskHandler].
   /// On iOS the handler receives the BGTaskScheduler identifier (the [uniqueName]),
-  /// because the identifier is what you register in Info.plist and AppDelegate.
+  /// because the identifier is what you register in Info.plist.
   /// a [frequency] is not required and will be defaulted to 15 minutes if not provided.
   /// a [frequency] has a minimum of 15 min. Android will automatically change your frequency to 15 min if you have configured a lower frequency.
   /// the [flexInterval] If the nature of the work is time-sensitive, you can configure the PeriodicWorkRequest to run in a flexible period at each interval.
   /// The [inputData] is the input data for task. Valid value types are: int, bool, double, String and their list
   ///
-  /// Unlike Android, you cannot set [frequency] for iOS here rather you have to set in `AppDelegate.swift` while registering the task.
+  /// On iOS, [frequency] is not used: the scheduling hint comes from
+  /// [initialDelay] (mapped to BGTaskScheduler's `earliestBeginDate`). The
+  /// launch handler is registered automatically by the plugin, so no
+  /// `AppDelegate.swift` code is required.
   /// The [inputData] is the input data for task. Valid value types are: int, bool, double, String and their list.
   ///
   /// For iOS see Apple docs:

--- a/workmanager_apple/ios/workmanager_apple/Sources/workmanager_apple/UserDefaultsHelper.swift
+++ b/workmanager_apple/ios/workmanager_apple/Sources/workmanager_apple/UserDefaultsHelper.swift
@@ -7,6 +7,20 @@
 
 import Foundation
 
+/// The kind of BGTaskScheduler task a scheduled identifier refers to.
+enum ScheduledTaskKind: String, Codable {
+    case refresh
+    case processing
+}
+
+/// Metadata persisted for a scheduled BGTask identifier so launch handlers
+/// can be re-registered on the next app launch (required by BGTaskScheduler
+/// before a task can be delivered to a relaunched app).
+struct ScheduledTaskInfo: Codable {
+    let kind: ScheduledTaskKind
+    let earliestBeginInSeconds: Double?
+}
+
 struct UserDefaultsHelper {
 
     // MARK: Properties
@@ -16,6 +30,7 @@ struct UserDefaultsHelper {
     enum Key {
         case callbackHandle
         case periodicTaskInputData(taskIdentifier: String)
+        case scheduledTasks
 
         var stringValue: String {
             switch self {
@@ -23,6 +38,8 @@ struct UserDefaultsHelper {
                 return "\(WorkmanagerPlugin.identifier).callbackHandle"
             case .periodicTaskInputData(let taskIdentifier):
                 return "\(WorkmanagerPlugin.identifier).periodicTaskInputData.\(taskIdentifier)"
+            case .scheduledTasks:
+                return "\(WorkmanagerPlugin.identifier).scheduledTasks"
             }
         }
     }
@@ -52,6 +69,38 @@ struct UserDefaultsHelper {
 
     static func getStoredPeriodicTaskInputData(forTaskIdentifier taskIdentifier: String) -> [String: Any]? {
         return getValue(for: .periodicTaskInputData(taskIdentifier: taskIdentifier))
+    }
+
+    // MARK: Scheduled BGTask identifiers
+
+    static func storeScheduledTask(_ task: ScheduledTaskInfo, forTaskIdentifier taskIdentifier: String) {
+        var tasks = getScheduledTasks()
+        tasks[taskIdentifier] = task
+        if let data = try? JSONEncoder().encode(tasks) {
+            userDefaults.set(data, forKey: Key.scheduledTasks.stringValue)
+        }
+    }
+
+    static func getScheduledTasks() -> [String: ScheduledTaskInfo] {
+        guard let data = userDefaults.data(forKey: Key.scheduledTasks.stringValue),
+              let tasks = try? JSONDecoder().decode([String: ScheduledTaskInfo].self, from: data)
+        else {
+            return [:]
+        }
+        return tasks
+    }
+
+    static func removeScheduledTask(_ taskIdentifier: String) {
+        var tasks = getScheduledTasks()
+        if tasks.removeValue(forKey: taskIdentifier) != nil {
+            if let data = try? JSONEncoder().encode(tasks) {
+                userDefaults.set(data, forKey: Key.scheduledTasks.stringValue)
+            }
+        }
+    }
+
+    static func removeAllScheduledTasks() {
+        userDefaults.removeObject(forKey: Key.scheduledTasks.stringValue)
     }
 
     // MARK: Private helper functions

--- a/workmanager_apple/ios/workmanager_apple/Sources/workmanager_apple/WorkmanagerPlugin.swift
+++ b/workmanager_apple/ios/workmanager_apple/Sources/workmanager_apple/WorkmanagerPlugin.swift
@@ -157,12 +157,14 @@ public class WorkmanagerPlugin: WorkmanagerPluginBase, FlutterPlugin, Workmanage
     func cancelByUniqueName(uniqueName: String, completion: @escaping (Result<Void, Error>) -> Void) {
         executeIfSupportedVoid(completion: completion, feature: "cancelByUniqueName") {
             BGTaskScheduler.shared.cancel(taskRequestWithIdentifier: uniqueName)
+            UserDefaultsHelper.removeScheduledTask(uniqueName)
         }
     }
 
     func cancelAll(completion: @escaping (Result<Void, Error>) -> Void) {
         executeIfSupportedVoid(completion: completion, feature: "cancelAll") {
             BGTaskScheduler.shared.cancelAllTaskRequests()
+            UserDefaultsHelper.removeAllScheduledTasks()
         }
     }
 
@@ -351,6 +353,12 @@ extension WorkmanagerPlugin {
 
 #if os(iOS)
 extension WorkmanagerPlugin {
+    /// Identifiers whose launch handler has already been registered in this
+    /// process. BGTaskScheduler rejects a second registration for the same
+    /// identifier, so this guards the submit-time and launch-time paths (and
+    /// user AppDelegate registrations) against double registration.
+    private static var registeredLaunchHandlers: Set<String> = []
+
     @available(iOS 13.0, *)
     private static func handleBGProcessingTask(identifier: String, task: BGProcessingTask) {
         let operationQueue = OperationQueue()
@@ -443,16 +451,11 @@ extension WorkmanagerPlugin {
     @objc
     public static func registerPeriodicTask(withIdentifier identifier: String, earliestBeginInSeconds: NSNumber? = nil) {
         if #available(iOS 13.0, *) {
-            BGTaskScheduler.shared.register(
-                forTaskWithIdentifier: identifier,
-                using: nil
-            ) { task in
-                if let task = task as? BGAppRefreshTask {
-                    // Retrieve the stored inputData for this periodic task
-                    let storedInputData = UserDefaultsHelper.getStoredPeriodicTaskInputData(forTaskIdentifier: task.identifier)
-                    handlePeriodicTask(identifier: identifier, task: task, earliestBeginInSeconds: earliestBeginInSeconds, inputData: storedInputData)
-                }
-            }
+            UserDefaultsHelper.storeScheduledTask(
+                ScheduledTaskInfo(kind: .refresh, earliestBeginInSeconds: earliestBeginInSeconds?.doubleValue),
+                forTaskIdentifier: identifier
+            )
+            registerLaunchHandlerOnce(forTaskWithIdentifier: identifier, earliestBeginInSeconds: earliestBeginInSeconds)
         }
     }
 
@@ -478,6 +481,14 @@ extension WorkmanagerPlugin {
         do {
             try BGTaskScheduler.shared.submit(request)
             logInfo("BGAppRefreshTask submitted \(identifier) earliestBeginInSeconds:\(String(describing: begin))")
+            UserDefaultsHelper.storeScheduledTask(
+                ScheduledTaskInfo(kind: .refresh, earliestBeginInSeconds: begin),
+                forTaskIdentifier: identifier
+            )
+            registerLaunchHandlerOnce(
+                forTaskWithIdentifier: identifier,
+                earliestBeginInSeconds: begin.map { NSNumber(value: $0) }
+            )
         } catch {
             logInfo("Could not schedule BGAppRefreshTask \(error.localizedDescription)")
         }
@@ -492,14 +503,11 @@ extension WorkmanagerPlugin {
     @objc
     public static func registerBGProcessingTask(withIdentifier identifier: String) {
         if #available(iOS 13.0, *) {
-            BGTaskScheduler.shared.register(
-                forTaskWithIdentifier: identifier,
-                using: nil
-            ) { task in
-                if let task = task as? BGProcessingTask {
-                    handleBGProcessingTask(identifier: identifier, task: task)
-                }
-            }
+            UserDefaultsHelper.storeScheduledTask(
+                ScheduledTaskInfo(kind: .processing, earliestBeginInSeconds: nil),
+                forTaskIdentifier: identifier
+            )
+            registerLaunchHandlerOnce(forTaskWithIdentifier: identifier, earliestBeginInSeconds: nil)
         }
     }
 
@@ -519,9 +527,47 @@ extension WorkmanagerPlugin {
         do {
             try BGTaskScheduler.shared.submit(request)
             logInfo("BGProcessingTask submitted \(uniqueTaskIdentifier) earliestBeginInSeconds:\(begin)")
+            UserDefaultsHelper.storeScheduledTask(
+                ScheduledTaskInfo(kind: .processing, earliestBeginInSeconds: begin),
+                forTaskIdentifier: uniqueTaskIdentifier
+            )
+            registerLaunchHandlerOnce(forTaskWithIdentifier: uniqueTaskIdentifier, earliestBeginInSeconds: nil)
         } catch {
             logInfo("Could not schedule BGProcessingTask identifier:\(uniqueTaskIdentifier) error:\(error.localizedDescription)")
             logInfo("Possible issues can be: running on a simulator instead of a real device, or the task name is not registered")
+        }
+    }
+
+    /// Registers the launch handler for [identifier] at most once per process.
+    ///
+    /// The handler dispatches on the delivered task type so both periodic
+    /// (BGAppRefreshTask) and processing (BGProcessingTask) identifiers can be
+    /// re-registered from persisted state at app launch.
+    @available(iOS 13.0, *)
+    private static func registerLaunchHandlerOnce(
+        forTaskWithIdentifier identifier: String,
+        earliestBeginInSeconds: NSNumber?
+    ) {
+        guard !registeredLaunchHandlers.contains(identifier) else {
+            return
+        }
+        registeredLaunchHandlers.insert(identifier)
+        BGTaskScheduler.shared.register(
+            forTaskWithIdentifier: identifier,
+            using: nil
+        ) { task in
+            if let task = task as? BGAppRefreshTask {
+                // Retrieve the stored inputData for this periodic task
+                let storedInputData = UserDefaultsHelper.getStoredPeriodicTaskInputData(forTaskIdentifier: task.identifier)
+                handlePeriodicTask(
+                    identifier: identifier,
+                    task: task,
+                    earliestBeginInSeconds: earliestBeginInSeconds,
+                    inputData: storedInputData
+                )
+            } else if let task = task as? BGProcessingTask {
+                handleBGProcessingTask(identifier: identifier, task: task)
+            }
         }
     }
 
@@ -598,6 +644,25 @@ extension WorkmanagerPlugin {
 
 #if os(iOS)
 extension WorkmanagerPlugin {
+    override public func application(
+        _ application: UIApplication,
+        didFinishLaunchingWithOptions launchOptions: [AnyHashable: Any]? = nil
+    ) -> Bool {
+        // BGTaskScheduler only delivers a task to a relaunched app if a launch
+        // handler was registered during `didFinishLaunching`. Re-register the
+        // handlers for identifiers scheduled in previous sessions, so periodic
+        // and processing tasks keep working without manual AppDelegate code.
+        if #available(iOS 13.0, *) {
+            for (identifier, info) in UserDefaultsHelper.getScheduledTasks() {
+                WorkmanagerPlugin.registerLaunchHandlerOnce(
+                    forTaskWithIdentifier: identifier,
+                    earliestBeginInSeconds: info.earliestBeginInSeconds.map { NSNumber(value: $0) }
+                )
+            }
+        }
+        return true
+    }
+
     override public func application(
         _ application: UIApplication,
         performFetchWithCompletionHandler completionHandler: @escaping (UIBackgroundFetchResult) -> Void


### PR DESCRIPTION
## What

Scheduled periodic/processing tasks now have their BGTaskScheduler launch handler registered automatically, so tasks scheduled from Dart no longer crash with `No launch handler registered for task with identifier` after the app is relaunched by iOS.

## Root cause

`registerPeriodicTask` from Dart only submitted the `BGAppRefreshTaskRequest`. The launch handler (required by BGTaskScheduler to be registered during `didFinishLaunching`) was only registered when users manually added `WorkmanagerPlugin.registerPeriodicTask(withIdentifier:)` to their AppDelegate. When the system relaunched the app to deliver a task, no handler existed for the identifier → `NSInternalInconsistencyException`.

## Fix

- Persist scheduled BGTask identifiers (kind + earliestBegin hint) on successful submit
- Register the launch handler immediately at submit time
- Re-register all persisted handlers in `application(_:didFinishLaunchingWithOptions:)` on every launch
- Deduplicate registration per identifier/process so existing AppDelegate registrations don't double-register (BGTaskScheduler rejects a second registration)
- Clean up persisted identifiers on `cancelByUniqueName`/`cancelAll`
- Docs: AppDelegate registration is now optional (still requires `BGTaskSchedulerPermittedIdentifiers` in Info.plist)

## Verification

- `xcodebuild build` of the example iOS workspace: BUILD SUCCEEDED
- `flutter analyze` on workmanager/workmanager_apple/workmanager_platform_interface: clean
- swiftlint: no new violations (pre-existing debt only)