### PR TITLE
fix(ios): run one-off tasks on the main engine to avoid release crash (fixes #653)

### DIFF
--- a/example/ios/RunnerTests/WorkmanagerTests.swift
+++ b/example/ios/RunnerTests/WorkmanagerTests.swift
@@ -7,19 +7,109 @@
 //
 
 import XCTest
+import Flutter
 
 @testable import workmanager_apple
+
+/// Minimal `FlutterBinaryMessenger` stub that records outgoing channel messages
+/// and replies with pigeon-encoded success payloads, simulating the Dart side
+/// of the workmanager Flutter API.
+private final class MockBinaryMessenger: NSObject, FlutterBinaryMessenger {
+    private let codec = WorkmanagerApiPigeonCodec.shared
+    private(set) var sentChannels: [String] = []
+
+    /// When set, the reply sent for the `backgroundChannelInitialized` call is
+    /// a pigeon error instead of success (simulating an unregistered handler).
+    var failBackgroundChannelInitialized = false
+
+    func send(onChannel channel: String, message: Data?) {
+        sentChannels.append(channel)
+    }
+
+    func send(
+        onChannel channel: String,
+        message: Data?,
+        binaryReply reply: FlutterBinaryReply?
+    ) {
+        sentChannels.append(channel)
+
+        let response: Any
+        if channel.contains("backgroundChannelInitialized") {
+            response = failBackgroundChannelInitialized
+                ? ["99", "No handler registered", nil] as [Any?]
+                : [] as [Any]
+        } else {
+            response = [true]
+        }
+        reply?(codec.encode(response))
+    }
+
+    func setMessageHandlerOnChannel(
+        _ channel: String,
+        binaryMessageHandler handler: FlutterBinaryMessageHandler?
+    ) -> FlutterBinaryMessengerConnection {
+        return 0
+    }
+
+    func cleanUpConnection(_ connection: FlutterBinaryMessengerConnection) {}
+}
 
 class WorkmanagerTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
+        WorkmanagerPlugin.mainBinaryMessenger = nil
         UserDefaultsHelper.removeAllScheduledTasks()
     }
 
     override func tearDown() {
+        WorkmanagerPlugin.mainBinaryMessenger = nil
         UserDefaultsHelper.removeAllScheduledTasks()
         super.tearDown()
+    }
+
+    // MARK: - In-process one-off task execution (#653)
+
+    func testOneOffTaskExecutesOnMainEngineWhenMessengerIsAvailable() {
+        let messenger = MockBinaryMessenger()
+        WorkmanagerPlugin.mainBinaryMessenger = messenger
+
+        WorkmanagerPlugin.startOneOffTask(
+            identifier: "dev.fluttercommunity.test.oneOff",
+            taskIdentifier: .invalid,
+            inputData: ["key": "value"],
+            delaySeconds: 0
+        )
+
+        XCTAssertEqual(
+            messenger.sentChannels,
+            [
+                "dev.flutter.pigeon.workmanager_platform_interface.WorkmanagerFlutterApi.backgroundChannelInitialized",
+                "dev.flutter.pigeon.workmanager_platform_interface.WorkmanagerFlutterApi.executeTask"
+            ]
+        )
+    }
+
+    func testOneOffTaskFallsBackToHeadlessEngineWhenDartHandlerIsNotReady() {
+        let messenger = MockBinaryMessenger()
+        messenger.failBackgroundChannelInitialized = true
+        WorkmanagerPlugin.mainBinaryMessenger = messenger
+
+        WorkmanagerPlugin.startOneOffTask(
+            identifier: "dev.fluttercommunity.test.oneOffFallback",
+            taskIdentifier: .invalid,
+            inputData: nil,
+            delaySeconds: 0
+        )
+
+        // The in-process path must not execute the task; the headless engine
+        // fallback handles it instead (and does not use the main messenger).
+        XCTAssertEqual(
+            messenger.sentChannels,
+            [
+                "dev.flutter.pigeon.workmanager_platform_interface.WorkmanagerFlutterApi.backgroundChannelInitialized"
+            ]
+        )
     }
 
     // MARK: - Scheduled task persistence (BGTask launch-handler re-registration)

