### PR TITLE
feat(ios): add BGHealthResearchTaskRequest support (fixes #532)

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -33,6 +33,7 @@ platform.
 | One-off tasks (`registerOneOffTask`) | ✅ Scheduled by the OS; survives app restarts | ⚠️ Runs via `beginBackgroundTask` while the app is alive (foreground or shortly after backgrounding). Not guaranteed after the app is terminated | ⚠️ Runs via `NSBackgroundActivityScheduler` while the app is running/backgrounded and the Mac is awake. Tasks with no `initialDelay` run immediately; delayed tasks are best-effort |
 | Periodic tasks (`registerPeriodicTask`) | ✅ Reliable, 15-minute minimum frequency | ⚠️ Best-effort. iOS decides when (and whether) background fetch runs, based on app usage; 15-minute minimum hint | ⚠️ Best-effort. `NSBackgroundActivityScheduler` decides timing; the Dart `frequency` is the interval hint |
 | Processing tasks (`registerProcessingTask`) | ❌ Not supported | ✅ BGProcessingTask (longer work, requires registration in AppDelegate) | ⚠️ Mapped to a one-off `NSBackgroundActivityScheduler` activity; network/charging constraints are ignored |
+| Health research tasks (`registerHealthResearchTask`) | ❌ Not supported | ⚠️ iOS 17+ only, via `BGHealthResearchTaskRequest`. Requires a Health Research Study container + `com.apple.developer.backgroundtasks.healthresearch` entitlement and user opt-in (see below) | ❌ Not supported |
 | `initialDelay` | ✅ Honored for one-off tasks. For periodic tasks it is best-effort (see below) | ⚠️ One-off: honored while the app stays alive. Periodic: used as the earliest-begin hint for BGTaskScheduler | ⚠️ Best-effort via the activity interval (0 = run as soon as possible); the system may defer the run |
 | `inputData` | ✅ All supported types | ✅ Supported for one-off and periodic tasks | ✅ Supported for one-off and periodic tasks (captured at schedule time) |
 | `taskName` in callback | ✅ The value you passed as `taskName` | ✅ One-off tasks receive the `taskName` you passed. Periodic/processing tasks receive the BGTaskScheduler identifier (the `uniqueName` you registered) | ✅ Tasks receive the activity identifier (the `uniqueName` you registered) |
@@ -65,6 +66,67 @@ handle (there is no `FlutterCallbackCache` on macOS), so the callback function
 must be a top-level function named exactly `callbackDispatcher` in your app's
 main library (e.g. `main.dart`).
 </Warning>
+
+## iOS Background Task Strategies
+
+iOS offers several scheduling strategies. Workmanager wraps the three
+`BGTaskScheduler`-based strategies plus the legacy background-fetch path:
+
+| Strategy | workmanager API | iOS version | Runtime budget | When the system runs it | Reliability |
+|---|---|---|---|---|---|
+| `BGAppRefreshTaskRequest` | `registerPeriodicTask` | 13+ | ~30 seconds | Periodically, based on app usage; at least 15 minutes between launches | Best-effort; no guaranteed interval; does not run on a schedule |
+| `BGProcessingTaskRequest` | `registerProcessingTask` | 13+ | Minutes (typically 1–10, dynamically adjusted) | When the device is idle (often overnight, possibly while charging) | Best-effort but more generous than refresh; may be deferred or interrupted |
+| `BGHealthResearchTaskRequest` | `registerHealthResearchTask` | 17+ | Minutes, like processing tasks | When the device is idle, with additional priority for study-essential processing | Higher priority/reliability than plain processing, but only for health-research apps (entitlement + study container + user opt-in) |
+| `BGContinuedProcessingTaskRequest` | Not yet supported (planned) | 26+ | Starts in the foreground, continues in background | Immediately after submission, which must be a user action (e.g. button tap) | Continues as long as progress is reported (Live Activity + progress protocol); the system can terminate it abruptly under resource pressure |
+| Background fetch (`performFetchWithCompletionHandler`) | iOS < 13 fallback (`Workmanager.iOSBackgroundTask`) | 7–12 | ~30 seconds | System-managed; typically ~once per day based on usage | Best-effort |
+
+**Gaps in workmanager today:**
+
+- `BGContinuedProcessingTaskRequest` (iOS 26+) is not supported. It is a
+  *foreground-initiated* task (submitted as a result of a user action, showing
+  progress in a Live Activity), which does not fit the register-then-run-later
+  model of workmanager. A future API would need to run the Flutter engine in
+  the foreground and keep it alive across backgrounding — a distinct feature,
+  tracked in issue #638.
+- `registerProcessingTask` on iOS currently delivers the task without the
+  `inputData` captured at registration time (only one-off and periodic tasks
+  persist input data). Health research tasks persist input data like periodic
+  tasks.
+
+### Health research tasks (`BGHealthResearchTaskRequest`)
+
+`Workmanager().registerHealthResearchTask(...)` (iOS 17+) schedules a
+`BGHealthResearchTaskRequest` — a subclass of `BGProcessingTaskRequest` that
+iOS delivers with additional priority and reliability when the processing is
+essential to a health research study the user participates in.
+
+Apple enforces app-level requirements *before* such a task can be submitted or
+delivered; the plugin cannot bypass them:
+
+1. **Health Research Study container**: the app must be part of a HealthKit
+   "Health Research Study" container (typically provisioned with ResearchKit /
+   `HKResearchStudy`).
+2. **Entitlement**: the `com.apple.developer.backgroundtasks.healthresearch`
+   entitlement must be added to the app's `.entitlements` file (granted by
+   Apple for approved research apps).
+3. **User opt-in**: the user must have opted in to the study and remain a
+   participant.
+4. **Info.plist**: the task identifier must be listed in
+   `BGTaskSchedulerPermittedIdentifiers` (same as processing tasks).
+
+Without these, `BGTaskScheduler.shared.submit` fails and the plugin logs the
+error (the Dart call still completes; check `printScheduledTasks` or logs).
+The plugin registers the launch handler automatically at schedule time and
+again on the next app launch; you only need
+`WorkmanagerPlugin.registerBGHealthResearchTask(withIdentifier:)` in
+`AppDelegate.swift` if you want to pre-register the handler.
+
+<Info>
+**Testing constraint:** BGHealthResearchTask delivery can only be validated on
+a physical device with the health-research entitlement and an active study
+container. The plugin code is iOS-17 availability-gated, but runtime
+verification remains a TODO until tested by a health-research app.
+</Info>
 
 ## Common Use Cases
 

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -119,11 +119,69 @@ control the scheduling hint from native code.
 **iOS Task Identifier Matching:** The task name in your Dart code must **exactly match** the identifier in Info.plist and AppDelegate. Using short names like `"cleanup"` in Dart while having `com.yourapp.periodic_task` in native code will cause `BGTaskSchedulerErrorDomain Code 3` errors.
 </Warning>
 
