### PR TITLE
feat(android): long-running workers via foreground service (fixes #573)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,27 @@ Background tasks are perfect for:
 - **Fetch notifications** - Check for new messages
 - **Database maintenance** - Optimize and clean databases
 
+## ⏱ Long-Running Tasks (Android)
+
+For work that takes longer than the regular background execution window (bulk
+uploads/downloads, ML processing), Android tasks can run as a **foreground
+service** with a persistent notification. Pass a `foregroundServiceConfig` to
+`registerOneOffTask` or `registerPeriodicTask`:
+
+```dart
+await Workmanager().registerOneOffTask(
+  "upload-task",
+  "upload_files",
+  foregroundServiceConfig: ForegroundServiceConfig(
+    notificationTitle: "Uploading files",
+    notificationText: "Your files are being uploaded",
+  ),
+);
+```
+
+See the [Quick Start guide](https://docs.page/fluttercommunity/flutter_workmanager/quickstart)
+for details and platform caveats.
+
 
 ## 🐛 Issues & Support
 

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -415,6 +415,83 @@ you'll get `BGTaskSchedulerErrorDomain Code 3` ("not advertised in the
 application's Info.plist"). On Android no native setup is needed.
 </Warning>
 
+## Long-running tasks (foreground service)
+
+Android's WorkManager runs background workers for a limited time (typically a
+few minutes). For work that legitimately takes longer — bulk uploads or
+downloads, ML processing, large file operations — Android's first-class answer
+is a **foreground service**: the worker is promoted to the foreground, the
+process is kept alive, and a notification stays visible for the whole duration
+of the task.
+
+To run a task as a foreground service, pass a `foregroundServiceConfig` when
+registering the task:
+
+```dart
+await Workmanager().registerOneOffTask(
+  "upload-task",
+  "upload_files",
+  inputData: <String, dynamic>{
+    'destination': 'https://api.example.com/uploads',
+  },
+  foregroundServiceConfig: ForegroundServiceConfig(
+    notificationTitle: "Uploading files",
+    notificationText: "Your files are being uploaded",
+  ),
+);
+```
+
+The same option is available on `registerPeriodicTask`. The notification is
+shown as soon as the task starts and is removed automatically when the task
+finishes (or is cancelled). The worker keeps running even if the app is in the
+background or closed, for as long as the task takes.
+
+`ForegroundServiceConfig` has sane defaults for every field; you only need to
+provide the notification text you want to show:
+
+| Field | Default |
+| --- | --- |
+| `notificationTitle` | `Task in progress` |
+| `notificationText` | `Your task is still running` |
+| `notificationChannelId` | `workmanager_foreground_tasks` |
+| `notificationChannelName` | `Long-running tasks` |
+| `notificationId` | `0` |
+| `foregroundServiceType` | `ForegroundServiceType.dataSync` |
+
+The supported foreground service types are `dataSync` (default; for
+synchronization, uploads and downloads) and `shortService` (short, critical
+work that must complete quickly):
+
+```dart
+foregroundServiceConfig: ForegroundServiceConfig(
+  notificationTitle: "Cleanup",
+  notificationText: "Removing temporary files",
+  foregroundServiceType: ForegroundServiceType.shortService,
+),
+```
+
+<Warning>
+**Android 13+ notification permission:** on Android 13 (API 33) and newer the
+foreground service still runs, but the notification is only visible when the
+app holds the `POST_NOTIFICATIONS` runtime permission. Request it from your UI
+before registering the task if you want the notification to be shown.
+</Warning>
+
+<Warning>
+**Android 14+ foreground service types:** apps targeting SDK 34+ must declare
+the foreground service type in the manifest and hold the matching permission.
+The plugin already declares `dataSync` and `shortService` (and their
+permissions) for you — no native setup is required.
+</Warning>
+
+<Info>
+**Android 15+ limitations:** on Android 15 (API 35), `dataSync` foreground
+services may run for at most 6 hours in any 24-hour period, and work launched
+directly from `BOOT_COMPLETED` may be blocked from starting a `dataSync` or
+`shortService` foreground service by the system. In that case the task simply
+falls back to running as a regular background worker within the usual limits.
+</Info>
+
 ## Task Results
 
 Your background tasks can return:

--- a/workmanager/lib/src/workmanager_impl.dart
+++ b/workmanager/lib/src/workmanager_impl.dart
@@ -182,6 +182,11 @@ class Workmanager {
   /// - [tag]: is an optional tag that can be used to identify or cancel the task.
   /// - [existingWorkPolicy]: is the policy to use when work with the same [uniqueName] already exists.
   /// - [outOfQuotaPolicy]: is the policy to use when the device is out of quota. (Android only)
+  /// - [foregroundServiceConfig]: when provided (Android only), the worker
+  ///   runs as an Android foreground service for the whole duration of the
+  ///   task. This allows work to keep running beyond the usual background
+  ///   execution limits, in exchange for a persistent notification. See
+  ///   [ForegroundServiceConfig] for the available options.
   Future<void> registerOneOffTask(
     String uniqueName,
     String taskName, {
@@ -193,6 +198,7 @@ class Workmanager {
     Duration? backoffPolicyDelay,
     String? tag,
     OutOfQuotaPolicy? outOfQuotaPolicy,
+    ForegroundServiceConfig? foregroundServiceConfig,
   }) async {
     return _platform.registerOneOffTask(
       uniqueName,
@@ -205,6 +211,7 @@ class Workmanager {
       backoffPolicyDelay: backoffPolicyDelay,
       tag: tag,
       outOfQuotaPolicy: outOfQuotaPolicy,
+      foregroundServiceConfig: foregroundServiceConfig,
     );
   }
 
@@ -233,6 +240,10 @@ class Workmanager {
   /// [iOS 13+ Using background tasks to update your app](https://developer.apple.com/documentation/uikit/app_and_environment/scenes/preparing_your_ui_to_run_in_the_background/using_background_tasks_to_update_your_app/)
   ///
   /// [iOS 13+ BGAppRefreshTask](https://developer.apple.com/documentation/backgroundtasks/bgapprefreshtask/)
+  ///
+  /// [foregroundServiceConfig]: when provided (Android only), the worker runs
+  /// as an Android foreground service for the whole duration of the task,
+  /// showing a persistent notification. See [ForegroundServiceConfig].
   Future<void> registerPeriodicTask(
     String uniqueName,
     String taskName, {
@@ -245,6 +256,7 @@ class Workmanager {
     BackoffPolicy? backoffPolicy,
     Duration? backoffPolicyDelay,
     String? tag,
+    ForegroundServiceConfig? foregroundServiceConfig,
   }) async {
     return _platform.registerPeriodicTask(
       uniqueName,
@@ -258,6 +270,7 @@ class Workmanager {
       backoffPolicy: backoffPolicy,
       backoffPolicyDelay: backoffPolicyDelay,
       tag: tag,
+      foregroundServiceConfig: foregroundServiceConfig,
     );
   }
 

--- a/workmanager/test/workmanager_test.mocks.dart
+++ b/workmanager/test/workmanager_test.mocks.dart
@@ -71,6 +71,7 @@ class MockWorkmanager extends _i1.Mock implements _i2.Workmanager {
     Duration? backoffPolicyDelay,
     String? tag,
     _i4.OutOfQuotaPolicy? outOfQuotaPolicy,
+    _i4.ForegroundServiceConfig? foregroundServiceConfig,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -88,6 +89,7 @@ class MockWorkmanager extends _i1.Mock implements _i2.Workmanager {
             #backoffPolicyDelay: backoffPolicyDelay,
             #tag: tag,
             #outOfQuotaPolicy: outOfQuotaPolicy,
+            #foregroundServiceConfig: foregroundServiceConfig,
           },
         ),
         returnValue: _i3.Future<void>.value(),
@@ -107,6 +109,7 @@ class MockWorkmanager extends _i1.Mock implements _i2.Workmanager {
     _i4.BackoffPolicy? backoffPolicy,
     Duration? backoffPolicyDelay,
     String? tag,
+    _i4.ForegroundServiceConfig? foregroundServiceConfig,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -125,6 +128,7 @@ class MockWorkmanager extends _i1.Mock implements _i2.Workmanager {
             #backoffPolicy: backoffPolicy,
             #backoffPolicyDelay: backoffPolicyDelay,
             #tag: tag,
+            #foregroundServiceConfig: foregroundServiceConfig,
           },
         ),
         returnValue: _i3.Future<void>.value(),

--- a/workmanager_android/android/src/main/AndroidManifest.xml
+++ b/workmanager_android/android/src/main/AndroidManifest.xml
@@ -1,3 +1,24 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
+    <!-- Foreground service support for long-running workers. -->
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
+    <!-- Android 14+ requires a type-specific permission for each FGS type. -->
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC"/>
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SHORT_SERVICE"/>
+
+    <!--
+        Android 14+ (target SDK 34+) requires the foreground service type to be
+        declared in the manifest for the service that is started. WorkManager
+        runs long-running workers in androidx.work.impl.foreground.SystemForegroundService,
+        which declares no type of its own, so the plugin merges the supported
+        types (dataSync, shortService) onto it.
+    -->
+    <application>
+        <service
+            android:name="androidx.work.impl.foreground.SystemForegroundService"
+            android:foregroundServiceType="dataSync|shortService"
+            tools:node="merge"
+            tools:targetApi="34"/>
+    </application>
 </manifest>

--- a/workmanager_android/android/src/main/kotlin/dev/fluttercommunity/workmanager/BackgroundWorker.kt
+++ b/workmanager_android/android/src/main/kotlin/dev/fluttercommunity/workmanager/BackgroundWorker.kt
@@ -7,6 +7,7 @@ import androidx.concurrent.futures.CallbackToFutureAdapter
 import androidx.work.ListenableWorker
 import androidx.work.WorkerParameters
 import com.google.common.util.concurrent.ListenableFuture
+import dev.fluttercommunity.workmanager.pigeon.ForegroundServiceConfig
 import dev.fluttercommunity.workmanager.pigeon.TaskStatus
 import dev.fluttercommunity.workmanager.pigeon.WorkmanagerFlutterApi
 import io.flutter.FlutterInjector
@@ -15,6 +16,8 @@ import io.flutter.embedding.engine.dart.DartExecutor
 import io.flutter.embedding.engine.loader.FlutterLoader
 import io.flutter.view.FlutterCallbackInformation
 import java.security.SecureRandom
+import java.util.concurrent.Executor
+import java.util.concurrent.atomic.AtomicBoolean
 
 /**
  * A simple worker that posts your input back to your Flutter application.
@@ -52,8 +55,21 @@ class BackgroundWorker(
             null
         }
 
+    private val foregroundServiceConfig: ForegroundServiceConfig? =
+        decodeForegroundServiceConfig(workerParams.inputData)
+
+    private val directExecutor = Executor { it.run() }
+
     override fun startWork(): ListenableFuture<Result> {
         startTime = System.currentTimeMillis()
+
+        // Promote the worker to a foreground service right away when a config
+        // was provided at registration time, so the notification (and the
+        // process priority boost) are in place while the Dart engine starts.
+        val foregroundFuture =
+            foregroundServiceConfig?.let { config ->
+                setForegroundAsync(createForegroundInfo(applicationContext, config))
+            }
 
         val flutterLoader: FlutterLoader = FlutterInjector.instance().flutterLoader()
 
@@ -119,7 +135,41 @@ class BackgroundWorker(
             }
         }
 
-        return resolvableFuture
+        return combineForegroundWithResult(foregroundFuture)
+    }
+
+    /**
+     * WorkManager requires the future returned by [setForegroundAsync] to be
+     * part of the future returned from [startWork]. The combined future only
+     * completes once both the foreground service has been started and the
+     * Dart task has finished. A failure to start the foreground service never
+     * fails the worker; it is reported through the debug handler and the task
+     * simply keeps running as a regular background worker.
+     */
+    private fun combineForegroundWithResult(foregroundFuture: ListenableFuture<*>?): ListenableFuture<Result> {
+        if (foregroundFuture == null) {
+            return resolvableFuture
+        }
+
+        return CallbackToFutureAdapter.getFuture { combinedCompleter ->
+            val completed = AtomicBoolean(false)
+            val listener =
+                Runnable {
+                    if (foregroundFuture.isDone && resolvableFuture.isDone && completed.compareAndSet(false, true)) {
+                        foregroundFuture.takeUnless { it.isCancelled }?.let {
+                            try {
+                                it.get()
+                            } catch (e: Exception) {
+                                WorkmanagerDebug.onExceptionEncountered(applicationContext, null, e)
+                            }
+                        }
+                        combinedCompleter.set(resolvableFuture.get())
+                    }
+                }
+            foregroundFuture.addListener(listener, directExecutor)
+            resolvableFuture.addListener(listener, directExecutor)
+            null
+        }
     }
 
     override fun onStopped() {

--- a/workmanager_android/android/src/main/kotlin/dev/fluttercommunity/workmanager/ForegroundServiceUtils.kt
+++ b/workmanager_android/android/src/main/kotlin/dev/fluttercommunity/workmanager/ForegroundServiceUtils.kt
@@ -1,0 +1,95 @@
+package dev.fluttercommunity.workmanager
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.content.Context
+import android.content.pm.ServiceInfo
+import android.os.Build
+import androidx.core.app.NotificationCompat
+import androidx.work.ForegroundInfo
+import dev.fluttercommunity.workmanager.pigeon.ForegroundServiceConfig
+import dev.fluttercommunity.workmanager.pigeon.ForegroundServiceType
+
+// Defaults mirroring the ones resolved in the Dart platform implementation.
+// They keep the native side robust for work requests enqueued before a value
+// was resolved (e.g. legacy persisted jobs or direct WorkManager enqueues).
+private const val DEFAULT_NOTIFICATION_CHANNEL_ID = "workmanager_foreground_tasks"
+private const val DEFAULT_NOTIFICATION_CHANNEL_NAME = "Long-running tasks"
+private const val DEFAULT_NOTIFICATION_TITLE = "Task in progress"
+private const val DEFAULT_NOTIFICATION_TEXT = "Your task is still running"
+private const val DEFAULT_NOTIFICATION_ID = 0
+
+/**
+ * Builds the [ForegroundInfo] used to promote a worker to a foreground service.
+ *
+ * On Android 14+ (target SDK 34+) the foreground service type must be declared
+ * in the manifest (see the plugin's AndroidManifest.xml) and passed to
+ * `startForeground`; below Android 14 the type parameter is not validated, so
+ * it is omitted entirely.
+ */
+fun createForegroundInfo(
+    context: Context,
+    config: ForegroundServiceConfig,
+): ForegroundInfo {
+    createNotificationChannel(context, config)
+
+    val notification =
+        NotificationCompat
+            .Builder(context, config.notificationChannelId ?: DEFAULT_NOTIFICATION_CHANNEL_ID)
+            .setContentTitle(config.notificationTitle ?: DEFAULT_NOTIFICATION_TITLE)
+            .setContentText(config.notificationText ?: DEFAULT_NOTIFICATION_TEXT)
+            .setSmallIcon(resolveNotificationIcon(context))
+            .setOngoing(true)
+            .build()
+
+    return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+        ForegroundInfo(
+            config.notificationId?.toInt() ?: DEFAULT_NOTIFICATION_ID,
+            notification,
+            resolveForegroundServiceType(config),
+        )
+    } else {
+        ForegroundInfo(config.notificationId?.toInt() ?: DEFAULT_NOTIFICATION_ID, notification)
+    }
+}
+
+/**
+ * Creates the notification channel used by the foreground service notification.
+ * Notification channels only exist on Android 8.0+ (API 26).
+ */
+private fun createNotificationChannel(
+    context: Context,
+    config: ForegroundServiceConfig,
+) {
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
+        return
+    }
+    val channel =
+        NotificationChannel(
+            config.notificationChannelId ?: DEFAULT_NOTIFICATION_CHANNEL_ID,
+            config.notificationChannelName ?: DEFAULT_NOTIFICATION_CHANNEL_NAME,
+            NotificationManager.IMPORTANCE_LOW,
+        )
+    context
+        .getSystemService(NotificationManager::class.java)
+        .createNotificationChannel(channel)
+}
+
+private fun resolveForegroundServiceType(config: ForegroundServiceConfig): Int =
+    when (config.foregroundServiceType) {
+        ForegroundServiceType.SHORT_SERVICE ->
+            ServiceInfo.FOREGROUND_SERVICE_TYPE_SHORT_SERVICE
+        else ->
+            ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC
+    }
+
+/**
+ * Uses the application icon for the notification when available, falling back
+ * to a generic system icon otherwise. The small icon must be a white silhouette
+ * for best results; apps can provide their own drawable by overriding the
+ * application icon.
+ */
+private fun resolveNotificationIcon(context: Context): Int {
+    val applicationIcon = context.applicationInfo.icon
+    return if (applicationIcon != 0) applicationIcon else android.R.drawable.ic_dialog_info
+}

--- a/workmanager_android/android/src/main/kotlin/dev/fluttercommunity/workmanager/InputDataUtils.kt
+++ b/workmanager_android/android/src/main/kotlin/dev/fluttercommunity/workmanager/InputDataUtils.kt
@@ -1,6 +1,8 @@
 package dev.fluttercommunity.workmanager
 
 import androidx.work.Data
+import dev.fluttercommunity.workmanager.pigeon.ForegroundServiceConfig
+import dev.fluttercommunity.workmanager.pigeon.ForegroundServiceType
 import org.json.JSONArray
 import org.json.JSONObject
 import org.json.JSONTokener
@@ -19,6 +21,14 @@ const val PAYLOAD_PREFIX = "payload_"
 const val JSON_PAYLOAD_PREFIX = "json_payload_"
 
 /**
+ * Key under which the foreground service configuration is stored in
+ * WorkManager [Data]. Kept separate from the user payload so it is never
+ * delivered to the Dart callback and never collides with user keys.
+ */
+const val FOREGROUND_SERVICE_CONFIG_KEY =
+    "dev.fluttercommunity.workmanager.FOREGROUND_SERVICE_CONFIG"
+
+/**
  * Serializes [dartTask] and [payload] into WorkManager [Data].
  *
  * - Scalars are stored natively under `payload_<key>` (same keys as before).
@@ -27,12 +37,19 @@ const val JSON_PAYLOAD_PREFIX = "json_payload_"
  *   non-String elements.
  * - Nested maps, heterogeneous lists, and null values are JSON-encoded under
  *   `json_payload_<key>` and decoded again when the task runs.
+ * - An optional [foregroundServiceConfig] is JSON-encoded under
+ *   [FOREGROUND_SERVICE_CONFIG_KEY].
  */
 fun buildTaskInputData(
     dartTask: String,
     payload: Map<String, Any?>?,
+    foregroundServiceConfig: ForegroundServiceConfig? = null,
 ): Data {
     val builder = Data.Builder().putString(BackgroundWorker.DART_TASK_KEY, dartTask)
+
+    foregroundServiceConfig?.let {
+        builder.putString(FOREGROUND_SERVICE_CONFIG_KEY, encodeForegroundServiceConfig(it))
+    }
 
     payload?.forEach { (key, value) ->
         when (value) {
@@ -56,6 +73,40 @@ fun buildTaskInputData(
 
     return builder.build()
 }
+
+/** Encodes a [ForegroundServiceConfig] as a JSON string for WorkManager [Data]. */
+fun encodeForegroundServiceConfig(config: ForegroundServiceConfig): String =
+    JSONObject()
+        .apply {
+            config.notificationTitle?.let { put("notificationTitle", it) }
+            config.notificationText?.let { put("notificationText", it) }
+            config.notificationChannelId?.let { put("notificationChannelId", it) }
+            config.notificationChannelName?.let { put("notificationChannelName", it) }
+            config.notificationId?.let { put("notificationId", it) }
+            config.foregroundServiceType?.let { put("foregroundServiceType", it.name) }
+        }.toString()
+
+/** Decodes a [ForegroundServiceConfig] from WorkManager [Data], or `null` when absent. */
+fun decodeForegroundServiceConfig(data: Data?): ForegroundServiceConfig? =
+    data?.getString(FOREGROUND_SERVICE_CONFIG_KEY)?.let(::decodeForegroundServiceConfig)
+
+/** Decodes a [ForegroundServiceConfig] from its JSON representation. */
+fun decodeForegroundServiceConfig(json: String): ForegroundServiceConfig =
+    JSONObject(json).let { obj ->
+        ForegroundServiceConfig(
+            notificationTitle = obj.optStringOrNull("notificationTitle"),
+            notificationText = obj.optStringOrNull("notificationText"),
+            notificationChannelId = obj.optStringOrNull("notificationChannelId"),
+            notificationChannelName = obj.optStringOrNull("notificationChannelName"),
+            notificationId = obj.takeIf { it.has("notificationId") }?.getLong("notificationId"),
+            foregroundServiceType =
+                obj
+                    .optStringOrNull("foregroundServiceType")
+                    ?.let { ForegroundServiceType.valueOf(it) },
+        )
+    }
+
+private fun JSONObject.optStringOrNull(key: String): String? = if (isNull(key)) null else optString(key)
 
 /**
  * Converts a WorkManager [Data] key-value map back into the payload map that

--- a/workmanager_android/android/src/main/kotlin/dev/fluttercommunity/workmanager/WorkManagerUtils.kt
+++ b/workmanager_android/android/src/main/kotlin/dev/fluttercommunity/workmanager/WorkManagerUtils.kt
@@ -37,6 +37,7 @@ val defaultOutOfQuotaPolicy: OutOfQuotaPolicy? = null
 internal fun createPeriodicWorkRequest(
     taskName: String,
     inputData: Map<String, Any?>?,
+    foregroundServiceConfig: dev.fluttercommunity.workmanager.pigeon.ForegroundServiceConfig? = null,
     frequencySeconds: Long,
     flexIntervalSeconds: Long?,
     initialDelaySeconds: Long?,
@@ -63,7 +64,7 @@ internal fun createPeriodicWorkRequest(
                 )
         }
     return builder
-        .setInputData(buildTaskInputData(taskName, inputData))
+        .setInputData(buildTaskInputData(taskName, inputData, foregroundServiceConfig))
         .setInitialDelay(
             initialDelaySeconds ?: DEFAULT_INITIAL_DELAY_SECONDS,
             TimeUnit.SECONDS,
@@ -166,6 +167,7 @@ class WorkManagerWrapper(
                         buildTaskInputData(
                             request.taskName,
                             request.inputData?.filterNotNullKeys(),
+                            request.foregroundServiceConfig,
                         ),
                     ).setInitialDelay(
                         request.initialDelaySeconds ?: DEFAULT_INITIAL_DELAY_SECONDS,
@@ -211,6 +213,7 @@ class WorkManagerWrapper(
             createPeriodicWorkRequest(
                 taskName = request.taskName,
                 inputData = request.inputData?.filterNotNullKeys(),
+                foregroundServiceConfig = request.foregroundServiceConfig,
                 frequencySeconds = request.frequencySeconds,
                 flexIntervalSeconds = request.flexIntervalSeconds,
                 initialDelaySeconds = request.initialDelaySeconds,

--- a/workmanager_android/android/src/main/kotlin/dev/fluttercommunity/workmanager/pigeon/WorkmanagerApi.g.kt
+++ b/workmanager_android/android/src/main/kotlin/dev/fluttercommunity/workmanager/pigeon/WorkmanagerApi.g.kt
@@ -376,6 +376,112 @@ enum class OutOfQuotaPolicy(val raw: Int) {
   }
 }
 
+/**
+ * Foreground service types supported for Android long-running workers.
+ *
+ * These map to the foreground service types introduced by Android 14
+ * (API level 34), when specifying a type became mandatory for apps targeting
+ * SDK 34+. See:
+ * https://developer.android.com/about/versions/14/changes/fgs-types-required
+ */
+enum class ForegroundServiceType(val raw: Int) {
+  /**
+   * Used for long-running data synchronization, uploads and downloads that
+   * are important to the user.
+   */
+  DATA_SYNC(0),
+  /**
+   * Used for short, critical work that the user is aware of and that must
+   * complete quickly (a few minutes at most).
+   */
+  SHORT_SERVICE(1);
+
+  companion object {
+    fun ofRaw(raw: Int): ForegroundServiceType? {
+      return values().firstOrNull { it.raw == raw }
+    }
+  }
+}
+
+/**
+ * Android-only configuration that promotes a worker to a foreground service
+ * while it runs, keeping the process alive for long-running work.
+ *
+ * When provided to [OneOffTaskRequest.foregroundServiceConfig] or
+ * [PeriodicTaskRequest.foregroundServiceConfig], the worker calls
+ * WorkManager's `setForegroundAsync` as soon as it starts and shows a
+ * notification for the whole duration of the task.
+ *
+ * All fields are optional; the platform implementation fills in sane
+ * defaults for anything that is not provided.
+ *
+ * Generated class from Pigeon that represents data sent in messages.
+ */
+data class ForegroundServiceConfig (
+  /** Title shown in the foreground service notification. */
+  val notificationTitle: String? = null,
+  /** Body text shown in the foreground service notification. */
+  val notificationText: String? = null,
+  /**
+   * Id of the notification channel used for the foreground service
+   * notification (Android 8.0+).
+   */
+  val notificationChannelId: String? = null,
+  /** User-visible name of the notification channel. */
+  val notificationChannelName: String? = null,
+  /** Id used for the foreground service notification. */
+  val notificationId: Long? = null,
+  /**
+   * Foreground service type to start with (Android 14+). Defaults to
+   * [ForegroundServiceType.dataSync].
+   */
+  val foregroundServiceType: ForegroundServiceType? = null
+)
+ {
+  companion object {
+    fun fromList(pigeonVar_list: List<Any?>): ForegroundServiceConfig {
+      val notificationTitle = pigeonVar_list[0] as String?
+      val notificationText = pigeonVar_list[1] as String?
+      val notificationChannelId = pigeonVar_list[2] as String?
+      val notificationChannelName = pigeonVar_list[3] as String?
+      val notificationId = pigeonVar_list[4] as Long?
+      val foregroundServiceType = pigeonVar_list[5] as ForegroundServiceType?
+      return ForegroundServiceConfig(notificationTitle, notificationText, notificationChannelId, notificationChannelName, notificationId, foregroundServiceType)
+    }
+  }
+  fun toList(): List<Any?> {
+    return listOf(
+      notificationTitle,
+      notificationText,
+      notificationChannelId,
+      notificationChannelName,
+      notificationId,
+      foregroundServiceType,
+    )
+  }
+  override fun equals(other: Any?): Boolean {
+    if (other == null || other.javaClass != javaClass) {
+      return false
+    }
+    if (this === other) {
+      return true
+    }
+    val other = other as ForegroundServiceConfig
+    return WorkmanagerApiPigeonUtils.deepEquals(this.notificationTitle, other.notificationTitle) && WorkmanagerApiPigeonUtils.deepEquals(this.notificationText, other.notificationText) && WorkmanagerApiPigeonUtils.deepEquals(this.notificationChannelId, other.notificationChannelId) && WorkmanagerApiPigeonUtils.deepEquals(this.notificationChannelName, other.notificationChannelName) && WorkmanagerApiPigeonUtils.deepEquals(this.notificationId, other.notificationId) && WorkmanagerApiPigeonUtils.deepEquals(this.foregroundServiceType, other.foregroundServiceType)
+  }
+
+  override fun hashCode(): Int {
+    var result = javaClass.hashCode()
+    result = 31 * result + WorkmanagerApiPigeonUtils.deepHash(this.notificationTitle)
+    result = 31 * result + WorkmanagerApiPigeonUtils.deepHash(this.notificationText)
+    result = 31 * result + WorkmanagerApiPigeonUtils.deepHash(this.notificationChannelId)
+    result = 31 * result + WorkmanagerApiPigeonUtils.deepHash(this.notificationChannelName)
+    result = 31 * result + WorkmanagerApiPigeonUtils.deepHash(this.notificationId)
+    result = 31 * result + WorkmanagerApiPigeonUtils.deepHash(this.foregroundServiceType)
+    return result
+  }
+}
+
 /** Generated class from Pigeon that represents data sent in messages. */
 data class Constraints (
   val networkType: NetworkType? = null,
@@ -508,7 +614,9 @@ data class OneOffTaskRequest (
   val backoffPolicy: BackoffPolicyConfig? = null,
   val tag: String? = null,
   val existingWorkPolicy: ExistingWorkPolicy? = null,
-  val outOfQuotaPolicy: OutOfQuotaPolicy? = null
+  val outOfQuotaPolicy: OutOfQuotaPolicy? = null,
+  /** When set, the worker runs as an Android foreground service. */
+  val foregroundServiceConfig: ForegroundServiceConfig? = null
 )
  {
   companion object {
@@ -522,7 +630,8 @@ data class OneOffTaskRequest (
       val tag = pigeonVar_list[6] as String?
       val existingWorkPolicy = pigeonVar_list[7] as ExistingWorkPolicy?
       val outOfQuotaPolicy = pigeonVar_list[8] as OutOfQuotaPolicy?
-      return OneOffTaskRequest(uniqueName, taskName, inputData, initialDelaySeconds, constraints, backoffPolicy, tag, existingWorkPolicy, outOfQuotaPolicy)
+      val foregroundServiceConfig = pigeonVar_list[9] as ForegroundServiceConfig?
+      return OneOffTaskRequest(uniqueName, taskName, inputData, initialDelaySeconds, constraints, backoffPolicy, tag, existingWorkPolicy, outOfQuotaPolicy, foregroundServiceConfig)
     }
   }
   fun toList(): List<Any?> {
@@ -536,6 +645,7 @@ data class OneOffTaskRequest (
       tag,
       existingWorkPolicy,
       outOfQuotaPolicy,
+      foregroundServiceConfig,
     )
   }
   override fun equals(other: Any?): Boolean {
@@ -546,7 +656,7 @@ data class OneOffTaskRequest (
       return true
     }
     val other = other as OneOffTaskRequest
-    return WorkmanagerApiPigeonUtils.deepEquals(this.uniqueName, other.uniqueName) && WorkmanagerApiPigeonUtils.deepEquals(this.taskName, other.taskName) && WorkmanagerApiPigeonUtils.deepEquals(this.inputData, other.inputData) && WorkmanagerApiPigeonUtils.deepEquals(this.initialDelaySeconds, other.initialDelaySeconds) && WorkmanagerApiPigeonUtils.deepEquals(this.constraints, other.constraints) && WorkmanagerApiPigeonUtils.deepEquals(this.backoffPolicy, other.backoffPolicy) && WorkmanagerApiPigeonUtils.deepEquals(this.tag, other.tag) && WorkmanagerApiPigeonUtils.deepEquals(this.existingWorkPolicy, other.existingWorkPolicy) && WorkmanagerApiPigeonUtils.deepEquals(this.outOfQuotaPolicy, other.outOfQuotaPolicy)
+    return WorkmanagerApiPigeonUtils.deepEquals(this.uniqueName, other.uniqueName) && WorkmanagerApiPigeonUtils.deepEquals(this.taskName, other.taskName) && WorkmanagerApiPigeonUtils.deepEquals(this.inputData, other.inputData) && WorkmanagerApiPigeonUtils.deepEquals(this.initialDelaySeconds, other.initialDelaySeconds) && WorkmanagerApiPigeonUtils.deepEquals(this.constraints, other.constraints) && WorkmanagerApiPigeonUtils.deepEquals(this.backoffPolicy, other.backoffPolicy) && WorkmanagerApiPigeonUtils.deepEquals(this.tag, other.tag) && WorkmanagerApiPigeonUtils.deepEquals(this.existingWorkPolicy, other.existingWorkPolicy) && WorkmanagerApiPigeonUtils.deepEquals(this.outOfQuotaPolicy, other.outOfQuotaPolicy) && WorkmanagerApiPigeonUtils.deepEquals(this.foregroundServiceConfig, other.foregroundServiceConfig)
   }
 
   override fun hashCode(): Int {
@@ -560,6 +670,7 @@ data class OneOffTaskRequest (
     result = 31 * result + WorkmanagerApiPigeonUtils.deepHash(this.tag)
     result = 31 * result + WorkmanagerApiPigeonUtils.deepHash(this.existingWorkPolicy)
     result = 31 * result + WorkmanagerApiPigeonUtils.deepHash(this.outOfQuotaPolicy)
+    result = 31 * result + WorkmanagerApiPigeonUtils.deepHash(this.foregroundServiceConfig)
     return result
   }
 }
@@ -575,7 +686,9 @@ data class PeriodicTaskRequest (
   val constraints: Constraints? = null,
   val backoffPolicy: BackoffPolicyConfig? = null,
   val tag: String? = null,
-  val existingWorkPolicy: ExistingPeriodicWorkPolicy? = null
+  val existingWorkPolicy: ExistingPeriodicWorkPolicy? = null,
+  /** When set, the worker runs as an Android foreground service. */
+  val foregroundServiceConfig: ForegroundServiceConfig? = null
 )
  {
   companion object {
@@ -590,7 +703,8 @@ data class PeriodicTaskRequest (
       val backoffPolicy = pigeonVar_list[7] as BackoffPolicyConfig?
       val tag = pigeonVar_list[8] as String?
       val existingWorkPolicy = pigeonVar_list[9] as ExistingPeriodicWorkPolicy?
-      return PeriodicTaskRequest(uniqueName, taskName, frequencySeconds, flexIntervalSeconds, inputData, initialDelaySeconds, constraints, backoffPolicy, tag, existingWorkPolicy)
+      val foregroundServiceConfig = pigeonVar_list[10] as ForegroundServiceConfig?
+      return PeriodicTaskRequest(uniqueName, taskName, frequencySeconds, flexIntervalSeconds, inputData, initialDelaySeconds, constraints, backoffPolicy, tag, existingWorkPolicy, foregroundServiceConfig)
     }
   }
   fun toList(): List<Any?> {
@@ -605,6 +719,7 @@ data class PeriodicTaskRequest (
       backoffPolicy,
       tag,
       existingWorkPolicy,
+      foregroundServiceConfig,
     )
   }
   override fun equals(other: Any?): Boolean {
@@ -615,7 +730,7 @@ data class PeriodicTaskRequest (
       return true
     }
     val other = other as PeriodicTaskRequest
-    return WorkmanagerApiPigeonUtils.deepEquals(this.uniqueName, other.uniqueName) && WorkmanagerApiPigeonUtils.deepEquals(this.taskName, other.taskName) && WorkmanagerApiPigeonUtils.deepEquals(this.frequencySeconds, other.frequencySeconds) && WorkmanagerApiPigeonUtils.deepEquals(this.flexIntervalSeconds, other.flexIntervalSeconds) && WorkmanagerApiPigeonUtils.deepEquals(this.inputData, other.inputData) && WorkmanagerApiPigeonUtils.deepEquals(this.initialDelaySeconds, other.initialDelaySeconds) && WorkmanagerApiPigeonUtils.deepEquals(this.constraints, other.constraints) && WorkmanagerApiPigeonUtils.deepEquals(this.backoffPolicy, other.backoffPolicy) && WorkmanagerApiPigeonUtils.deepEquals(this.tag, other.tag) && WorkmanagerApiPigeonUtils.deepEquals(this.existingWorkPolicy, other.existingWorkPolicy)
+    return WorkmanagerApiPigeonUtils.deepEquals(this.uniqueName, other.uniqueName) && WorkmanagerApiPigeonUtils.deepEquals(this.taskName, other.taskName) && WorkmanagerApiPigeonUtils.deepEquals(this.frequencySeconds, other.frequencySeconds) && WorkmanagerApiPigeonUtils.deepEquals(this.flexIntervalSeconds, other.flexIntervalSeconds) && WorkmanagerApiPigeonUtils.deepEquals(this.inputData, other.inputData) && WorkmanagerApiPigeonUtils.deepEquals(this.initialDelaySeconds, other.initialDelaySeconds) && WorkmanagerApiPigeonUtils.deepEquals(this.constraints, other.constraints) && WorkmanagerApiPigeonUtils.deepEquals(this.backoffPolicy, other.backoffPolicy) && WorkmanagerApiPigeonUtils.deepEquals(this.tag, other.tag) && WorkmanagerApiPigeonUtils.deepEquals(this.existingWorkPolicy, other.existingWorkPolicy) && WorkmanagerApiPigeonUtils.deepEquals(this.foregroundServiceConfig, other.foregroundServiceConfig)
   }
 
   override fun hashCode(): Int {
@@ -630,6 +745,7 @@ data class PeriodicTaskRequest (
     result = 31 * result + WorkmanagerApiPigeonUtils.deepHash(this.backoffPolicy)
     result = 31 * result + WorkmanagerApiPigeonUtils.deepHash(this.tag)
     result = 31 * result + WorkmanagerApiPigeonUtils.deepHash(this.existingWorkPolicy)
+    result = 31 * result + WorkmanagerApiPigeonUtils.deepHash(this.foregroundServiceConfig)
     return result
   }
 }
@@ -775,36 +891,46 @@ private open class WorkmanagerApiPigeonCodec : StandardMessageCodec() {
         }
       }
       135.toByte() -> {
-        return (readValue(buffer) as? List<Any?>)?.let {
-          Constraints.fromList(it)
+        return (readValue(buffer) as Long?)?.let {
+          ForegroundServiceType.ofRaw(it.toInt())
         }
       }
       136.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          BackoffPolicyConfig.fromList(it)
+          ForegroundServiceConfig.fromList(it)
         }
       }
       137.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          InitializeRequest.fromList(it)
+          Constraints.fromList(it)
         }
       }
       138.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          OneOffTaskRequest.fromList(it)
+          BackoffPolicyConfig.fromList(it)
         }
       }
       139.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          PeriodicTaskRequest.fromList(it)
+          InitializeRequest.fromList(it)
         }
       }
       140.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          ProcessingTaskRequest.fromList(it)
+          OneOffTaskRequest.fromList(it)
         }
       }
       141.toByte() -> {
+        return (readValue(buffer) as? List<Any?>)?.let {
+          PeriodicTaskRequest.fromList(it)
+        }
+      }
+      142.toByte() -> {
+        return (readValue(buffer) as? List<Any?>)?.let {
+          ProcessingTaskRequest.fromList(it)
+        }
+      }
+      143.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
           HealthResearchTaskRequest.fromList(it)
         }
@@ -838,32 +964,40 @@ private open class WorkmanagerApiPigeonCodec : StandardMessageCodec() {
         stream.write(134)
         writeValue(stream, value.raw.toLong())
       }
-      is Constraints -> {
+      is ForegroundServiceType -> {
         stream.write(135)
-        writeValue(stream, value.toList())
+        writeValue(stream, value.raw.toLong())
       }
-      is BackoffPolicyConfig -> {
+      is ForegroundServiceConfig -> {
         stream.write(136)
         writeValue(stream, value.toList())
       }
-      is InitializeRequest -> {
+      is Constraints -> {
         stream.write(137)
         writeValue(stream, value.toList())
       }
-      is OneOffTaskRequest -> {
+      is BackoffPolicyConfig -> {
         stream.write(138)
         writeValue(stream, value.toList())
       }
-      is PeriodicTaskRequest -> {
+      is InitializeRequest -> {
         stream.write(139)
         writeValue(stream, value.toList())
       }
-      is ProcessingTaskRequest -> {
+      is OneOffTaskRequest -> {
         stream.write(140)
         writeValue(stream, value.toList())
       }
-      is HealthResearchTaskRequest -> {
+      is PeriodicTaskRequest -> {
         stream.write(141)
+        writeValue(stream, value.toList())
+      }
+      is ProcessingTaskRequest -> {
+        stream.write(142)
+        writeValue(stream, value.toList())
+      }
+      is HealthResearchTaskRequest -> {
+        stream.write(143)
         writeValue(stream, value.toList())
       }
       else -> super.writeValue(stream, value)

--- a/workmanager_android/android/src/test/kotlin/dev/fluttercommunity/workmanager/ForegroundServiceConfigTest.kt
+++ b/workmanager_android/android/src/test/kotlin/dev/fluttercommunity/workmanager/ForegroundServiceConfigTest.kt
@@ -1,0 +1,79 @@
+package dev.fluttercommunity.workmanager
+
+import androidx.work.Data
+import dev.fluttercommunity.workmanager.pigeon.ForegroundServiceConfig
+import dev.fluttercommunity.workmanager.pigeon.ForegroundServiceType
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class ForegroundServiceConfigTest {
+    @Test
+    fun `config round-trips through WorkManager data`() {
+        val config =
+            ForegroundServiceConfig(
+                notificationTitle = "Syncing",
+                notificationText = "Uploading 42 files",
+                notificationChannelId = "uploads",
+                notificationChannelName = "Uploads",
+                notificationId = 7,
+                foregroundServiceType = ForegroundServiceType.SHORT_SERVICE,
+            )
+
+        val data = Data.Builder().putString(FOREGROUND_SERVICE_CONFIG_KEY, encodeForegroundServiceConfig(config)).build()
+
+        assertEquals(config, decodeForegroundServiceConfig(data))
+    }
+
+    @Test
+    fun `config is embedded in task input data under the reserved key`() {
+        val config = ForegroundServiceConfig(notificationTitle = "Syncing")
+
+        val data = buildTaskInputData("task", payload = null, foregroundServiceConfig = config)
+
+        assertEquals(
+            config,
+            decodeForegroundServiceConfig(data),
+        )
+        // The reserved key must not leak into the user-facing payload.
+        assertNull(decodePayload(data.keyValueMap)[FOREGROUND_SERVICE_CONFIG_KEY])
+    }
+
+    @Test
+    fun `payload-only input data has no foreground config`() {
+        val data = buildTaskInputData("task", payload = mapOf("key" to "value"))
+
+        assertNull(decodeForegroundServiceConfig(data))
+    }
+
+    @Test
+    fun `periodic work request embeds the foreground config`() {
+        val config = ForegroundServiceConfig(notificationTitle = "Syncing")
+
+        val request =
+            createPeriodicWorkRequest(
+                taskName = "task",
+                inputData = null,
+                foregroundServiceConfig = config,
+                frequencySeconds = 900,
+                flexIntervalSeconds = null,
+                initialDelaySeconds = 0,
+                constraints = androidx.work.Constraints.NONE,
+                backoffPolicy = null,
+                tag = null,
+            )
+
+        assertEquals(config, decodeForegroundServiceConfig(request.workSpec.input))
+    }
+
+    @Test
+    fun `null fields in the JSON config decode back as null`() {
+        val json = """{"notificationTitle":"Only a title"}"""
+
+        val config = decodeForegroundServiceConfig(json)
+
+        assertEquals("Only a title", config.notificationTitle)
+        assertNull(config.notificationText)
+        assertNull(config.foregroundServiceType)
+    }
+}

--- a/workmanager_android/lib/workmanager_android.dart
+++ b/workmanager_android/lib/workmanager_android.dart
@@ -1,4 +1,5 @@
 import 'dart:ui';
+import 'package:flutter/foundation.dart';
 import 'package:workmanager_platform_interface/workmanager_platform_interface.dart';
 
 /// Android implementation of [WorkmanagerPlatform].
@@ -39,6 +40,7 @@ class WorkmanagerAndroid extends WorkmanagerPlatform {
     Duration? backoffPolicyDelay,
     String? tag,
     OutOfQuotaPolicy? outOfQuotaPolicy,
+    ForegroundServiceConfig? foregroundServiceConfig,
   }) async {
     await _api.registerOneOffTask(OneOffTaskRequest(
       uniqueName: uniqueName,
@@ -55,6 +57,8 @@ class WorkmanagerAndroid extends WorkmanagerPlatform {
           : null,
       tag: tag,
       outOfQuotaPolicy: outOfQuotaPolicy,
+      foregroundServiceConfig:
+          resolveForegroundServiceConfig(foregroundServiceConfig),
     ));
   }
 
@@ -71,6 +75,7 @@ class WorkmanagerAndroid extends WorkmanagerPlatform {
     BackoffPolicy? backoffPolicy,
     Duration? backoffPolicyDelay,
     String? tag,
+    ForegroundServiceConfig? foregroundServiceConfig,
   }) async {
     await _api.registerPeriodicTask(PeriodicTaskRequest(
       uniqueName: uniqueName,
@@ -88,6 +93,8 @@ class WorkmanagerAndroid extends WorkmanagerPlatform {
             )
           : null,
       tag: tag,
+      foregroundServiceConfig:
+          resolveForegroundServiceConfig(foregroundServiceConfig),
     ));
   }
 
@@ -140,4 +147,43 @@ class WorkmanagerAndroid extends WorkmanagerPlatform {
   Future<String> printScheduledTasks() async {
     throw UnsupportedError('printScheduledTasks is not supported on Android');
   }
+}
+
+/// Defaults for the Android foreground service notification.
+///
+/// The defaults are resolved on the platform implementation (rather than in
+/// the shared [ForegroundServiceConfig] class) so that the platform contract
+/// keeps every field optional and older platform implementations keep
+/// working unchanged.
+const String _defaultForegroundNotificationTitle = 'Task in progress';
+const String _defaultForegroundNotificationText = 'Your task is still running';
+const String _defaultForegroundNotificationChannelId =
+    'workmanager_foreground_tasks';
+const String _defaultForegroundNotificationChannelName = 'Long-running tasks';
+const int _defaultForegroundNotificationId = 0;
+const ForegroundServiceType _defaultForegroundServiceType =
+    ForegroundServiceType.dataSync;
+
+/// Fills in the Android-side defaults for any field not provided by the
+/// caller. Returns `null` when no config was requested.
+@visibleForTesting
+ForegroundServiceConfig? resolveForegroundServiceConfig(
+  ForegroundServiceConfig? config,
+) {
+  if (config == null) {
+    return null;
+  }
+  return ForegroundServiceConfig(
+    notificationTitle:
+        config.notificationTitle ?? _defaultForegroundNotificationTitle,
+    notificationText:
+        config.notificationText ?? _defaultForegroundNotificationText,
+    notificationChannelId:
+        config.notificationChannelId ?? _defaultForegroundNotificationChannelId,
+    notificationChannelName: config.notificationChannelName ??
+        _defaultForegroundNotificationChannelName,
+    notificationId: config.notificationId ?? _defaultForegroundNotificationId,
+    foregroundServiceType:
+        config.foregroundServiceType ?? _defaultForegroundServiceType,
+  );
 }

--- a/workmanager_android/test/workmanager_android_test.dart
+++ b/workmanager_android/test/workmanager_android_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/services.dart';
 import 'package:workmanager_android/workmanager_android.dart';
 import 'package:workmanager_platform_interface/workmanager_platform_interface.dart';
 
@@ -276,6 +277,129 @@ void main() {
         expect(periodicRequest.flexIntervalSeconds, 300);
         expect(periodicRequest.existingWorkPolicy,
             ExistingPeriodicWorkPolicy.keep);
+      });
+    });
+
+    group('Foreground service config', () {
+      const oneOffChannel =
+          'dev.flutter.pigeon.workmanager_platform_interface.WorkmanagerHostApi.registerOneOffTask';
+      const periodicChannel =
+          'dev.flutter.pigeon.workmanager_platform_interface.WorkmanagerHostApi.registerPeriodicTask';
+
+      test('resolves sane defaults for a minimal config', () {
+        final resolved = resolveForegroundServiceConfig(
+          ForegroundServiceConfig(notificationTitle: 'Syncing'),
+        );
+
+        expect(resolved, isNotNull);
+        expect(resolved!.notificationTitle, 'Syncing');
+        expect(resolved.notificationText, 'Your task is still running');
+        expect(resolved.notificationChannelId, 'workmanager_foreground_tasks');
+        expect(resolved.notificationChannelName, 'Long-running tasks');
+        expect(resolved.notificationId, 0);
+        expect(resolved.foregroundServiceType, ForegroundServiceType.dataSync);
+      });
+
+      test('keeps explicitly provided values', () {
+        final resolved = resolveForegroundServiceConfig(
+          ForegroundServiceConfig(
+            notificationTitle: 'Upload',
+            notificationText: 'Uploading files',
+            notificationChannelId: 'uploads',
+            notificationChannelName: 'Uploads',
+            notificationId: 42,
+            foregroundServiceType: ForegroundServiceType.shortService,
+          ),
+        );
+
+        expect(resolved, isNotNull);
+        expect(resolved!.notificationTitle, 'Upload');
+        expect(resolved.notificationText, 'Uploading files');
+        expect(resolved.notificationChannelId, 'uploads');
+        expect(resolved.notificationChannelName, 'Uploads');
+        expect(resolved.notificationId, 42);
+        expect(
+          resolved.foregroundServiceType,
+          ForegroundServiceType.shortService,
+        );
+      });
+
+      test('returns null when no config is requested', () {
+        expect(resolveForegroundServiceConfig(null), isNull);
+      });
+
+      test('registerOneOffTask forwards the resolved config through pigeon',
+          () async {
+        late OneOffTaskRequest captured;
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMessageHandler(oneOffChannel, (ByteData? message) async {
+          final decoded = WorkmanagerHostApi.pigeonChannelCodec
+              .decodeMessage(message) as List<Object?>;
+          captured = decoded[0]! as OneOffTaskRequest;
+          return WorkmanagerHostApi.pigeonChannelCodec
+              .encodeMessage(<Object?>[]);
+        });
+
+        await workmanager.registerOneOffTask(
+          'unique',
+          'task',
+          foregroundServiceConfig:
+              ForegroundServiceConfig(notificationTitle: 'Syncing'),
+        );
+
+        expect(captured.foregroundServiceConfig, isNotNull);
+        expect(captured.foregroundServiceConfig!.notificationTitle, 'Syncing');
+        expect(
+          captured.foregroundServiceConfig!.foregroundServiceType,
+          ForegroundServiceType.dataSync,
+        );
+      });
+
+      test('registerPeriodicTask forwards the resolved config through pigeon',
+          () async {
+        late PeriodicTaskRequest captured;
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMessageHandler(periodicChannel, (ByteData? message) async {
+          final decoded = WorkmanagerHostApi.pigeonChannelCodec
+              .decodeMessage(message) as List<Object?>;
+          captured = decoded[0]! as PeriodicTaskRequest;
+          return WorkmanagerHostApi.pigeonChannelCodec
+              .encodeMessage(<Object?>[]);
+        });
+
+        await workmanager.registerPeriodicTask(
+          'unique',
+          'task',
+          foregroundServiceConfig: ForegroundServiceConfig(
+            foregroundServiceType: ForegroundServiceType.shortService,
+          ),
+        );
+
+        expect(captured.foregroundServiceConfig, isNotNull);
+        expect(
+          captured.foregroundServiceConfig!.foregroundServiceType,
+          ForegroundServiceType.shortService,
+        );
+        expect(
+          captured.foregroundServiceConfig!.notificationTitle,
+          'Task in progress',
+        );
+      });
+
+      test('request carries no config when none is provided', () async {
+        late OneOffTaskRequest captured;
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMessageHandler(oneOffChannel, (ByteData? message) async {
+          final decoded = WorkmanagerHostApi.pigeonChannelCodec
+              .decodeMessage(message) as List<Object?>;
+          captured = decoded[0]! as OneOffTaskRequest;
+          return WorkmanagerHostApi.pigeonChannelCodec
+              .encodeMessage(<Object?>[]);
+        });
+
+        await workmanager.registerOneOffTask('unique', 'task');
+
+        expect(captured.foregroundServiceConfig, isNull);
       });
     });
   });

--- a/workmanager_apple/ios/workmanager_apple/Sources/workmanager_apple/pigeon/WorkmanagerApi.g.swift
+++ b/workmanager_apple/ios/workmanager_apple/Sources/workmanager_apple/pigeon/WorkmanagerApi.g.swift
@@ -295,6 +295,96 @@ enum OutOfQuotaPolicy: Int {
   case dropWorkRequest = 1
 }
 
+/// Foreground service types supported for Android long-running workers.
+///
+/// These map to the foreground service types introduced by Android 14
+/// (API level 34), when specifying a type became mandatory for apps targeting
+/// SDK 34+. See:
+/// https://developer.android.com/about/versions/14/changes/fgs-types-required
+enum ForegroundServiceType: Int {
+  /// Used for long-running data synchronization, uploads and downloads that
+  /// are important to the user.
+  case dataSync = 0
+  /// Used for short, critical work that the user is aware of and that must
+  /// complete quickly (a few minutes at most).
+  case shortService = 1
+}
+
+/// Android-only configuration that promotes a worker to a foreground service
+/// while it runs, keeping the process alive for long-running work.
+///
+/// When provided to [OneOffTaskRequest.foregroundServiceConfig] or
+/// [PeriodicTaskRequest.foregroundServiceConfig], the worker calls
+/// WorkManager's `setForegroundAsync` as soon as it starts and shows a
+/// notification for the whole duration of the task.
+///
+/// All fields are optional; the platform implementation fills in sane
+/// defaults for anything that is not provided.
+///
+/// Generated class from Pigeon that represents data sent in messages.
+struct ForegroundServiceConfig: Hashable {
+  /// Title shown in the foreground service notification.
+  var notificationTitle: String? = nil
+  /// Body text shown in the foreground service notification.
+  var notificationText: String? = nil
+  /// Id of the notification channel used for the foreground service
+  /// notification (Android 8.0+).
+  var notificationChannelId: String? = nil
+  /// User-visible name of the notification channel.
+  var notificationChannelName: String? = nil
+  /// Id used for the foreground service notification.
+  var notificationId: Int64? = nil
+  /// Foreground service type to start with (Android 14+). Defaults to
+  /// [ForegroundServiceType.dataSync].
+  var foregroundServiceType: ForegroundServiceType? = nil
+
+
+  // swift-format-ignore: AlwaysUseLowerCamelCase
+  static func fromList(_ pigeonVar_list: [Any?]) -> ForegroundServiceConfig? {
+    let notificationTitle: String? = nilOrValue(pigeonVar_list[0])
+    let notificationText: String? = nilOrValue(pigeonVar_list[1])
+    let notificationChannelId: String? = nilOrValue(pigeonVar_list[2])
+    let notificationChannelName: String? = nilOrValue(pigeonVar_list[3])
+    let notificationId: Int64? = nilOrValue(pigeonVar_list[4])
+    let foregroundServiceType: ForegroundServiceType? = nilOrValue(pigeonVar_list[5])
+
+    return ForegroundServiceConfig(
+      notificationTitle: notificationTitle,
+      notificationText: notificationText,
+      notificationChannelId: notificationChannelId,
+      notificationChannelName: notificationChannelName,
+      notificationId: notificationId,
+      foregroundServiceType: foregroundServiceType
+    )
+  }
+  func toList() -> [Any?] {
+    return [
+      notificationTitle,
+      notificationText,
+      notificationChannelId,
+      notificationChannelName,
+      notificationId,
+      foregroundServiceType,
+    ]
+  }
+  static func == (lhs: ForegroundServiceConfig, rhs: ForegroundServiceConfig) -> Bool {
+    if Swift.type(of: lhs) != Swift.type(of: rhs) {
+      return false
+    }
+    return deepEqualsWorkmanagerApi(lhs.notificationTitle, rhs.notificationTitle) && deepEqualsWorkmanagerApi(lhs.notificationText, rhs.notificationText) && deepEqualsWorkmanagerApi(lhs.notificationChannelId, rhs.notificationChannelId) && deepEqualsWorkmanagerApi(lhs.notificationChannelName, rhs.notificationChannelName) && deepEqualsWorkmanagerApi(lhs.notificationId, rhs.notificationId) && deepEqualsWorkmanagerApi(lhs.foregroundServiceType, rhs.foregroundServiceType)
+  }
+
+  func hash(into hasher: inout Hasher) {
+    hasher.combine("ForegroundServiceConfig")
+    deepHashWorkmanagerApi(value: notificationTitle, hasher: &hasher)
+    deepHashWorkmanagerApi(value: notificationText, hasher: &hasher)
+    deepHashWorkmanagerApi(value: notificationChannelId, hasher: &hasher)
+    deepHashWorkmanagerApi(value: notificationChannelName, hasher: &hasher)
+    deepHashWorkmanagerApi(value: notificationId, hasher: &hasher)
+    deepHashWorkmanagerApi(value: foregroundServiceType, hasher: &hasher)
+  }
+}
+
 /// Generated class from Pigeon that represents data sent in messages.
 struct Constraints: Hashable {
   var networkType: NetworkType? = nil
@@ -424,6 +514,8 @@ struct OneOffTaskRequest: Hashable {
   var tag: String? = nil
   var existingWorkPolicy: ExistingWorkPolicy? = nil
   var outOfQuotaPolicy: OutOfQuotaPolicy? = nil
+  /// When set, the worker runs as an Android foreground service.
+  var foregroundServiceConfig: ForegroundServiceConfig? = nil
 
 
   // swift-format-ignore: AlwaysUseLowerCamelCase
@@ -437,6 +529,7 @@ struct OneOffTaskRequest: Hashable {
     let tag: String? = nilOrValue(pigeonVar_list[6])
     let existingWorkPolicy: ExistingWorkPolicy? = nilOrValue(pigeonVar_list[7])
     let outOfQuotaPolicy: OutOfQuotaPolicy? = nilOrValue(pigeonVar_list[8])
+    let foregroundServiceConfig: ForegroundServiceConfig? = nilOrValue(pigeonVar_list[9])
 
     return OneOffTaskRequest(
       uniqueName: uniqueName,
@@ -447,7 +540,8 @@ struct OneOffTaskRequest: Hashable {
       backoffPolicy: backoffPolicy,
       tag: tag,
       existingWorkPolicy: existingWorkPolicy,
-      outOfQuotaPolicy: outOfQuotaPolicy
+      outOfQuotaPolicy: outOfQuotaPolicy,
+      foregroundServiceConfig: foregroundServiceConfig
     )
   }
   func toList() -> [Any?] {
@@ -461,13 +555,14 @@ struct OneOffTaskRequest: Hashable {
       tag,
       existingWorkPolicy,
       outOfQuotaPolicy,
+      foregroundServiceConfig,
     ]
   }
   static func == (lhs: OneOffTaskRequest, rhs: OneOffTaskRequest) -> Bool {
     if Swift.type(of: lhs) != Swift.type(of: rhs) {
       return false
     }
-    return deepEqualsWorkmanagerApi(lhs.uniqueName, rhs.uniqueName) && deepEqualsWorkmanagerApi(lhs.taskName, rhs.taskName) && deepEqualsWorkmanagerApi(lhs.inputData, rhs.inputData) && deepEqualsWorkmanagerApi(lhs.initialDelaySeconds, rhs.initialDelaySeconds) && deepEqualsWorkmanagerApi(lhs.constraints, rhs.constraints) && deepEqualsWorkmanagerApi(lhs.backoffPolicy, rhs.backoffPolicy) && deepEqualsWorkmanagerApi(lhs.tag, rhs.tag) && deepEqualsWorkmanagerApi(lhs.existingWorkPolicy, rhs.existingWorkPolicy) && deepEqualsWorkmanagerApi(lhs.outOfQuotaPolicy, rhs.outOfQuotaPolicy)
+    return deepEqualsWorkmanagerApi(lhs.uniqueName, rhs.uniqueName) && deepEqualsWorkmanagerApi(lhs.taskName, rhs.taskName) && deepEqualsWorkmanagerApi(lhs.inputData, rhs.inputData) && deepEqualsWorkmanagerApi(lhs.initialDelaySeconds, rhs.initialDelaySeconds) && deepEqualsWorkmanagerApi(lhs.constraints, rhs.constraints) && deepEqualsWorkmanagerApi(lhs.backoffPolicy, rhs.backoffPolicy) && deepEqualsWorkmanagerApi(lhs.tag, rhs.tag) && deepEqualsWorkmanagerApi(lhs.existingWorkPolicy, rhs.existingWorkPolicy) && deepEqualsWorkmanagerApi(lhs.outOfQuotaPolicy, rhs.outOfQuotaPolicy) && deepEqualsWorkmanagerApi(lhs.foregroundServiceConfig, rhs.foregroundServiceConfig)
   }
 
   func hash(into hasher: inout Hasher) {
@@ -481,6 +576,7 @@ struct OneOffTaskRequest: Hashable {
     deepHashWorkmanagerApi(value: tag, hasher: &hasher)
     deepHashWorkmanagerApi(value: existingWorkPolicy, hasher: &hasher)
     deepHashWorkmanagerApi(value: outOfQuotaPolicy, hasher: &hasher)
+    deepHashWorkmanagerApi(value: foregroundServiceConfig, hasher: &hasher)
   }
 }
 
@@ -496,6 +592,8 @@ struct PeriodicTaskRequest: Hashable {
   var backoffPolicy: BackoffPolicyConfig? = nil
   var tag: String? = nil
   var existingWorkPolicy: ExistingPeriodicWorkPolicy? = nil
+  /// When set, the worker runs as an Android foreground service.
+  var foregroundServiceConfig: ForegroundServiceConfig? = nil
 
 
   // swift-format-ignore: AlwaysUseLowerCamelCase
@@ -510,6 +608,7 @@ struct PeriodicTaskRequest: Hashable {
     let backoffPolicy: BackoffPolicyConfig? = nilOrValue(pigeonVar_list[7])
     let tag: String? = nilOrValue(pigeonVar_list[8])
     let existingWorkPolicy: ExistingPeriodicWorkPolicy? = nilOrValue(pigeonVar_list[9])
+    let foregroundServiceConfig: ForegroundServiceConfig? = nilOrValue(pigeonVar_list[10])
 
     return PeriodicTaskRequest(
       uniqueName: uniqueName,
@@ -521,7 +620,8 @@ struct PeriodicTaskRequest: Hashable {
       constraints: constraints,
       backoffPolicy: backoffPolicy,
       tag: tag,
-      existingWorkPolicy: existingWorkPolicy
+      existingWorkPolicy: existingWorkPolicy,
+      foregroundServiceConfig: foregroundServiceConfig
     )
   }
   func toList() -> [Any?] {
@@ -536,13 +636,14 @@ struct PeriodicTaskRequest: Hashable {
       backoffPolicy,
       tag,
       existingWorkPolicy,
+      foregroundServiceConfig,
     ]
   }
   static func == (lhs: PeriodicTaskRequest, rhs: PeriodicTaskRequest) -> Bool {
     if Swift.type(of: lhs) != Swift.type(of: rhs) {
       return false
     }
-    return deepEqualsWorkmanagerApi(lhs.uniqueName, rhs.uniqueName) && deepEqualsWorkmanagerApi(lhs.taskName, rhs.taskName) && deepEqualsWorkmanagerApi(lhs.frequencySeconds, rhs.frequencySeconds) && deepEqualsWorkmanagerApi(lhs.flexIntervalSeconds, rhs.flexIntervalSeconds) && deepEqualsWorkmanagerApi(lhs.inputData, rhs.inputData) && deepEqualsWorkmanagerApi(lhs.initialDelaySeconds, rhs.initialDelaySeconds) && deepEqualsWorkmanagerApi(lhs.constraints, rhs.constraints) && deepEqualsWorkmanagerApi(lhs.backoffPolicy, rhs.backoffPolicy) && deepEqualsWorkmanagerApi(lhs.tag, rhs.tag) && deepEqualsWorkmanagerApi(lhs.existingWorkPolicy, rhs.existingWorkPolicy)
+    return deepEqualsWorkmanagerApi(lhs.uniqueName, rhs.uniqueName) && deepEqualsWorkmanagerApi(lhs.taskName, rhs.taskName) && deepEqualsWorkmanagerApi(lhs.frequencySeconds, rhs.frequencySeconds) && deepEqualsWorkmanagerApi(lhs.flexIntervalSeconds, rhs.flexIntervalSeconds) && deepEqualsWorkmanagerApi(lhs.inputData, rhs.inputData) && deepEqualsWorkmanagerApi(lhs.initialDelaySeconds, rhs.initialDelaySeconds) && deepEqualsWorkmanagerApi(lhs.constraints, rhs.constraints) && deepEqualsWorkmanagerApi(lhs.backoffPolicy, rhs.backoffPolicy) && deepEqualsWorkmanagerApi(lhs.tag, rhs.tag) && deepEqualsWorkmanagerApi(lhs.existingWorkPolicy, rhs.existingWorkPolicy) && deepEqualsWorkmanagerApi(lhs.foregroundServiceConfig, rhs.foregroundServiceConfig)
   }
 
   func hash(into hasher: inout Hasher) {
@@ -557,6 +658,7 @@ struct PeriodicTaskRequest: Hashable {
     deepHashWorkmanagerApi(value: backoffPolicy, hasher: &hasher)
     deepHashWorkmanagerApi(value: tag, hasher: &hasher)
     deepHashWorkmanagerApi(value: existingWorkPolicy, hasher: &hasher)
+    deepHashWorkmanagerApi(value: foregroundServiceConfig, hasher: &hasher)
   }
 }
 
@@ -712,18 +814,26 @@ private class WorkmanagerApiPigeonCodecReader: FlutterStandardReader {
       }
       return nil
     case 135:
-      return Constraints.fromList(self.readValue() as! [Any?])
+      let enumResultAsInt: Int? = nilOrValue(self.readValue() as! Int?)
+      if let enumResultAsInt = enumResultAsInt {
+        return ForegroundServiceType(rawValue: enumResultAsInt)
+      }
+      return nil
     case 136:
-      return BackoffPolicyConfig.fromList(self.readValue() as! [Any?])
+      return ForegroundServiceConfig.fromList(self.readValue() as! [Any?])
     case 137:
-      return InitializeRequest.fromList(self.readValue() as! [Any?])
+      return Constraints.fromList(self.readValue() as! [Any?])
     case 138:
-      return OneOffTaskRequest.fromList(self.readValue() as! [Any?])
+      return BackoffPolicyConfig.fromList(self.readValue() as! [Any?])
     case 139:
-      return PeriodicTaskRequest.fromList(self.readValue() as! [Any?])
+      return InitializeRequest.fromList(self.readValue() as! [Any?])
     case 140:
-      return ProcessingTaskRequest.fromList(self.readValue() as! [Any?])
+      return OneOffTaskRequest.fromList(self.readValue() as! [Any?])
     case 141:
+      return PeriodicTaskRequest.fromList(self.readValue() as! [Any?])
+    case 142:
+      return ProcessingTaskRequest.fromList(self.readValue() as! [Any?])
+    case 143:
       return HealthResearchTaskRequest.fromList(self.readValue() as! [Any?])
     default:
       return super.readValue(ofType: type)
@@ -751,26 +861,32 @@ private class WorkmanagerApiPigeonCodecWriter: FlutterStandardWriter {
     } else if let value = value as? OutOfQuotaPolicy {
       super.writeByte(134)
       super.writeValue(value.rawValue)
-    } else if let value = value as? Constraints {
+    } else if let value = value as? ForegroundServiceType {
       super.writeByte(135)
-      super.writeValue(value.toList())
-    } else if let value = value as? BackoffPolicyConfig {
+      super.writeValue(value.rawValue)
+    } else if let value = value as? ForegroundServiceConfig {
       super.writeByte(136)
       super.writeValue(value.toList())
-    } else if let value = value as? InitializeRequest {
+    } else if let value = value as? Constraints {
       super.writeByte(137)
       super.writeValue(value.toList())
-    } else if let value = value as? OneOffTaskRequest {
+    } else if let value = value as? BackoffPolicyConfig {
       super.writeByte(138)
       super.writeValue(value.toList())
-    } else if let value = value as? PeriodicTaskRequest {
+    } else if let value = value as? InitializeRequest {
       super.writeByte(139)
       super.writeValue(value.toList())
-    } else if let value = value as? ProcessingTaskRequest {
+    } else if let value = value as? OneOffTaskRequest {
       super.writeByte(140)
       super.writeValue(value.toList())
-    } else if let value = value as? HealthResearchTaskRequest {
+    } else if let value = value as? PeriodicTaskRequest {
       super.writeByte(141)
+      super.writeValue(value.toList())
+    } else if let value = value as? ProcessingTaskRequest {
+      super.writeByte(142)
+      super.writeValue(value.toList())
+    } else if let value = value as? HealthResearchTaskRequest {
+      super.writeByte(143)
       super.writeValue(value.toList())
     } else {
       super.writeValue(value)

--- a/workmanager_apple/lib/workmanager_apple.dart
+++ b/workmanager_apple/lib/workmanager_apple.dart
@@ -39,7 +39,9 @@ class WorkmanagerApple extends WorkmanagerPlatform {
     Duration? backoffPolicyDelay,
     String? tag,
     OutOfQuotaPolicy? outOfQuotaPolicy,
+    ForegroundServiceConfig? foregroundServiceConfig,
   }) async {
+    // Foreground service config is Android-only; it is intentionally ignored.
     await _api.registerOneOffTask(OneOffTaskRequest(
       uniqueName: uniqueName,
       taskName: taskName,
@@ -71,7 +73,9 @@ class WorkmanagerApple extends WorkmanagerPlatform {
     BackoffPolicy? backoffPolicy,
     Duration? backoffPolicyDelay,
     String? tag,
+    ForegroundServiceConfig? foregroundServiceConfig,
   }) async {
+    // Foreground service config is Android-only; it is intentionally ignored.
     await _api.registerPeriodicTask(PeriodicTaskRequest(
       uniqueName: uniqueName,
       taskName: taskName,

--- a/workmanager_platform_interface/lib/src/pigeon/workmanager_api.g.dart
+++ b/workmanager_platform_interface/lib/src/pigeon/workmanager_api.g.dart
@@ -224,6 +224,104 @@ enum OutOfQuotaPolicy {
   dropWorkRequest,
 }
 
+/// Foreground service types supported for Android long-running workers.
+///
+/// These map to the foreground service types introduced by Android 14
+/// (API level 34), when specifying a type became mandatory for apps targeting
+/// SDK 34+. See:
+/// https://developer.android.com/about/versions/14/changes/fgs-types-required
+enum ForegroundServiceType {
+  /// Used for long-running data synchronization, uploads and downloads that
+  /// are important to the user.
+  dataSync,
+  /// Used for short, critical work that the user is aware of and that must
+  /// complete quickly (a few minutes at most).
+  shortService,
+}
+
+/// Android-only configuration that promotes a worker to a foreground service
+/// while it runs, keeping the process alive for long-running work.
+///
+/// When provided to [OneOffTaskRequest.foregroundServiceConfig] or
+/// [PeriodicTaskRequest.foregroundServiceConfig], the worker calls
+/// WorkManager's `setForegroundAsync` as soon as it starts and shows a
+/// notification for the whole duration of the task.
+///
+/// All fields are optional; the platform implementation fills in sane
+/// defaults for anything that is not provided.
+class ForegroundServiceConfig {
+  ForegroundServiceConfig({
+    this.notificationTitle,
+    this.notificationText,
+    this.notificationChannelId,
+    this.notificationChannelName,
+    this.notificationId,
+    this.foregroundServiceType,
+  });
+
+  /// Title shown in the foreground service notification.
+  String? notificationTitle;
+
+  /// Body text shown in the foreground service notification.
+  String? notificationText;
+
+  /// Id of the notification channel used for the foreground service
+  /// notification (Android 8.0+).
+  String? notificationChannelId;
+
+  /// User-visible name of the notification channel.
+  String? notificationChannelName;
+
+  /// Id used for the foreground service notification.
+  int? notificationId;
+
+  /// Foreground service type to start with (Android 14+). Defaults to
+  /// [ForegroundServiceType.dataSync].
+  ForegroundServiceType? foregroundServiceType;
+
+  List<Object?> _toList() {
+    return <Object?>[
+      notificationTitle,
+      notificationText,
+      notificationChannelId,
+      notificationChannelName,
+      notificationId,
+      foregroundServiceType,
+    ];
+  }
+
+  Object encode() {
+    return _toList();  }
+
+  static ForegroundServiceConfig decode(Object result) {
+    result as List<Object?>;
+    return ForegroundServiceConfig(
+      notificationTitle: result[0] as String?,
+      notificationText: result[1] as String?,
+      notificationChannelId: result[2] as String?,
+      notificationChannelName: result[3] as String?,
+      notificationId: result[4] as int?,
+      foregroundServiceType: result[5] as ForegroundServiceType?,
+    );
+  }
+
+  @override
+  // ignore: avoid_equals_and_hash_code_on_mutable_classes
+  bool operator ==(Object other) {
+    if (other is! ForegroundServiceConfig || other.runtimeType != runtimeType) {
+      return false;
+    }
+    if (identical(this, other)) {
+      return true;
+    }
+    return _deepEquals(notificationTitle, other.notificationTitle) && _deepEquals(notificationText, other.notificationText) && _deepEquals(notificationChannelId, other.notificationChannelId) && _deepEquals(notificationChannelName, other.notificationChannelName) && _deepEquals(notificationId, other.notificationId) && _deepEquals(foregroundServiceType, other.foregroundServiceType);
+  }
+
+  @override
+  // ignore: avoid_equals_and_hash_code_on_mutable_classes
+  int get hashCode => _deepHash(<Object?>[runtimeType, ..._toList()]);
+}
+
 class Constraints {
   Constraints({
     this.networkType,
@@ -380,6 +478,7 @@ class OneOffTaskRequest {
     this.tag,
     this.existingWorkPolicy,
     this.outOfQuotaPolicy,
+    this.foregroundServiceConfig,
   });
 
   String uniqueName;
@@ -400,6 +499,9 @@ class OneOffTaskRequest {
 
   OutOfQuotaPolicy? outOfQuotaPolicy;
 
+  /// When set, the worker runs as an Android foreground service.
+  ForegroundServiceConfig? foregroundServiceConfig;
+
   List<Object?> _toList() {
     return <Object?>[
       uniqueName,
@@ -411,6 +513,7 @@ class OneOffTaskRequest {
       tag,
       existingWorkPolicy,
       outOfQuotaPolicy,
+      foregroundServiceConfig,
     ];
   }
 
@@ -429,6 +532,7 @@ class OneOffTaskRequest {
       tag: result[6] as String?,
       existingWorkPolicy: result[7] as ExistingWorkPolicy?,
       outOfQuotaPolicy: result[8] as OutOfQuotaPolicy?,
+      foregroundServiceConfig: result[9] as ForegroundServiceConfig?,
     );
   }
 
@@ -441,7 +545,7 @@ class OneOffTaskRequest {
     if (identical(this, other)) {
       return true;
     }
-    return _deepEquals(uniqueName, other.uniqueName) && _deepEquals(taskName, other.taskName) && _deepEquals(inputData, other.inputData) && _deepEquals(initialDelaySeconds, other.initialDelaySeconds) && _deepEquals(constraints, other.constraints) && _deepEquals(backoffPolicy, other.backoffPolicy) && _deepEquals(tag, other.tag) && _deepEquals(existingWorkPolicy, other.existingWorkPolicy) && _deepEquals(outOfQuotaPolicy, other.outOfQuotaPolicy);
+    return _deepEquals(uniqueName, other.uniqueName) && _deepEquals(taskName, other.taskName) && _deepEquals(inputData, other.inputData) && _deepEquals(initialDelaySeconds, other.initialDelaySeconds) && _deepEquals(constraints, other.constraints) && _deepEquals(backoffPolicy, other.backoffPolicy) && _deepEquals(tag, other.tag) && _deepEquals(existingWorkPolicy, other.existingWorkPolicy) && _deepEquals(outOfQuotaPolicy, other.outOfQuotaPolicy) && _deepEquals(foregroundServiceConfig, other.foregroundServiceConfig);
   }
 
   @override
@@ -461,6 +565,7 @@ class PeriodicTaskRequest {
     this.backoffPolicy,
     this.tag,
     this.existingWorkPolicy,
+    this.foregroundServiceConfig,
   });
 
   String uniqueName;
@@ -483,6 +588,9 @@ class PeriodicTaskRequest {
 
   ExistingPeriodicWorkPolicy? existingWorkPolicy;
 
+  /// When set, the worker runs as an Android foreground service.
+  ForegroundServiceConfig? foregroundServiceConfig;
+
   List<Object?> _toList() {
     return <Object?>[
       uniqueName,
@@ -495,6 +603,7 @@ class PeriodicTaskRequest {
       backoffPolicy,
       tag,
       existingWorkPolicy,
+      foregroundServiceConfig,
     ];
   }
 
@@ -514,6 +623,7 @@ class PeriodicTaskRequest {
       backoffPolicy: result[7] as BackoffPolicyConfig?,
       tag: result[8] as String?,
       existingWorkPolicy: result[9] as ExistingPeriodicWorkPolicy?,
+      foregroundServiceConfig: result[10] as ForegroundServiceConfig?,
     );
   }
 
@@ -526,7 +636,7 @@ class PeriodicTaskRequest {
     if (identical(this, other)) {
       return true;
     }
-    return _deepEquals(uniqueName, other.uniqueName) && _deepEquals(taskName, other.taskName) && _deepEquals(frequencySeconds, other.frequencySeconds) && _deepEquals(flexIntervalSeconds, other.flexIntervalSeconds) && _deepEquals(inputData, other.inputData) && _deepEquals(initialDelaySeconds, other.initialDelaySeconds) && _deepEquals(constraints, other.constraints) && _deepEquals(backoffPolicy, other.backoffPolicy) && _deepEquals(tag, other.tag) && _deepEquals(existingWorkPolicy, other.existingWorkPolicy);
+    return _deepEquals(uniqueName, other.uniqueName) && _deepEquals(taskName, other.taskName) && _deepEquals(frequencySeconds, other.frequencySeconds) && _deepEquals(flexIntervalSeconds, other.flexIntervalSeconds) && _deepEquals(inputData, other.inputData) && _deepEquals(initialDelaySeconds, other.initialDelaySeconds) && _deepEquals(constraints, other.constraints) && _deepEquals(backoffPolicy, other.backoffPolicy) && _deepEquals(tag, other.tag) && _deepEquals(existingWorkPolicy, other.existingWorkPolicy) && _deepEquals(foregroundServiceConfig, other.foregroundServiceConfig);
   }
 
   @override
@@ -690,26 +800,32 @@ class _PigeonCodec extends StandardMessageCodec {
     }    else if (value is OutOfQuotaPolicy) {
       buffer.putUint8(134);
       writeValue(buffer, value.index);
-    }    else if (value is Constraints) {
+    }    else if (value is ForegroundServiceType) {
       buffer.putUint8(135);
-      writeValue(buffer, value.encode());
-    }    else if (value is BackoffPolicyConfig) {
+      writeValue(buffer, value.index);
+    }    else if (value is ForegroundServiceConfig) {
       buffer.putUint8(136);
       writeValue(buffer, value.encode());
-    }    else if (value is InitializeRequest) {
+    }    else if (value is Constraints) {
       buffer.putUint8(137);
       writeValue(buffer, value.encode());
-    }    else if (value is OneOffTaskRequest) {
+    }    else if (value is BackoffPolicyConfig) {
       buffer.putUint8(138);
       writeValue(buffer, value.encode());
-    }    else if (value is PeriodicTaskRequest) {
+    }    else if (value is InitializeRequest) {
       buffer.putUint8(139);
       writeValue(buffer, value.encode());
-    }    else if (value is ProcessingTaskRequest) {
+    }    else if (value is OneOffTaskRequest) {
       buffer.putUint8(140);
       writeValue(buffer, value.encode());
-    }    else if (value is HealthResearchTaskRequest) {
+    }    else if (value is PeriodicTaskRequest) {
       buffer.putUint8(141);
+      writeValue(buffer, value.encode());
+    }    else if (value is ProcessingTaskRequest) {
+      buffer.putUint8(142);
+      writeValue(buffer, value.encode());
+    }    else if (value is HealthResearchTaskRequest) {
+      buffer.putUint8(143);
       writeValue(buffer, value.encode());
     } else {
       super.writeValue(buffer, value);
@@ -738,18 +854,23 @@ class _PigeonCodec extends StandardMessageCodec {
         final value = readValue(buffer) as int?;
         return value == null ? null : OutOfQuotaPolicy.values[value];
       case 135:
-        return Constraints.decode(readValue(buffer)!);
+        final value = readValue(buffer) as int?;
+        return value == null ? null : ForegroundServiceType.values[value];
       case 136:
-        return BackoffPolicyConfig.decode(readValue(buffer)!);
+        return ForegroundServiceConfig.decode(readValue(buffer)!);
       case 137:
-        return InitializeRequest.decode(readValue(buffer)!);
+        return Constraints.decode(readValue(buffer)!);
       case 138:
-        return OneOffTaskRequest.decode(readValue(buffer)!);
+        return BackoffPolicyConfig.decode(readValue(buffer)!);
       case 139:
-        return PeriodicTaskRequest.decode(readValue(buffer)!);
+        return InitializeRequest.decode(readValue(buffer)!);
       case 140:
-        return ProcessingTaskRequest.decode(readValue(buffer)!);
+        return OneOffTaskRequest.decode(readValue(buffer)!);
       case 141:
+        return PeriodicTaskRequest.decode(readValue(buffer)!);
+      case 142:
+        return ProcessingTaskRequest.decode(readValue(buffer)!);
+      case 143:
         return HealthResearchTaskRequest.decode(readValue(buffer)!);
       default:
         return super.readValueOfType(type, buffer);

--- a/workmanager_platform_interface/lib/src/workmanager_platform_interface.dart
+++ b/workmanager_platform_interface/lib/src/workmanager_platform_interface.dart
@@ -53,6 +53,8 @@ abstract class WorkmanagerPlatform extends PlatformInterface {
   /// [backoffPolicyDelay] is the delay for the backoff policy.
   /// [tag] is an optional tag for the task.
   /// [outOfQuotaPolicy] determines behavior when quota is exceeded (Android only).
+  /// [foregroundServiceConfig] promotes the worker to an Android foreground
+  /// service while it runs (Android only).
   Future<void> registerOneOffTask(
     String uniqueName,
     String taskName, {
@@ -64,6 +66,7 @@ abstract class WorkmanagerPlatform extends PlatformInterface {
     Duration? backoffPolicyDelay,
     String? tag,
     OutOfQuotaPolicy? outOfQuotaPolicy,
+    ForegroundServiceConfig? foregroundServiceConfig,
   }) {
     throw UnimplementedError('registerOneOffTask() has not been implemented.');
   }
@@ -81,6 +84,8 @@ abstract class WorkmanagerPlatform extends PlatformInterface {
   /// [backoffPolicy] determines the backoff policy for retries.
   /// [backoffPolicyDelay] is the delay for the backoff policy.
   /// [tag] is an optional tag for the task.
+  /// [foregroundServiceConfig] promotes the worker to an Android foreground
+  /// service while it runs (Android only).
   Future<void> registerPeriodicTask(
     String uniqueName,
     String taskName, {
@@ -93,6 +98,7 @@ abstract class WorkmanagerPlatform extends PlatformInterface {
     BackoffPolicy? backoffPolicy,
     Duration? backoffPolicyDelay,
     String? tag,
+    ForegroundServiceConfig? foregroundServiceConfig,
   }) {
     throw UnimplementedError(
         'registerPeriodicTask() has not been implemented.');
@@ -188,6 +194,7 @@ class _PlaceholderImplementation extends WorkmanagerPlatform {
     Duration? backoffPolicyDelay,
     String? tag,
     OutOfQuotaPolicy? outOfQuotaPolicy,
+    ForegroundServiceConfig? foregroundServiceConfig,
   }) async {
     throw UnimplementedError(
       'No implementation found for workmanager on this platform.',
@@ -207,6 +214,7 @@ class _PlaceholderImplementation extends WorkmanagerPlatform {
     BackoffPolicy? backoffPolicy,
     Duration? backoffPolicyDelay,
     String? tag,
+    ForegroundServiceConfig? foregroundServiceConfig,
   }) async {
     throw UnimplementedError(
       'No implementation found for workmanager on this platform.',

--- a/workmanager_platform_interface/pigeons/workmanager_api.dart
+++ b/workmanager_platform_interface/pigeons/workmanager_api.dart
@@ -149,6 +149,63 @@ enum OutOfQuotaPolicy {
   dropWorkRequest,
 }
 
+/// Foreground service types supported for Android long-running workers.
+///
+/// These map to the foreground service types introduced by Android 14
+/// (API level 34), when specifying a type became mandatory for apps targeting
+/// SDK 34+. See:
+/// https://developer.android.com/about/versions/14/changes/fgs-types-required
+enum ForegroundServiceType {
+  /// Used for long-running data synchronization, uploads and downloads that
+  /// are important to the user.
+  dataSync,
+
+  /// Used for short, critical work that the user is aware of and that must
+  /// complete quickly (a few minutes at most).
+  shortService,
+}
+
+/// Android-only configuration that promotes a worker to a foreground service
+/// while it runs, keeping the process alive for long-running work.
+///
+/// When provided to [OneOffTaskRequest.foregroundServiceConfig] or
+/// [PeriodicTaskRequest.foregroundServiceConfig], the worker calls
+/// WorkManager's `setForegroundAsync` as soon as it starts and shows a
+/// notification for the whole duration of the task.
+///
+/// All fields are optional; the platform implementation fills in sane
+/// defaults for anything that is not provided.
+class ForegroundServiceConfig {
+  ForegroundServiceConfig({
+    this.notificationTitle,
+    this.notificationText,
+    this.notificationChannelId,
+    this.notificationChannelName,
+    this.notificationId,
+    this.foregroundServiceType,
+  });
+
+  /// Title shown in the foreground service notification.
+  String? notificationTitle;
+
+  /// Body text shown in the foreground service notification.
+  String? notificationText;
+
+  /// Id of the notification channel used for the foreground service
+  /// notification (Android 8.0+).
+  String? notificationChannelId;
+
+  /// User-visible name of the notification channel.
+  String? notificationChannelName;
+
+  /// Id used for the foreground service notification.
+  int? notificationId;
+
+  /// Foreground service type to start with (Android 14+). Defaults to
+  /// [ForegroundServiceType.dataSync].
+  ForegroundServiceType? foregroundServiceType;
+}
+
 // Data classes
 class Constraints {
   Constraints({
@@ -193,6 +250,7 @@ class OneOffTaskRequest {
     this.tag,
     this.existingWorkPolicy,
     this.outOfQuotaPolicy,
+    this.foregroundServiceConfig,
   });
 
   String uniqueName;
@@ -204,6 +262,9 @@ class OneOffTaskRequest {
   String? tag;
   ExistingWorkPolicy? existingWorkPolicy;
   OutOfQuotaPolicy? outOfQuotaPolicy;
+
+  /// When set, the worker runs as an Android foreground service.
+  ForegroundServiceConfig? foregroundServiceConfig;
 }
 
 class PeriodicTaskRequest {
@@ -218,6 +279,7 @@ class PeriodicTaskRequest {
     this.backoffPolicy,
     this.tag,
     this.existingWorkPolicy,
+    this.foregroundServiceConfig,
   });
 
   String uniqueName;
@@ -230,6 +292,9 @@ class PeriodicTaskRequest {
   BackoffPolicyConfig? backoffPolicy;
   String? tag;
   ExistingPeriodicWorkPolicy? existingWorkPolicy;
+
+  /// When set, the worker runs as an Android foreground service.
+  ForegroundServiceConfig? foregroundServiceConfig;
 }
 
 // iOS specific request


### PR DESCRIPTION
## What

Takeover of the stale #573 (long-running workers on Android). Lands Android foreground-service support for long-running workers, following WorkManager's first-class `setForegroundAsync` + `ForegroundInfo` pattern — not a worker-thread hack.

## API

One optional parameter on the existing registration methods:

```dart
await Workmanager().registerOneOffTask(
  "upload-task",
  "upload_files",
  foregroundServiceConfig: ForegroundServiceConfig(
    notificationTitle: "Uploading files",
    notificationText: "Your files are being uploaded",
  ),
);
```

`ForegroundServiceConfig` (also available on `registerPeriodicTask`) is part of the Pigeon platform contract in `workmanager_platform_interface` and has sane defaults for every field:

| Field | Default |
| --- | --- |
| `notificationTitle` | `Task in progress` |
| `notificationText` | `Your task is still running` |
| `notificationChannelId` | `workmanager_foreground_tasks` |
| `notificationChannelName` | `Long-running tasks` |
| `notificationId` | `0` |
| `foregroundServiceType` | `ForegroundServiceType.dataSync` |

Supported types: `dataSync` (default) and `shortService`.

## How it works

- The config travels through the existing Pigeon request into the WorkRequest input data (reserved key, never exposed to the Dart callback).
- `BackgroundWorker` calls `setForegroundAsync` immediately at `startWork` and chains the returned future into the worker result (WorkManager contract), so the notification and process boost are in place while the Dart engine spins up.
- A failed foreground promotion degrades gracefully: the task keeps running as a regular background worker and the error is surfaced through the debug handler.
- The plugin manifest merges `android:foregroundServiceType="dataSync|shortService"` onto WorkManager's `SystemForegroundService` and declares the Android 14+ type permissions (`FOREGROUND_SERVICE_DATA_SYNC`, `FOREGROUND_SERVICE_SHORT_SERVICE`), so no native setup is required.

## Verification

- `flutter analyze` clean on all four packages
- `dart format` clean (CI command reproduced)
- ktlint 1.7.1 clean on changed Kotlin
- Dart tests: workmanager (14), workmanager_android (26, incl. new config tests), workmanager_apple (24)
- Native JVM tests: 24 passed incl. new `ForegroundServiceConfigTest` (round-trip through WorkManager `Data`, periodic request embedding)
- `example` debug APK builds; merged manifest verified to contain a single `SystemForegroundService` entry with `foregroundServiceType=0x801` and all required permissions
- `melos run generate` reproduces committed generated files

## Docs

New "Long-running tasks (foreground service)" section in `docs/quickstart.mdx` plus a README blurb, covering Android 13+ notification permission, Android 14+ type requirements, and Android 15+ limitations (dataSync 6h cap, BOOT_COMPLETED start restrictions).

Fixes #573. Closes the feature request in #236.