--- a/workmanager/lib/src/workmanager_impl.dart
+++ b/workmanager/lib/src/workmanager_impl.dart
@@ -112,6 +112,18 @@ class Workmanager {
   static BackgroundTaskHandler? _backgroundTaskHandler;
   static late final WorkmanagerFlutterApi _flutterApi;
 
+  /// The callback dispatcher registered via [initialize], kept so in-process
+  /// (main-engine) one-off tasks can lazily register their task handler on
+  /// first execution without spawning a second Flutter engine.
+  static Function? _callbackDispatcher;
+
+  /// Whether [_callbackDispatcher] has already run in the current isolate.
+  static bool _inProcessDispatcherStarted = false;
+
+  /// Flutter API handler registered on the current isolate's messenger by
+  /// [initialize] so the native side can execute tasks on the running engine.
+  static WorkmanagerFlutterApi? _inProcessFlutterApi;
+
   /// Platform implementation
   static WorkmanagerPlatform get _platform => WorkmanagerPlatform.instance;
 
@@ -126,9 +138,23 @@ class Workmanager {
         'Use WorkmanagerDebug handlers instead. This parameter has no effect.')
     bool isInDebugMode = false,
   }) async {
-    return _platform.initialize(callbackDispatcher,
+    await _platform.initialize(callbackDispatcher,
         // ignore: deprecated_member_use
         isInDebugMode: isInDebugMode);
+    _prepareInProcessExecution(callbackDispatcher);
+  }
+
+  /// Registers the Flutter API surface on the current isolate's messenger so
+  /// one-off tasks can execute on the running (main) engine instead of a second
+  /// full Flutter engine. The [callbackDispatcher] itself runs lazily on the
+  /// first in-process task (see
+  /// [_WorkmanagerFlutterApiImpl.backgroundChannelInitialized]).
+  void _prepareInProcessExecution(Function callbackDispatcher) {
+    _callbackDispatcher = callbackDispatcher;
+    if (_inProcessFlutterApi == null) {
+      _inProcessFlutterApi = _WorkmanagerFlutterApiImpl();
+      WorkmanagerFlutterApi.setUp(_inProcessFlutterApi!);
+    }
   }
 
   /// This method needs to be called from within your [callbackDispatcher].
@@ -432,7 +458,17 @@ Object? normalizeInputDataValue(Object? value) {
 /// Implementation of WorkmanagerFlutterApi for handling background task execution
 class _WorkmanagerFlutterApiImpl extends WorkmanagerFlutterApi {
   @override
-  Future<void> backgroundChannelInitialized() async {}
+  Future<void> backgroundChannelInitialized() async {
+    // On the main engine the callbackDispatcher has not run yet (it normally
+    // runs inside a dedicated headless engine). Run it once so the task
+    // handler is registered before executeTask is invoked, letting one-off
+    // tasks execute in-process without spawning a second engine (fixes #653).
+    final dispatcher = Workmanager._callbackDispatcher;
+    if (dispatcher != null && !Workmanager._inProcessDispatcherStarted) {
+      Workmanager._inProcessDispatcherStarted = true;
+      dispatcher();
+    }
+  }
 
   @override
   Future<bool> executeTask(

--- a/workmanager/test/in_process_task_execution_test.dart
+++ b/workmanager/test/in_process_task_execution_test.dart
@@ -1,0 +1,102 @@
+import 'dart:typed_data';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:workmanager/workmanager.dart';
+import 'package:workmanager_apple/workmanager_apple.dart';
+
+const String _channelPrefix =
+    'dev.flutter.pigeon.workmanager_platform_interface.WorkmanagerFlutterApi.';
+
+/// Fake platform that records initialize() calls without touching real
+/// platform channels. Extends [WorkmanagerApple] so Workmanager's platform
+/// auto-selection (which runs on macOS/iOS/Android hosts) does not replace it.
+class _FakeApplePlatform extends WorkmanagerApple {
+  Function? lastCallbackDispatcher;
+
+  @override
+  Future<void> initialize(
+    Function callbackDispatcher, {
+    @Deprecated(
+        'Use WorkmanagerDebug handlers instead. This parameter has no effect.')
+    bool isInDebugMode = false,
+  }) async {
+    lastCallbackDispatcher = callbackDispatcher;
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    WorkmanagerPlatform.instance = _FakeApplePlatform();
+  });
+
+  test(
+      'one-off tasks execute on the main engine without a second Flutter engine',
+      () async {
+    final executedTasks = <String>[];
+    var dispatcherRuns = 0;
+
+    void callbackDispatcher() {
+      dispatcherRuns++;
+      Workmanager().executeTask((taskName, inputData) async {
+        executedTasks.add(taskName);
+        return true;
+      });
+    }
+
+    await Workmanager().initialize(callbackDispatcher);
+
+    // The dispatcher must not run at initialize time; it runs lazily on the
+    // first in-process task.
+    expect(dispatcherRuns, 0);
+
+    final messenger =
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+    final codec = WorkmanagerFlutterApi.pigeonChannelCodec;
+
+    Future<List<Object?>?> send(String channel, Object? message) async {
+      ByteData? reply;
+      await messenger.handlePlatformMessage(
+        channel,
+        codec.encodeMessage(message),
+        (data) {
+          reply = data;
+        },
+      );
+      return reply == null
+          ? null
+          : codec.decodeMessage(reply) as List<Object?>?;
+    }
+
+    // Simulate the native side executing a one-off task on the running
+    // (main) engine: backgroundChannelInitialized, then executeTask.
+    final initReply =
+        await send('${_channelPrefix}backgroundChannelInitialized', null);
+    expect(initReply, isEmpty);
+    expect(dispatcherRuns, 1);
+
+    final taskReply = await send(
+      '${_channelPrefix}executeTask',
+      <Object?>[
+        'dev.fluttercommunity.test.oneOff',
+        <String?, Object?>{'foo': 'bar'},
+      ],
+    );
+    expect(taskReply, [true]);
+    expect(executedTasks, ['dev.fluttercommunity.test.oneOff']);
+
+    // A second task must not run the dispatcher again.
+    await send('${_channelPrefix}backgroundChannelInitialized', null);
+    await send(
+      '${_channelPrefix}executeTask',
+      <Object?>['dev.fluttercommunity.test.oneOff.two', null],
+    );
+    expect(dispatcherRuns, 1);
+    expect(executedTasks, [
+      'dev.fluttercommunity.test.oneOff',
+      'dev.fluttercommunity.test.oneOff.two',
+    ]);
+  });
+}

--- a/workmanager_apple/ios/workmanager_apple/Sources/workmanager_apple/WorkmanagerPlugin.swift
+++ b/workmanager_apple/ios/workmanager_apple/Sources/workmanager_apple/WorkmanagerPlugin.swift
@@ -35,6 +35,16 @@ public class WorkmanagerPlugin: WorkmanagerPluginBase, FlutterPlugin, Workmanage
 
     private static var flutterPluginRegistrantCallback: WMPFlutterPluginRegistrantCallback?
 
+    /// The binary messenger of the engine the plugin was registered on (the
+    /// main app engine on iOS).
+    ///
+    /// One-off tasks are executed through this messenger when the app is
+    /// alive, instead of spawning a second full Flutter engine. Spawning a
+    /// second engine reloads the AOT snapshot into a fresh isolate group and
+    /// can abort with an allocation failure on memory-constrained devices
+    /// (fluttercommunity/flutter_workmanager#653).
+    static var mainBinaryMessenger: FlutterBinaryMessenger?
+
     /// Sets the plugin registrant callback for background task execution.
     ///
     /// This callback is used to register additional plugins when background tasks
@@ -476,6 +486,146 @@ extension WorkmanagerPlugin {
     ///   - delaySeconds: Delay before task execution
     @available(iOS 13.0, *)
     public static func startOneOffTask(identifier: String, taskIdentifier: UIBackgroundTaskIdentifier, inputData: [String: Any]?, delaySeconds: Int64) {
+        let runTask = {
+            if let messenger = mainBinaryMessenger {
+                runOneOffTaskOnMainEngine(
+                    identifier: identifier,
+                    taskIdentifier: taskIdentifier,
+                    inputData: inputData,
+                    messenger: messenger
+                )
+            } else {
+                runOneOffTaskWithHeadlessEngine(
+                    identifier: identifier,
+                    taskIdentifier: taskIdentifier,
+                    inputData: inputData
+                )
+            }
+        }
+        if delaySeconds > 0 {
+            DispatchQueue.global().asyncAfter(deadline: .now() + Double(delaySeconds)) {
+                runTask()
+            }
+        } else {
+            runTask()
+        }
+    }
+
+    /// Executes a one-off task on the running (main) Flutter engine.
+    ///
+    /// The Dart side registers its task handler on the main engine's messenger
+    /// during `initialize` (running the callbackDispatcher lazily on the first
+    /// task), so the task can be executed without loading the AOT snapshot a
+    /// second time. Falls back to a dedicated headless engine when the Dart
+    /// side is not ready (e.g. initialize has not completed yet).
+    @available(iOS 13.0, *)
+    private static func runOneOffTaskOnMainEngine(
+        identifier: String,
+        taskIdentifier: UIBackgroundTaskIdentifier,
+        inputData: [String: Any]?,
+        messenger: FlutterBinaryMessenger
+    ) {
+        let taskSessionStart = Date()
+        let taskInfo = TaskDebugInfo(
+            taskName: identifier,
+            uniqueName: nil,
+            inputData: inputData,
+            startTime: taskSessionStart.timeIntervalSince1970,
+            callbackHandle: UserDefaultsHelper.getStoredCallbackHandle(),
+            callbackInfo: identifier
+        )
+        WorkmanagerDebug.onTaskStatusUpdate(taskInfo: taskInfo, status: .started)
+
+        let flutterApi = WorkmanagerFlutterApi(binaryMessenger: messenger)
+        flutterApi.backgroundChannelInitialized { result in
+            switch result {
+            case .success:
+                flutterApi.executeTask(
+                    taskName: identifier,
+                    inputData: pigeonInputData(for: inputData)
+                ) { taskResult in
+                    completeOneOffTaskOnMainEngine(
+                        identifier: identifier,
+                        taskIdentifier: taskIdentifier,
+                        taskInfo: taskInfo,
+                        taskSessionStart: taskSessionStart,
+                        taskResult: taskResult
+                    )
+                }
+            case .failure:
+                // The Dart side has not registered an in-process handler yet;
+                // fall back to the dedicated headless engine so the task still
+                // runs via its own callbackDispatcher execution.
+                logError(
+                    "[\(String(describing: self))] in-process execution unavailable for \(identifier), " +
+                        "falling back to headless engine"
+                )
+                runOneOffTaskWithHeadlessEngine(
+                    identifier: identifier,
+                    taskIdentifier: taskIdentifier,
+                    inputData: inputData
+                )
+            }
+        }
+    }
+
+    /// Converts inputData to the key/value format expected by Pigeon.
+    private static func pigeonInputData(for inputData: [String: Any]?) -> [String?: Any?]? {
+        guard let inputData = inputData else {
+            return nil
+        }
+        return Dictionary(uniqueKeysWithValues: inputData.map { ($0.key as String?, $0.value as Any?) })
+    }
+
+    /// Ends the background task and reports the debug status for a one-off task
+    /// that executed on the main engine.
+    @available(iOS 13.0, *)
+    private static func completeOneOffTaskOnMainEngine(
+        identifier: String,
+        taskIdentifier: UIBackgroundTaskIdentifier,
+        taskInfo: TaskDebugInfo,
+        taskSessionStart: Date,
+        taskResult: Result<Bool, PigeonError>
+    ) {
+        UIApplication.shared.endBackgroundTask(taskIdentifier)
+
+        let taskDuration = Date().timeIntervalSince(taskSessionStart)
+        let status: TaskStatus
+        let errorMessage: String?
+        switch taskResult {
+        case .success:
+            status = .completed
+            errorMessage = nil
+        case .failure(let error):
+            status = .failed
+            errorMessage = error.localizedDescription
+        }
+
+        logInfo(
+            "[\(String(describing: self))] one-off task \(identifier) -> .\(status) " +
+                "(finished in \(taskDuration.formatToSeconds()))"
+        )
+        WorkmanagerDebug.onTaskStatusUpdate(
+            taskInfo: taskInfo,
+            status: status,
+            result: TaskResult(
+                success: status == .completed,
+                duration: Int64(taskDuration * 1000),
+                error: errorMessage
+            )
+        )
+    }
+
+    /// Executes a one-off task in a dedicated headless Flutter engine.
+    ///
+    /// Kept as the fallback path (and for apps that never register the plugin
+    /// on the main engine); see [runOneOffTaskOnMainEngine].
+    @available(iOS 13.0, *)
+    private static func runOneOffTaskWithHeadlessEngine(
+        identifier: String,
+        taskIdentifier: UIBackgroundTaskIdentifier,
+        inputData: [String: Any]?
+    ) {
         let operationQueue = OperationQueue()
         let operation = createBackgroundOperation(
             identifier: identifier,
@@ -484,13 +634,7 @@ extension WorkmanagerPlugin {
         )
 
         operation.completionBlock = { UIApplication.shared.endBackgroundTask(taskIdentifier) }
-        if delaySeconds > 0 {
-            DispatchQueue.global().asyncAfter(deadline: .now() + Double(delaySeconds)) {
-                operationQueue.addOperation(operation)
-            }
-        } else {
-            operationQueue.addOperation(operation)
-        }
+        operationQueue.addOperation(operation)
     }
 
     /// Registers a periodic background task with iOS BGTaskScheduler.
@@ -788,6 +932,7 @@ extension WorkmanagerPlugin {
     public static func register(with registrar: FlutterPluginRegistrar) {
         let instance = WorkmanagerPlugin()
         #if os(iOS)
+        mainBinaryMessenger = registrar.messenger()
         WorkmanagerHostApiSetup.setUp(binaryMessenger: registrar.messenger(), api: instance)
         registrar.addApplicationDelegate(instance)
         registrar.addSceneDelegate(instance)


### PR DESCRIPTION
## What

Fixes the release-only iOS crash in `performBackgroundRequest` when invoking a one-off task while the app is alive (fluttercommunity/flutter_workmanager#653).

### Root cause

`registerOneOffTask` runs while the app is alive. The plugin started a `beginBackgroundTask` budget and then created a **second full `FlutterEngine`** (`run(withEntrypoint:libraryURI:)`) to run the callbackDispatcher. In release AOT that second engine deserializes the whole program snapshot into a fresh isolate group (`dart::Object::Allocate` abort in `FullSnapshotReader::ReadProgramSnapshot`). On memory-constrained physical devices that allocation fails; on simulators it succeeds — matching the "works on simulator, crashes on device" report. Recent landings (#692 launch-handler auto-registration, #696 UIScene migration) do not touch this path, so it was still broken on `main`.

### Fix

When the app is alive, execute the one-off task on the **running (main) engine** instead of spawning a second engine:

- **Dart** (`workmanager`): `initialize()` now registers the Flutter API surface on the current isolate's messenger and keeps the callbackDispatcher. The dispatcher runs lazily on the first in-process task (`backgroundChannelInitialized`), so the task handler is registered before `executeTask` is invoked.
- **iOS** (`workmanager_apple`): `startOneOffTask` sends `backgroundChannelInitialized` + `executeTask` through the main engine's binary messenger (captured at plugin registration) and ends the background task on completion, with debug status reporting preserved. If the Dart side is not ready (e.g. `initialize` not finished), it falls back to the previous headless-engine path.

The headless-engine path is kept for BGTask-delivered work (periodic/processing/health research), where the system may launch the process specifically to deliver the task.

## Verification

- Dart: new unit test in `workmanager/test/in_process_task_execution_test.dart` drives the real pigeon channel handlers and asserts the dispatcher runs once and tasks execute with results flowing back; all 15 `workmanager` tests pass.
- iOS: new RunnerTests with a `FlutterBinaryMessenger` stub assert the main-engine flow (`backgroundChannelInitialized` → `executeTask`) and the fallback; `xcodebuild test` passes on a simulator.
- End-to-end: full `integration_test/workmanager_integration_test.dart` suite (17 tests) passes on an iOS simulator, including all one-off task tests (input data transfer, retry, taskName delivery, multi-task flow) now running through the main-engine path.
- `flutter analyze` clean, `dart format` clean, swiftlint adds no new warnings.

## Follow-up

BGTask-delivered tasks delivered while the app is alive can still hit the same second-engine allocation; extending in-process execution to that path (with fallback for system-launched processes) is a possible follow-up.