+#### Option D: Health Research Tasks (iOS 17+)
+For apps participating in a Health Research Study — `BGHealthResearchTaskRequest`
+gets additional priority/reliability for study-essential processing:
+
+1. **App requirements (Apple-enforced, outside the plugin):**
+   - The app must be part of a HealthKit **Health Research Study container**
+     (typically provisioned with ResearchKit / `HKResearchStudy`).
+   - The `com.apple.developer.backgroundtasks.healthresearch` entitlement must
+     be present in your `.entitlements` file.
+   - The user must have **opted in** to the study.
+
+2. **Enable Background Modes** and add the identifier to Info.plist:
+```xml
+<key>UIBackgroundModes</key>
+<array>
+    <string>processing</string>
+</array>
+
+<key>BGTaskSchedulerPermittedIdentifiers</key>
+<array>
+    <string>com.yourapp.health_research_task</string>
+</array>
+```
+
+3. **(Optional) Pre-register the launch handler** in `AppDelegate.swift`:
+```swift
+import workmanager_apple
+
+// In application didFinishLaunching
+WorkmanagerPlugin.registerBGHealthResearchTask(
+  withIdentifier: "com.yourapp.health_research_task"
+)
+```
+The plugin also registers the handler automatically at schedule time and on
+the next app launch.
+
+4. **Schedule from Dart** (iOS 17+; older iOS versions receive an error):
+```dart
+await Workmanager().registerHealthResearchTask(
+  'com.yourapp.health_research_task',
+  'healthResearchTask',
+  initialDelay: const Duration(hours: 1),
+  constraints: Constraints(
+    networkType: NetworkType.connected,
+    requiresCharging: true,
+  ),
+);
+```
+
+<Warning>
+**Health research tasks require the entitlement.** Without the Health Research
+Study container and `com.apple.developer.backgroundtasks.healthresearch`
+entitlement, `BGTaskScheduler.submit` fails and the task is never delivered —
+the plugin cannot validate this for you. See the capability matrix in the docs
+index for the full iOS strategy comparison.
+</Warning>
+
 <Success>
 **Which option to choose?** 
 - **Option A (Background Fetch)** for non-critical updates that can happen once daily (data sync, content refresh)
 - **Option B (BGTaskScheduler)** for one-time tasks, file uploads, or immediate task scheduling  
 - **Option C (Periodic Tasks)** for regular tasks with custom frequency control (15+ minutes)
+- **Option D (Health Research Tasks)** for iOS 17+ health research study apps that need reliable background processing
 </Success>
 
 ### macOS

--- a/workmanager/lib/src/workmanager_impl.dart
+++ b/workmanager/lib/src/workmanager_impl.dart
@@ -298,6 +298,58 @@ class Workmanager {
     );
   }
 
+  /// Register a health research task (iOS 17+ only, health research apps).
+  ///
+  /// Health research tasks are scheduled with
+  /// [BGHealthResearchTaskRequest](https://developer.apple.com/documentation/backgroundtasks/bghealthresearchtaskrequest),
+  /// which iOS delivers with additional priority and reliability for
+  /// processing that is essential to a health research study.
+  ///
+  /// Availability:
+  /// - iOS 17+ only. On older iOS versions the call fails with an
+  ///   [UnsupportedError] (platform) or a Pigeon error (iOS < 17).
+  /// - Android and macOS do not support this task type.
+  ///
+  /// App requirements (checked by Apple at submission time, not by this
+  /// plugin):
+  /// - The app must be a [Health Research Study container](https://developer.apple.com/documentation/healthkit)
+  ///   with the `com.apple.developer.backgroundtasks.healthresearch`
+  ///   entitlement.
+  /// - The user must have opted in to the relevant study.
+  /// - The task identifier must be listed in `BGTaskSchedulerPermittedIdentifiers`
+  ///   in Info.plist, and `BGTaskSchedulerPermittedIdentifiers` registration
+  ///   happens automatically by the plugin (see the docs for
+  ///   `WorkmanagerPlugin.registerBGHealthResearchTask(withIdentifier:)`).
+  ///
+  /// Like processing tasks, health research tasks run while the device is
+  /// idle, can run for minutes, and may be interrupted by the system. The
+  /// [taskName] is the value returned in the [BackgroundTaskHandler]; on iOS
+  /// the handler receives the BGTaskScheduler identifier (the [uniqueName]).
+  ///
+  /// [uniqueName] is a required unique identifier for the task.
+  /// [taskName] is the value returned in the [BackgroundTaskHandler].
+  /// [initialDelay] is the earliest-begin hint passed to the system.
+  /// [inputData] is the input data for the task (int, bool, double, String
+  /// and their lists).
+  /// [constraints] maps to the BGProcessingTaskRequest network/charging
+  /// requirements (only `networkType` and `requiresCharging` are honored on
+  /// iOS).
+  Future<void> registerHealthResearchTask(
+    String uniqueName,
+    String taskName, {
+    Duration? initialDelay,
+    Map<String, dynamic>? inputData,
+    Constraints? constraints,
+  }) async {
+    return _platform.registerHealthResearchTask(
+      uniqueName,
+      taskName,
+      initialDelay: initialDelay,
+      inputData: inputData,
+      constraints: constraints,
+    );
+  }
+
   /// Cancels task by [uniqueName]
   Future<void> cancelByUniqueName(String uniqueName) async =>
       _platform.cancelByUniqueName(uniqueName);

--- a/workmanager/test/workmanager_test.mocks.dart
+++ b/workmanager/test/workmanager_test.mocks.dart
@@ -167,6 +167,31 @@ class MockWorkmanager extends _i1.Mock implements _i2.Workmanager {
       ) as _i3.Future<void>);
 
   @override
