### PR TITLE
feat(ios): add UIScene lifecycle support (fixes #662)

### DIFF
--- a/docs/debugging.mdx
+++ b/docs/debugging.mdx
@@ -64,16 +64,18 @@ Shows debug information in iOS's unified logging system:
 import workmanager_apple
 
 @main
-class AppDelegate: FlutterAppDelegate {
+class AppDelegate: FlutterAppDelegate, FlutterImplicitEngineDelegate {
     override func application(
         _ application: UIApplication,
         didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
     ) -> Bool {
-        GeneratedPluginRegistrant.register(with: self)
-        
         WorkmanagerDebug.setCurrent(LoggingDebugHandler())
         
         return super.application(application, didFinishLaunchingWithOptions: launchOptions)
+    }
+
+    func didInitializeImplicitFlutterEngine(_ engineBridge: FlutterImplicitEngineBridge) {
+        GeneratedPluginRegistrant.register(with: engineBridge.pluginRegistry)
     }
 }
 ```
@@ -87,13 +89,11 @@ Shows debug information as notifications (helpful for seeing background task exe
 import workmanager_apple
 
 @main
-class AppDelegate: FlutterAppDelegate {
+class AppDelegate: FlutterAppDelegate, FlutterImplicitEngineDelegate {
     override func application(
         _ application: UIApplication,
         didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
     ) -> Bool {
-        GeneratedPluginRegistrant.register(with: self)
-        
         // Set notification delegate first
         UNUserNotificationCenter.current().delegate = self
         
@@ -116,6 +116,10 @@ class AppDelegate: FlutterAppDelegate {
         willPresent notification: UNNotification,
         withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
             completionHandler(.alert)  // Show notification banner even if app is in foreground
+    }
+
+    func didInitializeImplicitFlutterEngine(_ engineBridge: FlutterImplicitEngineBridge) {
+        GeneratedPluginRegistrant.register(with: engineBridge.pluginRegistry)
     }
 }
 ```

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -43,7 +43,14 @@ fails with `PlatformException(channel-error, Unable to establish connection on
 channel...)`.
 
 To make plugins available in the background engine, wire the plugin
-registrant callback in your `AppDelegate.swift`:
+registrant callback in your `AppDelegate.swift`. The snippet below also follows
+Flutter's [UIScene lifecycle migration](https://docs.flutter.dev/release/breaking-changes/uiscenedelegate):
+plugins are registered in `didInitializeImplicitFlutterEngine` (instead of
+`application(_:didFinishLaunchingWithOptions:)`), and
+`WorkmanagerPlugin.registerLaunchHandlers()` re-registers the BGTaskScheduler
+launch handlers persisted from previous sessions — iOS requires those to be
+registered before app launch finishes, and under UIScene the plugin's own
+`application` callback runs too late for that:
 
 ```swift
 import Flutter
@@ -51,12 +58,12 @@ import UIKit
 import workmanager_apple
 
 @main
-@objc class AppDelegate: FlutterAppDelegate {
+@objc class AppDelegate: FlutterAppDelegate, FlutterImplicitEngineDelegate {
   override func application(
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
   ) -> Bool {
-    GeneratedPluginRegistrant.register(with: self)
+    WorkmanagerPlugin.registerLaunchHandlers()
 
     WorkmanagerPlugin.setPluginRegistrantCallback { registry in
       GeneratedPluginRegistrant.register(with: registry)
@@ -64,8 +71,23 @@ import workmanager_apple
 
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
   }
+
+  func didInitializeImplicitFlutterEngine(_ engineBridge: FlutterImplicitEngineBridge) {
+    GeneratedPluginRegistrant.register(with: engineBridge.pluginRegistry)
+  }
 }
 ```
+
+<Info>
+**UIScene lifecycle:** Apple requires UIKit apps to adopt the UIScene lifecycle
+from the release following iOS 26. After migration, call
+`WorkmanagerPlugin.registerLaunchHandlers()` in your AppDelegate's
+`application(_:didFinishLaunchingWithOptions:)` so BGTaskScheduler launch
+handlers are registered before app launch finishes (the plugin re-registers
+every identifier it persisted in previous sessions, so tasks scheduled from
+Dart keep being delivered after a relaunch). Apps that haven't migrated to
+UIScene keep working without this call.
+</Info>
 
 <Warning>
 **Background-isolate plugins:** only plugins that are safe to use from a
@@ -116,6 +138,11 @@ WorkmanagerPlugin.registerBGProcessingTask(
 )
 ```
 
+Apps that adopted the UIScene lifecycle must also call
+`WorkmanagerPlugin.registerLaunchHandlers()` in
+`application(_:didFinishLaunchingWithOptions:)` — see the
+[registrant wiring section above](#use-other-flutter-plugins-inside-background-tasks-ios).
+
 <Warning>
 **iOS Task Identifier Matching:** The task name in your Dart code must **exactly match** the identifier in Info.plist and AppDelegate. Using short names like `"data_sync"` in Dart while having `com.yourapp.processing_task` in native code will cause `BGTaskSchedulerErrorDomain Code 3` errors.
 </Warning>
@@ -152,7 +179,10 @@ WorkmanagerPlugin.registerPeriodicTask(
 ```
 The plugin re-registers launch handlers for scheduled task identifiers on app
 launch, so this step is only needed if you want to pre-register the task or
-control the scheduling hint from native code.
+control the scheduling hint from native code. Apps that adopted the UIScene
+lifecycle must also call `WorkmanagerPlugin.registerLaunchHandlers()` in
+`application(_:didFinishLaunchingWithOptions:)` — see the
+[registrant wiring section above](#use-other-flutter-plugins-inside-background-tasks-ios).
 
 <Warning>
 **iOS Task Identifier Matching:** The task name in your Dart code must **exactly match** the identifier in Info.plist and AppDelegate. Using short names like `"cleanup"` in Dart while having `com.yourapp.periodic_task` in native code will cause `BGTaskSchedulerErrorDomain Code 3` errors.

--- a/example/ios/Runner/AppDelegate.swift
+++ b/example/ios/Runner/AppDelegate.swift
@@ -4,13 +4,19 @@ import workmanager_apple
 
 @UIApplicationMain
 
-@objc class AppDelegate: FlutterAppDelegate {
+@objc class AppDelegate: FlutterAppDelegate, FlutterImplicitEngineDelegate {
 
     override func application(
         _ application: UIApplication,
         didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
 
-        GeneratedPluginRegistrant.register(with: self)
+        // Under the UIScene lifecycle, Flutter registers plugins after
+        // `didFinishLaunching` returns (during scene connection). BGTaskScheduler
+        // still requires launch handlers to be registered before app launch
+        // finishes, so re-register the handlers persisted from previous sessions
+        // here. The plugin's own `application` callback runs too late for that.
+        WorkmanagerPlugin.registerLaunchHandlers()
+
         UNUserNotificationCenter.current().delegate = self
 
         // Request notification permission for debug handler
@@ -53,6 +59,10 @@ import workmanager_apple
 
         return super.application(application, didFinishLaunchingWithOptions: launchOptions)
 
+    }
+
+    func didInitializeImplicitFlutterEngine(_ engineBridge: FlutterImplicitEngineBridge) {
+        GeneratedPluginRegistrant.register(with: engineBridge.pluginRegistry)
     }
 
     override func userNotificationCenter(

--- a/example/ios/Runner/Info.plist
+++ b/example/ios/Runner/Info.plist
@@ -45,6 +45,27 @@
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>
 	<string>Main</string>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneClassName</key>
+					<string>UIWindowScene</string>
+					<key>UISceneDelegateClassName</key>
+					<string>FlutterSceneDelegate</string>
+					<key>UISceneConfigurationName</key>
+					<string>flutter</string>
+					<key>UISceneStoryboardFile</key>
+					<string>Main</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>

--- a/example/ios/RunnerTests/WorkmanagerTests.swift
+++ b/example/ios/RunnerTests/WorkmanagerTests.swift
@@ -12,9 +12,70 @@ import XCTest
 
 class WorkmanagerTests: XCTestCase {
 
-    // TODO: Add tests for Pigeon-based implementation
-    func testPlaceholder() throws {
-        XCTAssertTrue(true)
+    override func setUp() {
+        super.setUp()
+        UserDefaultsHelper.removeAllScheduledTasks()
+    }
+
+    override func tearDown() {
+        UserDefaultsHelper.removeAllScheduledTasks()
+        super.tearDown()
+    }
+
+    // MARK: - Scheduled task persistence (BGTask launch-handler re-registration)
+
+    func testScheduledTaskRoundTripPreservesKindAndEarliestBegin() {
+        let identifier = "dev.fluttercommunity.test.roundTrip"
+        let task = ScheduledTaskInfo(kind: .processing, earliestBeginInSeconds: 120)
+
+        UserDefaultsHelper.storeScheduledTask(task, forTaskIdentifier: identifier)
+
+        let stored = UserDefaultsHelper.getScheduledTasks()[identifier]
+        XCTAssertNotNil(stored, "stored task should be retrievable")
+        XCTAssertEqual(stored?.kind, .processing)
+        XCTAssertEqual(stored?.earliestBeginInSeconds, 120)
+    }
+
+    func testScheduledTaskStoresNilEarliestBeginForRefreshTasks() {
+        let identifier = "dev.fluttercommunity.test.nilEarliestBegin"
+        UserDefaultsHelper.storeScheduledTask(
+            ScheduledTaskInfo(kind: .refresh, earliestBeginInSeconds: nil),
+            forTaskIdentifier: identifier
+        )
+
+        let stored = UserDefaultsHelper.getScheduledTasks()[identifier]
+        XCTAssertNotNil(stored, "stored task should be retrievable")
+        XCTAssertEqual(stored?.kind, .refresh)
+        XCTAssertNil(stored?.earliestBeginInSeconds)
+    }
+
+    func testRemoveScheduledTaskOnlyRemovesMatchingIdentifier() {
+        let keepIdentifier = "dev.fluttercommunity.test.keep"
+        let removeIdentifier = "dev.fluttercommunity.test.remove"
+        UserDefaultsHelper.storeScheduledTask(
+            ScheduledTaskInfo(kind: .refresh, earliestBeginInSeconds: nil),
+            forTaskIdentifier: keepIdentifier
+        )
+        UserDefaultsHelper.storeScheduledTask(
+            ScheduledTaskInfo(kind: .processing, earliestBeginInSeconds: 60),
+            forTaskIdentifier: removeIdentifier
+        )
+
+        UserDefaultsHelper.removeScheduledTask(removeIdentifier)
+
+        XCTAssertNil(UserDefaultsHelper.getScheduledTasks()[removeIdentifier])
+        XCTAssertNotNil(UserDefaultsHelper.getScheduledTasks()[keepIdentifier])
+    }
+
+    func testRemoveAllScheduledTasksClearsPersistedState() {
+        UserDefaultsHelper.storeScheduledTask(
+            ScheduledTaskInfo(kind: .refresh, earliestBeginInSeconds: nil),
+            forTaskIdentifier: "dev.fluttercommunity.test.clear"
+        )
+
+        UserDefaultsHelper.removeAllScheduledTasks()
+
+        XCTAssertTrue(UserDefaultsHelper.getScheduledTasks().isEmpty)
     }
 
 }

--- a/workmanager_apple/ios/workmanager_apple/Sources/workmanager_apple/WorkmanagerPlugin.swift
+++ b/workmanager_apple/ios/workmanager_apple/Sources/workmanager_apple/WorkmanagerPlugin.swift
@@ -571,6 +571,30 @@ extension WorkmanagerPlugin {
         }
     }
 
+    /// Re-registers the BGTaskScheduler launch handler for every task
+    /// identifier persisted from a previous session.
+    ///
+    /// BGTaskScheduler only delivers a task to a relaunched app if its launch
+    /// handler was registered during `application(_:didFinishLaunchingWithOptions:)`.
+    /// With the UIScene lifecycle, Flutter registers plugins after
+    /// `didFinishLaunching` returns (during scene connection), so the plugin's
+    /// own `application` callback can no longer re-register the handlers in
+    /// time. Apps that adopt UIScene must call this method from their
+    /// AppDelegate's `application(_:didFinishLaunchingWithOptions:)` before it
+    /// returns. Non-scene apps keep working without it because the plugin
+    /// performs the same re-registration in its `application` callback.
+    @objc
+    public static func registerLaunchHandlers() {
+        if #available(iOS 13.0, *) {
+            for (identifier, info) in UserDefaultsHelper.getScheduledTasks() {
+                WorkmanagerPlugin.registerLaunchHandlerOnce(
+                    forTaskWithIdentifier: identifier,
+                    earliestBeginInSeconds: info.earliestBeginInSeconds.map { NSNumber(value: $0) }
+                )
+            }
+        }
+    }
+
     private func createUnsupportedVersionError(feature: String) -> PigeonError {
         return PigeonError(
             code: "99",
@@ -634,11 +658,24 @@ extension WorkmanagerPlugin {
         #if os(iOS)
         WorkmanagerHostApiSetup.setUp(binaryMessenger: registrar.messenger(), api: instance)
         registrar.addApplicationDelegate(instance)
+        registrar.addSceneDelegate(instance)
         #elseif os(macOS)
         WorkmanagerHostApiSetup.setUp(binaryMessenger: registrar.messenger, api: instance)
         #endif
     }
 }
+
+// MARK: - FlutterSceneLifeCycleDelegate conformance (iOS only)
+
+#if os(iOS)
+extension WorkmanagerPlugin: FlutterSceneLifeCycleDelegate {
+    // Workmanager has no UI-lifecycle-specific work today: BGTaskScheduler
+    // registration is app-level (see `registerLaunchHandlers()`) and background
+    // fetch remains an application delegate event. Registering as a scene
+    // delegate keeps the plugin available to scene-based apps (required by
+    // Flutter's UIScene migration) and future scene events can be added here.
+}
+#endif
 
 // MARK: - AppDelegate conformance (iOS only)
 
@@ -652,14 +689,7 @@ extension WorkmanagerPlugin {
         // handler was registered during `didFinishLaunching`. Re-register the
         // handlers for identifiers scheduled in previous sessions, so periodic
         // and processing tasks keep working without manual AppDelegate code.
-        if #available(iOS 13.0, *) {
-            for (identifier, info) in UserDefaultsHelper.getScheduledTasks() {
-                WorkmanagerPlugin.registerLaunchHandlerOnce(
-                    forTaskWithIdentifier: identifier,
-                    earliestBeginInSeconds: info.earliestBeginInSeconds.map { NSNumber(value: $0) }
-                )
-            }
-        }
+        WorkmanagerPlugin.registerLaunchHandlers()
         return true
     }
 

--- a/workmanager_apple/pubspec.yaml
+++ b/workmanager_apple/pubspec.yaml
@@ -8,7 +8,7 @@ issue_tracker: https://github.com/fluttercommunity/flutter_workmanager/issues
 
 environment:
   sdk: '>=3.5.0 <4.0.0'
-  flutter: ">=3.32.0"
+  flutter: ">=3.38.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
## Summary

Adds [UIScene lifecycle](https://docs.flutter.dev/release/breaking-changes/uiscenedelegate) support to the iOS plugin so apps remain launchable on iOS 26+ (Apple will require the UIScene lifecycle in the release following iOS 26). Fixes #662.

**Plugin (`workmanager_apple`, iOS)**
- `WorkmanagerPlugin` now conforms to `FlutterSceneLifeCycleDelegate` and is registered via `registrar.addSceneDelegate(_:)` in addition to `addApplicationDelegate(_:)`, so it works on both scene-based and legacy apps.
- New public `WorkmanagerPlugin.registerLaunchHandlers()` re-registers the BGTaskScheduler launch handlers persisted in previous sessions (#692 `UserDefaultsHelper.ScheduledTaskInfo` untouched). Under UIScene, Flutter registers plugins after `application(_:didFinishLaunchingWithOptions:)` returns, which is too late for BGTaskScheduler, so scene-based apps must call this from their AppDelegate. Non-scene apps keep working automatically via the plugin's existing `application` callback (unchanged behavior, deduplicated per process).
- No UI-lifecycle events are currently needed by the plugin (BGTaskScheduler + background fetch are app-level), so no scene event methods were added.
- `pubspec.yaml` Flutter constraint bumped to `>=3.38.0` (minimum required for `addSceneDelegate`/`FlutterSceneLifeCycleDelegate` per the Flutter migration guide). Dart SDK constraint and package version untouched.

**Example app**
- `AppDelegate` conforms to `FlutterImplicitEngineDelegate`; `GeneratedPluginRegistrant.register(with:)` moved to `didInitializeImplicitFlutterEngine(_:)`. Notification/debug/registrant-callback setup stays in `application(_:didFinishLaunchingWithOptions:)` (process-level), which now calls `WorkmanagerPlugin.registerLaunchHandlers()`.
- `Info.plist` gains `UIApplicationSceneManifest` (single scene, `FlutterSceneDelegate`, storyboard `Main`) — exactly what the Flutter tool auto-migration writes.

**Docs**
- `docs/quickstart.mdx`: registrant-wiring AppDelegate snippet updated to the new lifecycle and a `registerLaunchHandlers()` callout added for UIScene apps; Option B/C notes reference the wiring section instead of duplicating it (#513/#694 docs stay authoritative).
- `docs/debugging.mdx`: debug-handler AppDelegate snippets updated to the new registration flow.

## Verification
- `flutter analyze` (workspace + packages): clean
- `dart format --set-exit-if-changed`: clean
- `swiftlint` on changed files: no new violations (existing warnings only)
- `melos run test`: green
- `flutter build ios --debug --no-codesign`: green
- Integration tests on iPhone 16 Pro simulator (`flutter test integration_test`): 17/17 passed — app launches under UIScene, plugins register, background one-off tasks execute
- Native iOS unit tests (`xcodebuild test`, RunnerTests): green, incl. 4 new tests for the persisted scheduled-task state the BGTask re-registration relies on

## Breaking Changes
**Before:** app-side BGTask launch-handler re-registration was fully automatic via the plugin's `application(_:didFinishLaunchingWithOptions:)` callback.

**After:** apps that adopt the UIScene lifecycle must add one call in their AppDelegate:
```swift
override func application(...) -> Bool {
  WorkmanagerPlugin.registerLaunchHandlers()
  ...
}
```
Flutter 3.38+ is now required for the iOS plugin (build-time requirement from the new engine APIs). CHANGELOG/version bump intentionally left to the owner.

Fixes #662