+  _i3.Future<void> registerHealthResearchTask(
+    String? uniqueName,
+    String? taskName, {
+    Duration? initialDelay,
+    Map<String, dynamic>? inputData,
+    _i4.Constraints? constraints,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #registerHealthResearchTask,
+          [
+            uniqueName,
+            taskName,
+          ],
+          {
+            #initialDelay: initialDelay,
+            #inputData: inputData,
+            #constraints: constraints,
+          },
+        ),
+        returnValue: _i3.Future<void>.value(),
+        returnValueForMissingStub: _i3.Future<void>.value(),
+      ) as _i3.Future<void>);
+
+  @override
   _i3.Future<void> cancelByUniqueName(String? uniqueName) =>
       (super.noSuchMethod(
         Invocation.method(

--- a/workmanager_android/android/src/main/kotlin/dev/fluttercommunity/workmanager/WorkmanagerPlugin.kt
+++ b/workmanager_android/android/src/main/kotlin/dev/fluttercommunity/workmanager/WorkmanagerPlugin.kt
@@ -103,6 +103,20 @@ class WorkmanagerPlugin :
         callback(Result.failure(UnsupportedOperationException("Processing tasks are not supported on Android")))
     }
 
+    override fun registerHealthResearchTask(
+        request: HealthResearchTaskRequest,
+        callback: (Result<Unit>) -> Unit,
+    ) {
+        // Health research tasks are iOS 17+-specific
+        callback(
+            Result.failure(
+                UnsupportedOperationException(
+                    "Health research tasks are not supported on Android",
+                ),
+            ),
+        )
+    }
+
     override fun cancelByUniqueName(
         uniqueName: String,
         callback: (Result<Unit>) -> Unit,

--- a/workmanager_android/android/src/main/kotlin/dev/fluttercommunity/workmanager/WorkmanagerPlugin.kt
+++ b/workmanager_android/android/src/main/kotlin/dev/fluttercommunity/workmanager/WorkmanagerPlugin.kt
@@ -1,6 +1,7 @@
 package dev.fluttercommunity.workmanager
 
 import dev.fluttercommunity.workmanager.pigeon.InitializeRequest
+import dev.fluttercommunity.workmanager.pigeon.HealthResearchTaskRequest
 import dev.fluttercommunity.workmanager.pigeon.OneOffTaskRequest
 import dev.fluttercommunity.workmanager.pigeon.PeriodicTaskRequest
 import dev.fluttercommunity.workmanager.pigeon.ProcessingTaskRequest

--- a/workmanager_android/android/src/main/kotlin/dev/fluttercommunity/workmanager/pigeon/WorkmanagerApi.g.kt
+++ b/workmanager_android/android/src/main/kotlin/dev/fluttercommunity/workmanager/pigeon/WorkmanagerApi.g.kt
@@ -687,6 +687,60 @@ data class ProcessingTaskRequest (
     return result
   }
 }
+
+/** Generated class from Pigeon that represents data sent in messages. */
+data class HealthResearchTaskRequest (
+  val uniqueName: String,
+  val taskName: String,
+  val inputData: Map<String?, Any?>? = null,
+  val initialDelaySeconds: Long? = null,
+  val networkType: NetworkType? = null,
+  val requiresCharging: Boolean? = null
+)
+ {
+  companion object {
+    fun fromList(pigeonVar_list: List<Any?>): HealthResearchTaskRequest {
+      val uniqueName = pigeonVar_list[0] as String
+      val taskName = pigeonVar_list[1] as String
+      val inputData = pigeonVar_list[2] as Map<String?, Any?>?
+      val initialDelaySeconds = pigeonVar_list[3] as Long?
+      val networkType = pigeonVar_list[4] as NetworkType?
+      val requiresCharging = pigeonVar_list[5] as Boolean?
+      return HealthResearchTaskRequest(uniqueName, taskName, inputData, initialDelaySeconds, networkType, requiresCharging)
+    }
+  }
+  fun toList(): List<Any?> {
+    return listOf(
+      uniqueName,
+      taskName,
+      inputData,
+      initialDelaySeconds,
+      networkType,
+      requiresCharging,
+    )
+  }
+  override fun equals(other: Any?): Boolean {
+    if (other == null || other.javaClass != javaClass) {
+      return false
+    }
+    if (this === other) {
+      return true
+    }
+    val other = other as HealthResearchTaskRequest
+    return WorkmanagerApiPigeonUtils.deepEquals(this.uniqueName, other.uniqueName) && WorkmanagerApiPigeonUtils.deepEquals(this.taskName, other.taskName) && WorkmanagerApiPigeonUtils.deepEquals(this.inputData, other.inputData) && WorkmanagerApiPigeonUtils.deepEquals(this.initialDelaySeconds, other.initialDelaySeconds) && WorkmanagerApiPigeonUtils.deepEquals(this.networkType, other.networkType) && WorkmanagerApiPigeonUtils.deepEquals(this.requiresCharging, other.requiresCharging)
+  }
+
+  override fun hashCode(): Int {
+    var result = javaClass.hashCode()
+    result = 31 * result + WorkmanagerApiPigeonUtils.deepHash(this.uniqueName)
+    result = 31 * result + WorkmanagerApiPigeonUtils.deepHash(this.taskName)
+    result = 31 * result + WorkmanagerApiPigeonUtils.deepHash(this.inputData)
+    result = 31 * result + WorkmanagerApiPigeonUtils.deepHash(this.initialDelaySeconds)
+    result = 31 * result + WorkmanagerApiPigeonUtils.deepHash(this.networkType)
+    result = 31 * result + WorkmanagerApiPigeonUtils.deepHash(this.requiresCharging)
+    return result
+  }
+}
 private open class WorkmanagerApiPigeonCodec : StandardMessageCodec() {
   override fun readValueOfType(type: Byte, buffer: ByteBuffer): Any? {
     return when (type) {
@@ -750,6 +804,11 @@ private open class WorkmanagerApiPigeonCodec : StandardMessageCodec() {
           ProcessingTaskRequest.fromList(it)
         }
       }
+      141.toByte() -> {
+        return (readValue(buffer) as? List<Any?>)?.let {
+          HealthResearchTaskRequest.fromList(it)
+        }
+      }
       else -> super.readValueOfType(type, buffer)
     }
   }
@@ -803,6 +862,10 @@ private open class WorkmanagerApiPigeonCodec : StandardMessageCodec() {
         stream.write(140)
         writeValue(stream, value.toList())
       }
+      is HealthResearchTaskRequest -> {
+        stream.write(141)
+        writeValue(stream, value.toList())
+      }
       else -> super.writeValue(stream, value)
     }
   }
@@ -815,6 +878,7 @@ interface WorkmanagerHostApi {
   fun registerOneOffTask(request: OneOffTaskRequest, callback: (Result<Unit>) -> Unit)
   fun registerPeriodicTask(request: PeriodicTaskRequest, callback: (Result<Unit>) -> Unit)
   fun registerProcessingTask(request: ProcessingTaskRequest, callback: (Result<Unit>) -> Unit)
+  fun registerHealthResearchTask(request: HealthResearchTaskRequest, callback: (Result<Unit>) -> Unit)
   fun cancelByUniqueName(uniqueName: String, callback: (Result<Unit>) -> Unit)
   fun cancelByTag(tag: String, callback: (Result<Unit>) -> Unit)
   fun cancelAll(callback: (Result<Unit>) -> Unit)
@@ -894,6 +958,25 @@ interface WorkmanagerHostApi {
             val args = message as List<Any?>
             val requestArg = args[0] as ProcessingTaskRequest
             api.registerProcessingTask(requestArg) { result: Result<Unit> ->
+              val error = result.exceptionOrNull()
+              if (error != null) {
+                reply.reply(WorkmanagerApiPigeonUtils.wrapError(error))
+              } else {
+                reply.reply(WorkmanagerApiPigeonUtils.wrapResult(null))
+              }
+            }
+          }
+        } else {
+          channel.setMessageHandler(null)
+        }
+      }
+      run {
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.workmanager_platform_interface.WorkmanagerHostApi.registerHealthResearchTask$separatedMessageChannelSuffix", codec)
+        if (api != null) {
+          channel.setMessageHandler { message, reply ->
+            val args = message as List<Any?>
+            val requestArg = args[0] as HealthResearchTaskRequest
+            api.registerHealthResearchTask(requestArg) { result: Result<Unit> ->
               val error = result.exceptionOrNull()
               if (error != null) {
                 reply.reply(WorkmanagerApiPigeonUtils.wrapError(error))

--- a/workmanager_android/lib/workmanager_android.dart
+++ b/workmanager_android/lib/workmanager_android.dart
@@ -104,6 +104,19 @@ class WorkmanagerAndroid extends WorkmanagerPlatform {
   }
 
   @override
+  Future<void> registerHealthResearchTask(
+    String uniqueName,
+    String taskName, {
+    Duration? initialDelay,
+    Map<String, dynamic>? inputData,
+    Constraints? constraints,
+  }) async {
+    // Health research tasks are iOS 17+-specific, so this is a no-op on Android
+    throw UnsupportedError(
+        'Health research tasks are not supported on Android');
+  }
+
+  @override
   Future<void> cancelByUniqueName(String uniqueName) async {
     await _api.cancelByUniqueName(uniqueName);
   }

--- a/workmanager_android/test/workmanager_android_test.dart
+++ b/workmanager_android/test/workmanager_android_test.dart
@@ -27,6 +27,19 @@ void main() {
       });
 
       test(
+          'should throw UnsupportedError for registerHealthResearchTask (Android does not support BGHealthResearchTask)',
+          () {
+        expect(
+          () => workmanager.registerHealthResearchTask('task', 'name'),
+          throwsA(isA<UnsupportedError>().having(
+            (e) => e.message,
+            'message',
+            contains('Health research tasks are not supported on Android'),
+          )),
+        );
+      });
+
+      test(
           'should throw UnsupportedError for printScheduledTasks (Android WorkManager does not expose task lists)',
           () {
         expect(

--- a/workmanager_apple/ios/workmanager_apple/Sources/workmanager_apple/BackgroundWorker.swift
+++ b/workmanager_apple/ios/workmanager_apple/Sources/workmanager_apple/BackgroundWorker.swift
@@ -29,6 +29,7 @@ enum BackgroundMode {
     case backgroundProcessingTask(identifier: String)
     case backgroundPeriodicTask(identifier: String)
     case backgroundOneOffTask(identifier: String)
+    case backgroundHealthResearchTask(identifier: String)
 
     var flutterThreadlabelPrefix: String {
         switch self {
@@ -40,6 +41,8 @@ enum BackgroundMode {
             return "\(WorkmanagerPlugin.identifier).BackgroundPeriodicTask"
         case .backgroundOneOffTask:
             return "\(WorkmanagerPlugin.identifier).OneOffTask"
+        case .backgroundHealthResearchTask:
+            return "\(WorkmanagerPlugin.identifier).HealthResearchTask"
         }
     }
 
@@ -52,6 +55,8 @@ enum BackgroundMode {
         case let .backgroundPeriodicTask(identifier):
             return ["\(WorkmanagerPlugin.identifier).DART_TASK": identifier]
         case let .backgroundOneOffTask(identifier):
+            return ["\(WorkmanagerPlugin.identifier).DART_TASK": identifier]
+        case let .backgroundHealthResearchTask(identifier):
             return ["\(WorkmanagerPlugin.identifier).DART_TASK": identifier]
         }
     }

--- a/workmanager_apple/ios/workmanager_apple/Sources/workmanager_apple/UserDefaultsHelper.swift
+++ b/workmanager_apple/ios/workmanager_apple/Sources/workmanager_apple/UserDefaultsHelper.swift
@@ -11,6 +11,7 @@ import Foundation
 enum ScheduledTaskKind: String, Codable {
     case refresh
     case processing
+    case healthResearch
 }
 
 /// Metadata persisted for a scheduled BGTask identifier so launch handlers

--- a/workmanager_apple/ios/workmanager_apple/Sources/workmanager_apple/WorkmanagerPlugin.swift
+++ b/workmanager_apple/ios/workmanager_apple/Sources/workmanager_apple/WorkmanagerPlugin.swift
@@ -154,6 +154,44 @@ public class WorkmanagerPlugin: WorkmanagerPluginBase, FlutterPlugin, Workmanage
         }
     }
 
+    func registerHealthResearchTask(
+        request: HealthResearchTaskRequest,
+        completion: @escaping (Result<Void, Error>) -> Void
+    ) {
+        guard validateCallbackHandle() else {
+            completion(.failure(createInitializationError()))
+            return
+        }
+
+        guard #available(iOS 17.0, *) else {
+            completion(.failure(PigeonError(
+                code: "99",
+                message: "HealthResearchTask could not be registered",
+                details: "BGHealthResearchTaskRequest is only supported on iOS 17+"
+            )))
+            return
+        }
+
+        let delaySeconds = Double(request.initialDelaySeconds ?? 0)
+        let requiresCharging = request.requiresCharging ?? false
+        let requiresNetwork = request.networkType == .connected || request.networkType == .metered
+
+        // Reuse the periodic inputData storage (keyed by task identifier) so
+        // the task receives the payload captured at registration time.
+        UserDefaultsHelper.storePeriodicTaskInputData(
+            request.inputData as? [String: Any],
+            forTaskIdentifier: request.uniqueName
+        )
+
+        WorkmanagerPlugin.scheduleHealthResearchTask(
+            withIdentifier: request.uniqueName,
+            earliestBeginInSeconds: delaySeconds,
+            requiresNetworkConnectivity: requiresNetwork,
+            requiresExternalPower: requiresCharging
+        )
+        completion(.success(()))
+    }
+
     func cancelByUniqueName(uniqueName: String, completion: @escaping (Result<Void, Error>) -> Void) {
         executeIfSupportedVoid(completion: completion, feature: "cancelByUniqueName") {
             BGTaskScheduler.shared.cancel(taskRequestWithIdentifier: uniqueName)
@@ -327,6 +365,19 @@ extension WorkmanagerPlugin {
         )
         WorkmanagerDebug.getCurrent().onTaskStatusUpdate(taskInfo: taskInfo, status: .scheduled, result: nil)
         completion(.success(()))
+    }
+
+    func registerHealthResearchTask(
+        request: HealthResearchTaskRequest,
+        completion: @escaping (Result<Void, Error>) -> Void
+    ) {
+        // BGHealthResearchTaskRequest is iOS 17+-only and requires the health
+        // research study entitlement; it is not available on macOS.
+        completion(.failure(PigeonError(
+            code: "99",
+            message: "HealthResearchTask could not be registered",
+            details: "BGHealthResearchTaskRequest is only supported on iOS 17+"
+        )))
     }
 
     func cancelByUniqueName(uniqueName: String, completion: @escaping (Result<Void, Error>) -> Void) {
@@ -511,6 +562,27 @@ extension WorkmanagerPlugin {
         }
     }
 
+    /// Registers a health research task with iOS BGTaskScheduler.
+    ///
+    /// Health research tasks are delivered to apps participating in a Health
+    /// Research Study container (iOS 17+) with the
+    /// `com.apple.developer.backgroundtasks.healthresearch` entitlement, where
+    /// the user has opted in to the study. The identifier must also be listed
+    /// in `BGTaskSchedulerPermittedIdentifiers` in Info.plist.
+    ///
+    /// - Parameter identifier: Unique task identifier that matches the one used in Dart
+    @objc
+    public static func registerBGHealthResearchTask(withIdentifier identifier: String) {
+        guard #available(iOS 17.0, *) else {
+            return
+        }
+        UserDefaultsHelper.storeScheduledTask(
+            ScheduledTaskInfo(kind: .healthResearch, earliestBeginInSeconds: nil),
+            forTaskIdentifier: identifier
+        )
+        registerLaunchHandlerOnce(forTaskWithIdentifier: identifier, earliestBeginInSeconds: nil)
+    }
+
     @objc
     @available(iOS 13.0, *)
     private static func scheduleBackgroundProcessingTask(
@@ -538,11 +610,61 @@ extension WorkmanagerPlugin {
         }
     }
 
+    /// Handles execution of a health research background task.
+    ///
+    /// BGHealthResearchTask is a subclass of BGProcessingTask: the task can
+    /// run for minutes while the device is idle, but the system can still
+    /// interrupt it (the expiration handler cancels the operation).
+    @available(iOS 17.0, *)
+    private static func handleBGHealthResearchTask(identifier: String, task: BGHealthResearchTask) {
+        let operationQueue = OperationQueue()
+        // Deliver the inputData stored at registration time (mirroring the
+        // periodic task path, keyed by task identifier).
+        let storedInputData = UserDefaultsHelper.getStoredPeriodicTaskInputData(forTaskIdentifier: task.identifier)
+        let operation = createBackgroundOperation(
+            identifier: task.identifier,
+            inputData: storedInputData,
+            backgroundMode: .backgroundHealthResearchTask(identifier: identifier)
+        )
+
+        task.expirationHandler = { operation.cancel() }
+        operation.completionBlock = { task.setTaskCompleted(success: !operation.isCancelled) }
+
+        operationQueue.addOperation(operation)
+    }
+
+    @available(iOS 17.0, *)
+    private static func scheduleHealthResearchTask(
+        withIdentifier uniqueTaskIdentifier: String,
+        earliestBeginInSeconds begin: Double,
+        requiresNetworkConnectivity: Bool,
+        requiresExternalPower: Bool
+    ) {
+        let request = BGHealthResearchTaskRequest(identifier: uniqueTaskIdentifier)
+        request.earliestBeginDate = Date(timeIntervalSinceNow: begin)
+        request.requiresNetworkConnectivity = requiresNetworkConnectivity
+        request.requiresExternalPower = requiresExternalPower
+
+        do {
+            try BGTaskScheduler.shared.submit(request)
+            logInfo("BGHealthResearchTask submitted \(uniqueTaskIdentifier) earliestBeginInSeconds:\(begin)")
+            UserDefaultsHelper.storeScheduledTask(
+                ScheduledTaskInfo(kind: .healthResearch, earliestBeginInSeconds: begin),
+                forTaskIdentifier: uniqueTaskIdentifier
+            )
+            registerLaunchHandlerOnce(forTaskWithIdentifier: uniqueTaskIdentifier, earliestBeginInSeconds: nil)
+        } catch {
+            logInfo("Could not schedule BGHealthResearchTask identifier:\(uniqueTaskIdentifier) error:\(error.localizedDescription)")
+            logInfo("Possible issues: iOS 17+ required, or the app is missing the health research study entitlement / the user has not opted in")
+        }
+    }
+
     /// Registers the launch handler for [identifier] at most once per process.
     ///
-    /// The handler dispatches on the delivered task type so both periodic
-    /// (BGAppRefreshTask) and processing (BGProcessingTask) identifiers can be
-    /// re-registered from persisted state at app launch.
+    /// The handler dispatches on the delivered task type so periodic
+    /// (BGAppRefreshTask), processing (BGProcessingTask) and health research
+    /// (BGHealthResearchTask) identifiers can be re-registered from persisted
+    /// state at app launch.
     @available(iOS 13.0, *)
     private static func registerLaunchHandlerOnce(
         forTaskWithIdentifier identifier: String,
@@ -565,6 +687,10 @@ extension WorkmanagerPlugin {
                     earliestBeginInSeconds: earliestBeginInSeconds,
                     inputData: storedInputData
                 )
+            } else if #available(iOS 17.0, *), let task = task as? BGHealthResearchTask {
+                // BGHealthResearchTask is a subclass of BGProcessingTask, so it
+                // must be checked before the generic BGProcessingTask branch.
+                handleBGHealthResearchTask(identifier: identifier, task: task)
             } else if let task = task as? BGProcessingTask {
                 handleBGProcessingTask(identifier: identifier, task: task)
             }

--- a/workmanager_apple/ios/workmanager_apple/Sources/workmanager_apple/pigeon/WorkmanagerApi.g.swift
+++ b/workmanager_apple/ios/workmanager_apple/Sources/workmanager_apple/pigeon/WorkmanagerApi.g.swift
@@ -616,6 +616,62 @@ struct ProcessingTaskRequest: Hashable {
   }
 }
 
+/// Generated class from Pigeon that represents data sent in messages.
+struct HealthResearchTaskRequest: Hashable {
+  var uniqueName: String
+  var taskName: String
+  var inputData: [String?: Any?]? = nil
+  var initialDelaySeconds: Int64? = nil
+  var networkType: NetworkType? = nil
+  var requiresCharging: Bool? = nil
+
+
+  // swift-format-ignore: AlwaysUseLowerCamelCase
+  static func fromList(_ pigeonVar_list: [Any?]) -> HealthResearchTaskRequest? {
+    let uniqueName = pigeonVar_list[0] as! String
+    let taskName = pigeonVar_list[1] as! String
+    let inputData: [String?: Any?]? = nilOrValue(pigeonVar_list[2])
+    let initialDelaySeconds: Int64? = nilOrValue(pigeonVar_list[3])
+    let networkType: NetworkType? = nilOrValue(pigeonVar_list[4])
+    let requiresCharging: Bool? = nilOrValue(pigeonVar_list[5])
+
+    return HealthResearchTaskRequest(
+      uniqueName: uniqueName,
+      taskName: taskName,
+      inputData: inputData,
+      initialDelaySeconds: initialDelaySeconds,
+      networkType: networkType,
+      requiresCharging: requiresCharging
+    )
+  }
+  func toList() -> [Any?] {
+    return [
+      uniqueName,
+      taskName,
+      inputData,
+      initialDelaySeconds,
+      networkType,
+      requiresCharging,
+    ]
+  }
+  static func == (lhs: HealthResearchTaskRequest, rhs: HealthResearchTaskRequest) -> Bool {
+    if Swift.type(of: lhs) != Swift.type(of: rhs) {
+      return false
+    }
+    return deepEqualsWorkmanagerApi(lhs.uniqueName, rhs.uniqueName) && deepEqualsWorkmanagerApi(lhs.taskName, rhs.taskName) && deepEqualsWorkmanagerApi(lhs.inputData, rhs.inputData) && deepEqualsWorkmanagerApi(lhs.initialDelaySeconds, rhs.initialDelaySeconds) && deepEqualsWorkmanagerApi(lhs.networkType, rhs.networkType) && deepEqualsWorkmanagerApi(lhs.requiresCharging, rhs.requiresCharging)
+  }
+
+  func hash(into hasher: inout Hasher) {
+    hasher.combine("HealthResearchTaskRequest")
+    deepHashWorkmanagerApi(value: uniqueName, hasher: &hasher)
+    deepHashWorkmanagerApi(value: taskName, hasher: &hasher)
+    deepHashWorkmanagerApi(value: inputData, hasher: &hasher)
+    deepHashWorkmanagerApi(value: initialDelaySeconds, hasher: &hasher)
+    deepHashWorkmanagerApi(value: networkType, hasher: &hasher)
+    deepHashWorkmanagerApi(value: requiresCharging, hasher: &hasher)
+  }
+}
+
 private class WorkmanagerApiPigeonCodecReader: FlutterStandardReader {
   override func readValue(ofType type: UInt8) -> Any? {
     switch type {
@@ -667,6 +723,8 @@ private class WorkmanagerApiPigeonCodecReader: FlutterStandardReader {
       return PeriodicTaskRequest.fromList(self.readValue() as! [Any?])
     case 140:
       return ProcessingTaskRequest.fromList(self.readValue() as! [Any?])
+    case 141:
+      return HealthResearchTaskRequest.fromList(self.readValue() as! [Any?])
     default:
       return super.readValue(ofType: type)
     }
@@ -711,6 +769,9 @@ private class WorkmanagerApiPigeonCodecWriter: FlutterStandardWriter {
     } else if let value = value as? ProcessingTaskRequest {
       super.writeByte(140)
       super.writeValue(value.toList())
+    } else if let value = value as? HealthResearchTaskRequest {
+      super.writeByte(141)
+      super.writeValue(value.toList())
     } else {
       super.writeValue(value)
     }
@@ -738,6 +799,7 @@ protocol WorkmanagerHostApi {
   func registerOneOffTask(request: OneOffTaskRequest, completion: @escaping (Result<Void, Error>) -> Void)
   func registerPeriodicTask(request: PeriodicTaskRequest, completion: @escaping (Result<Void, Error>) -> Void)
   func registerProcessingTask(request: ProcessingTaskRequest, completion: @escaping (Result<Void, Error>) -> Void)
+  func registerHealthResearchTask(request: HealthResearchTaskRequest, completion: @escaping (Result<Void, Error>) -> Void)
   func cancelByUniqueName(uniqueName: String, completion: @escaping (Result<Void, Error>) -> Void)
   func cancelByTag(tag: String, completion: @escaping (Result<Void, Error>) -> Void)
   func cancelAll(completion: @escaping (Result<Void, Error>) -> Void)
@@ -818,6 +880,23 @@ class WorkmanagerHostApiSetup {
       }
     } else {
       registerProcessingTaskChannel.setMessageHandler(nil)
+    }
+    let registerHealthResearchTaskChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.workmanager_platform_interface.WorkmanagerHostApi.registerHealthResearchTask\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
+    if let api = api {
+      registerHealthResearchTaskChannel.setMessageHandler { message, reply in
+        let args = message as! [Any?]
+        let requestArg = args[0] as! HealthResearchTaskRequest
+        api.registerHealthResearchTask(request: requestArg) { result in
+          switch result {
+          case .success:
+            reply(wrapResult(nil))
+          case .failure(let error):
+            reply(wrapError(error))
+          }
+        }
+      }
+    } else {
+      registerHealthResearchTaskChannel.setMessageHandler(nil)
     }
     let cancelByUniqueNameChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.workmanager_platform_interface.WorkmanagerHostApi.cancelByUniqueName\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
     if let api = api {

--- a/workmanager_apple/lib/workmanager_apple.dart
+++ b/workmanager_apple/lib/workmanager_apple.dart
@@ -110,6 +110,24 @@ class WorkmanagerApple extends WorkmanagerPlatform {
   }
 
   @override
+  Future<void> registerHealthResearchTask(
+    String uniqueName,
+    String taskName, {
+    Duration? initialDelay,
+    Map<String, dynamic>? inputData,
+    Constraints? constraints,
+  }) async {
+    await _api.registerHealthResearchTask(HealthResearchTaskRequest(
+      uniqueName: uniqueName,
+      taskName: taskName,
+      inputData: inputData?.cast<String?, Object?>(),
+      initialDelaySeconds: initialDelay?.inSeconds,
+      networkType: constraints?.networkType,
+      requiresCharging: constraints?.requiresCharging,
+    ));
+  }
+
+  @override
   Future<void> cancelByUniqueName(String uniqueName) async {
     await _api.cancelByUniqueName(uniqueName);
   }

--- a/workmanager_apple/test/workmanager_apple_test.dart
+++ b/workmanager_apple/test/workmanager_apple_test.dart
@@ -131,6 +131,40 @@ void main() {
       });
     });
 
+    group('iOS-specific health research task request validation', () {
+      test('should handle HealthResearchTaskRequest creation', () {
+        final healthRequest = HealthResearchTaskRequest(
+          uniqueName: 'com.example.health-research-task',
+          taskName: 'Health Research Task',
+          inputData: {'study': 'example-study', 'participantId': '42'},
+          initialDelaySeconds: 600, // 10 minutes
+          networkType: NetworkType.unmetered,
+          requiresCharging: true,
+        );
+
+        expect(healthRequest.uniqueName, 'com.example.health-research-task');
+        expect(healthRequest.taskName, 'Health Research Task');
+        expect(healthRequest.networkType, NetworkType.unmetered);
+        expect(healthRequest.requiresCharging, true);
+        expect(healthRequest.initialDelaySeconds, 600);
+        expect(healthRequest.inputData?['study'], 'example-study');
+      });
+
+      test('should handle minimal health research task configuration', () {
+        final minimalRequest = HealthResearchTaskRequest(
+          uniqueName: 'minimal-health-task',
+          taskName: 'Minimal Health Task',
+        );
+
+        expect(minimalRequest.uniqueName, 'minimal-health-task');
+        expect(minimalRequest.taskName, 'Minimal Health Task');
+        expect(minimalRequest.inputData, null);
+        expect(minimalRequest.initialDelaySeconds, null);
+        expect(minimalRequest.networkType, null);
+        expect(minimalRequest.requiresCharging, null);
+      });
+    });
+
     group('iOS constraint handling differences', () {
       test('should handle battery constraints appropriately for iOS', () {
         // iOS handles battery constraints differently than Android

--- a/workmanager_platform_interface/lib/src/pigeon/workmanager_api.g.dart
+++ b/workmanager_platform_interface/lib/src/pigeon/workmanager_api.g.dart
@@ -599,6 +599,71 @@ class ProcessingTaskRequest {
   int get hashCode => _deepHash(<Object?>[runtimeType, ..._toList()]);
 }
 
+class HealthResearchTaskRequest {
+  HealthResearchTaskRequest({
+    required this.uniqueName,
+    required this.taskName,
+    this.inputData,
+    this.initialDelaySeconds,
+    this.networkType,
+    this.requiresCharging,
+  });
+
+  String uniqueName;
+
+  String taskName;
+
+  Map<String?, Object?>? inputData;
+
+  int? initialDelaySeconds;
+
+  NetworkType? networkType;
+
+  bool? requiresCharging;
+
+  List<Object?> _toList() {
+    return <Object?>[
+      uniqueName,
+      taskName,
+      inputData,
+      initialDelaySeconds,
+      networkType,
+      requiresCharging,
+    ];
+  }
+
+  Object encode() {
+    return _toList();  }
+
+  static HealthResearchTaskRequest decode(Object result) {
+    result as List<Object?>;
+    return HealthResearchTaskRequest(
+      uniqueName: result[0]! as String,
+      taskName: result[1]! as String,
+      inputData: (result[2] as Map<Object?, Object?>?)?.cast<String?, Object?>(),
+      initialDelaySeconds: result[3] as int?,
+      networkType: result[4] as NetworkType?,
+      requiresCharging: result[5] as bool?,
+    );
+  }
+
+  @override
+  // ignore: avoid_equals_and_hash_code_on_mutable_classes
+  bool operator ==(Object other) {
+    if (other is! HealthResearchTaskRequest || other.runtimeType != runtimeType) {
+      return false;
+    }
+    if (identical(this, other)) {
+      return true;
+    }
+    return _deepEquals(uniqueName, other.uniqueName) && _deepEquals(taskName, other.taskName) && _deepEquals(inputData, other.inputData) && _deepEquals(initialDelaySeconds, other.initialDelaySeconds) && _deepEquals(networkType, other.networkType) && _deepEquals(requiresCharging, other.requiresCharging);
+  }
+
+  @override
+  // ignore: avoid_equals_and_hash_code_on_mutable_classes
+  int get hashCode => _deepHash(<Object?>[runtimeType, ..._toList()]);
+}
+
 
 class _PigeonCodec extends StandardMessageCodec {
   const _PigeonCodec();
@@ -643,6 +708,9 @@ class _PigeonCodec extends StandardMessageCodec {
     }    else if (value is ProcessingTaskRequest) {
       buffer.putUint8(140);
       writeValue(buffer, value.encode());
+    }    else if (value is HealthResearchTaskRequest) {
+      buffer.putUint8(141);
+      writeValue(buffer, value.encode());
     } else {
       super.writeValue(buffer, value);
     }
@@ -681,6 +749,8 @@ class _PigeonCodec extends StandardMessageCodec {
         return PeriodicTaskRequest.decode(readValue(buffer)!);
       case 140:
         return ProcessingTaskRequest.decode(readValue(buffer)!);
+      case 141:
+        return HealthResearchTaskRequest.decode(readValue(buffer)!);
       default:
         return super.readValueOfType(type, buffer);
     }
@@ -756,6 +826,24 @@ class WorkmanagerHostApi {
 
   Future<void> registerProcessingTask(ProcessingTaskRequest request) async {
     final pigeonVar_channelName = 'dev.flutter.pigeon.workmanager_platform_interface.WorkmanagerHostApi.registerProcessingTask$pigeonVar_messageChannelSuffix';
+    final pigeonVar_channel = BasicMessageChannel<Object?>(
+      pigeonVar_channelName,
+      pigeonChannelCodec,
+      binaryMessenger: pigeonVar_binaryMessenger,
+    );
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[request]);
+    final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
+
+    _extractReplyValueOrThrow(
+        pigeonVar_replyList,
+        pigeonVar_channelName,
+        isNullValid: true,
+    )
+    ;
+  }
+
+  Future<void> registerHealthResearchTask(HealthResearchTaskRequest request) async {
+    final pigeonVar_channelName = 'dev.flutter.pigeon.workmanager_platform_interface.WorkmanagerHostApi.registerHealthResearchTask$pigeonVar_messageChannelSuffix';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,

--- a/workmanager_platform_interface/lib/src/workmanager_platform_interface.dart
+++ b/workmanager_platform_interface/lib/src/workmanager_platform_interface.dart
@@ -116,6 +116,24 @@ abstract class WorkmanagerPlatform extends PlatformInterface {
         'registerProcessingTask() has not been implemented.');
   }
 
+  /// Register a health research task (iOS 17+ only).
+  ///
+  /// [uniqueName] is the unique identifier for this task.
+  /// [taskName] is the name of the task that will be passed to the callback.
+  /// [initialDelay] is the delay before the task is executed.
+  /// [inputData] is optional data that will be passed to the callback.
+  /// [constraints] are the constraints that must be met for the task to run.
+  Future<void> registerHealthResearchTask(
+    String uniqueName,
+    String taskName, {
+    Duration? initialDelay,
+    Map<String, dynamic>? inputData,
+    Constraints? constraints,
+  }) {
+    throw UnimplementedError(
+        'registerHealthResearchTask() has not been implemented.');
+  }
+
   /// Cancel a task by its unique name.
   Future<void> cancelByUniqueName(String uniqueName) {
     throw UnimplementedError('cancelByUniqueName() has not been implemented.');
@@ -197,6 +215,19 @@ class _PlaceholderImplementation extends WorkmanagerPlatform {
 
   @override
   Future<void> registerProcessingTask(
+    String uniqueName,
+    String taskName, {
+    Duration? initialDelay,
+    Map<String, dynamic>? inputData,
+    Constraints? constraints,
+  }) async {
+    throw UnimplementedError(
+      'No implementation found for workmanager on this platform.',
+    );
+  }
+
+  @override
+  Future<void> registerHealthResearchTask(
     String uniqueName,
     String taskName, {
     Duration? initialDelay,

--- a/workmanager_platform_interface/pigeons/workmanager_api.dart
+++ b/workmanager_platform_interface/pigeons/workmanager_api.dart
@@ -251,6 +251,29 @@ class ProcessingTaskRequest {
   bool? requiresCharging;
 }
 
+// iOS specific request
+// BGHealthResearchTaskRequest (iOS 17+) for apps participating in health
+// research studies. It extends BGProcessingTaskRequest and is scheduled the
+// same way, but is delivered with higher priority/reliability for study-
+// essential processing.
+class HealthResearchTaskRequest {
+  HealthResearchTaskRequest({
+    required this.uniqueName,
+    required this.taskName,
+    this.inputData,
+    this.initialDelaySeconds,
+    this.networkType,
+    this.requiresCharging,
+  });
+
+  String uniqueName;
+  String taskName;
+  Map<String?, Object?>? inputData;
+  int? initialDelaySeconds;
+  NetworkType? networkType;
+  bool? requiresCharging;
+}
+
 // Host API (Flutter calls native)
 @HostApi()
 abstract class WorkmanagerHostApi {
@@ -265,6 +288,9 @@ abstract class WorkmanagerHostApi {
 
   @async
   void registerProcessingTask(ProcessingTaskRequest request);
+
+  @async
+  void registerHealthResearchTask(HealthResearchTaskRequest request);
 
   @async
   void cancelByUniqueName(String uniqueName);


### PR DESCRIPTION
Adds `Workmanager().registerHealthResearchTask(...)` — iOS 17+ `BGHealthResearchTaskRequest` support for apps participating in a Health Research Study container.

## What's included
- Pigeon: new `HealthResearchTaskRequest` + `registerHealthResearchTask` host API (regenerated Dart/Kotlin/Swift).
- Dart: `Workmanager.registerHealthResearchTask` + platform interface (Android/macOS throw `UnsupportedError`; iOS < 17 returns a Pigeon error).
- iOS: `BGHealthResearchTaskRequest` submission (earliestBeginDate/network/charging), inputData persistence, automatic launch-handler registration + `WorkmanagerPlugin.registerBGHealthResearchTask(withIdentifier:)` for AppDelegate pre-registration, and `BGHealthResearchTask` dispatch in the launch handler (checked before the `BGProcessingTask` branch since it's a subclass).
- Docs: iOS background-strategy capability matrix (BGAppRefresh / BGProcessing / BGHealthResearch / BGContinuedProcessing / legacy fetch) in `docs/index.mdx`, plus Quick Start "Option D".

## Honest constraints (documented in docs)
- Apple requires the `com.apple.developer.backgroundtasks.healthresearch` entitlement, a Health Research Study container (HealthKit/ResearchKit), and user opt-in before the system will accept or deliver these tasks. Without them `BGTaskScheduler.submit` fails; the plugin cannot validate this.
- Runtime delivery cannot be verified without a physical device + entitlement + active study — marked as a TODO in docs.
- `BGContinuedProcessingTaskRequest` (iOS 26+, issue #638) is documented as not-yet-supported (foreground-initiated task model).

Closes #532.