### PR TITLE
feat(ios): add BGContinuedProcessingTask support (fixes #638)

### DIFF
--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -252,12 +252,66 @@ the plugin cannot validate this for you. See the capability matrix in the docs
 index for the full iOS strategy comparison.
 </Warning>
 
+#### Option E: Continued Processing Tasks (iOS 26+)
+For workloads that must **begin immediately or shortly after submission** and
+are allowed to **continue running while the app is backgrounded** (e.g. ML
+inference on a captured camera session) — `BGContinuedProcessingTaskRequest`.
+The system shows a Live Activity to the user while the task runs.
+
+1. **Enable Background Modes** and add the identifier to Info.plist:
+   Continued-processing identifiers must use **wildcard notation** ending in
+   `.*`, with a prefix containing your app's bundle identifier:
+```xml
+<key>UIBackgroundModes</key>
+<array>
+    <string>processing</string>
+</array>
+
+<key>BGTaskSchedulerPermittedIdentifiers</key>
+<array>
+    <string>com.yourapp.continuedProcessing.*</string>
+</array>
+```
+
+2. **(Optional) Pre-register the launch handler** in `AppDelegate.swift`:
+```swift
+import workmanager_apple
+
+// In application didFinishLaunching
+WorkmanagerPlugin.registerBGContinuedProcessingTask(
+  withIdentifier: "com.yourapp.continuedProcessing.*"
+)
+```
+The plugin also registers the handler automatically at schedule time and on
+the next app launch.
+
+3. **Schedule from Dart** (iOS 26+; older iOS versions receive an error):
+```dart
+await Workmanager().registerContinuedProcessingTask(
+  'com.yourapp.continuedProcessing.*',
+  'continuedProcessingTask',
+  title: 'Example continued processing',
+  subtitle: 'Processing in progress',
+  inputData: {'frames': 120},
+);
+```
+
+<Warning>
+**Differences vs processing tasks:** continued processing tasks start near
+submission time (the scheduler ignores `initialDelay`) and are not limited to
+idle devices, but the system still enforces expiration based on system
+conditions and user input. Apple expects tasks to report progress
+(`NSProgress`); the plugin does not currently plumb progress from Dart, so
+callbacks that appear stalled may be expired by the scheduler.
+</Warning>
+
 <Success>
 **Which option to choose?** 
 - **Option A (Background Fetch)** for non-critical updates that can happen once daily (data sync, content refresh)
 - **Option B (BGTaskScheduler)** for one-time tasks, file uploads, or immediate task scheduling  
 - **Option C (Periodic Tasks)** for regular tasks with custom frequency control (15+ minutes)
 - **Option D (Health Research Tasks)** for iOS 17+ health research study apps that need reliable background processing
+- **Option E (Continued Processing Tasks)** for iOS 26+ workloads that must start now and continue while backgrounded
 </Success>
 
 ### macOS

--- a/example/integration_test/workmanager_integration_test.dart
+++ b/example/integration_test/workmanager_integration_test.dart
@@ -377,6 +377,48 @@ void main() {
       }
     });
 
+    testWidgets('registerContinuedProcessingTask should work on iOS 26+',
+        (WidgetTester tester) async {
+      await workmanager.initialize(callbackDispatcher);
+
+      // BGContinuedProcessingTask requires wildcard identifiers ending in '.*'
+      // whose prefix contains the app bundle identifier.
+      const continuedProcessingIdentifier =
+          'dev.fluttercommunity.workmanagerExample.continuedProcessing.*';
+
+      if (Platform.isIOS) {
+        try {
+          await workmanager.registerContinuedProcessingTask(
+            continuedProcessingIdentifier,
+            'continuedProcessingTask',
+            title: 'Example continued processing',
+            subtitle: 'Processing in progress',
+            inputData: {'continued': 'processing'},
+          );
+          // Clean up
+          await workmanager.cancelByUniqueName(continuedProcessingIdentifier);
+        } on PlatformException catch (e) {
+          // iOS < 26 or the simulator test environment may reject the
+          // submission; both are expected.
+          if (e.code.contains('bgTaskSchedulingFailed') ||
+              e.message?.contains('ContinuedProcessingTask') == true) {
+            // Expected in test environment
+          } else {
+            rethrow;
+          }
+        }
+      } else {
+        // Should throw UnsupportedError on Android/macOS
+        expect(
+          () => workmanager.registerContinuedProcessingTask(
+            continuedProcessingIdentifier,
+            'continuedProcessingTask',
+          ),
+          throwsA(isA<UnsupportedError>()),
+        );
+      }
+    });
+
     testWidgets('cancelByUniqueName should succeed',
         (WidgetTester tester) async {
       await workmanager.initialize(callbackDispatcher);

--- a/example/ios/Runner/Info.plist
+++ b/example/ios/Runner/Info.plist
@@ -15,6 +15,7 @@
 		<string>dev.fluttercommunity.workmanagerExample.iOSBackgroundProcessingTask</string>
 		<string>dev.fluttercommunity.integrationTest.dataTransferTask</string>
 		<string>dev.fluttercommunity.integrationTest.retryTask</string>
+		<string>dev.fluttercommunity.workmanagerExample.continuedProcessing.*</string>
 	</array>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>

--- a/example/ios/RunnerTests/WorkmanagerTests.swift
+++ b/example/ios/RunnerTests/WorkmanagerTests.swift
@@ -139,6 +139,19 @@ class WorkmanagerTests: XCTestCase {
         XCTAssertNil(stored?.earliestBeginInSeconds)
     }
 
+    func testScheduledTaskRoundTripPreservesContinuedProcessingKind() {
+        let identifier = "dev.fluttercommunity.test.continuedProcessing"
+        UserDefaultsHelper.storeScheduledTask(
+            ScheduledTaskInfo(kind: .continuedProcessing, earliestBeginInSeconds: nil),
+            forTaskIdentifier: identifier
+        )
+
+        let stored = UserDefaultsHelper.getScheduledTasks()[identifier]
+        XCTAssertNotNil(stored, "stored task should be retrievable")
+        XCTAssertEqual(stored?.kind, .continuedProcessing)
+        XCTAssertNil(stored?.earliestBeginInSeconds)
+    }
+
     func testRemoveScheduledTaskOnlyRemovesMatchingIdentifier() {
         let keepIdentifier = "dev.fluttercommunity.test.keep"
         let removeIdentifier = "dev.fluttercommunity.test.remove"

--- a/workmanager/lib/src/workmanager_impl.dart
+++ b/workmanager/lib/src/workmanager_impl.dart
@@ -389,6 +389,56 @@ class Workmanager {
     );
   }
 
+  /// Register a continued processing task (iOS 26+ only).
+  ///
+  /// Continued processing tasks are scheduled with
+  /// [BGContinuedProcessingTaskRequest](https://developer.apple.com/documentation/backgroundtasks/bgcontinuedprocessingtaskrequest),
+  /// which begins immediately or shortly after submission and is allowed to
+  /// continue running even if the app is backgrounded. The system presents a
+  /// Live Activity to the user while the task is in progress.
+  ///
+  /// Availability:
+  /// - iOS 26+ only. On older iOS versions the call fails with a Pigeon error.
+  /// - Android and macOS do not support this task type.
+  ///
+  /// App requirements (checked by Apple at submission time, not by this
+  /// plugin):
+  /// - The [uniqueName] must use wildcard notation ending in `.*`, with a
+  ///   prefix that contains the app's bundle identifier (e.g.
+  ///   `com.example.app.continuedProcessing.*`).
+  /// - The identifier must be listed in `BGTaskSchedulerPermittedIdentifiers`
+  ///   in Info.plist, and `UIBackgroundModes` must include `processing`.
+  ///
+  /// Unlike processing tasks, continued processing tasks are not limited to
+  /// idle devices, but the system still enforces expiration based on changing
+  /// system conditions and user input. Tasks are expected to report progress
+  /// (NSProgress); the plugin does not currently plumb progress from Dart, so
+  /// very long-running callbacks that appear stalled may be expired by the
+  /// scheduler.
+  ///
+  /// [uniqueName] is a required unique identifier for the task.
+  /// [taskName] is the value returned in the [BackgroundTaskHandler]; on iOS
+  /// the handler receives the BGTaskScheduler identifier (the [uniqueName]).
+  /// [title] and [subtitle] are the localized strings shown to the user in
+  /// the Live Activity while the task runs.
+  /// [inputData] is the input data for the task (int, bool, double, String
+  /// and their lists).
+  Future<void> registerContinuedProcessingTask(
+    String uniqueName,
+    String taskName, {
+    String? title,
+    String? subtitle,
+    Map<String, dynamic>? inputData,
+  }) async {
+    return _platform.registerContinuedProcessingTask(
+      uniqueName,
+      taskName,
+      title: title,
+      subtitle: subtitle,
+      inputData: inputData,
+    );
+  }
+
   /// Cancels task by [uniqueName]
   Future<void> cancelByUniqueName(String uniqueName) async =>
       _platform.cancelByUniqueName(uniqueName);

--- a/workmanager/test/workmanager_test.mocks.dart
+++ b/workmanager/test/workmanager_test.mocks.dart
@@ -196,6 +196,31 @@ class MockWorkmanager extends _i1.Mock implements _i2.Workmanager {
       ) as _i3.Future<void>);
 
   @override
+  _i3.Future<void> registerContinuedProcessingTask(
+    String? uniqueName,
+    String? taskName, {
+    String? title,
+    String? subtitle,
+    Map<String, dynamic>? inputData,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #registerContinuedProcessingTask,
+          [
+            uniqueName,
+            taskName,
+          ],
+          {
+            #title: title,
+            #subtitle: subtitle,
+            #inputData: inputData,
+          },
+        ),
+        returnValue: _i3.Future<void>.value(),
+        returnValueForMissingStub: _i3.Future<void>.value(),
+      ) as _i3.Future<void>);
+
+  @override
   _i3.Future<void> cancelByUniqueName(String? uniqueName) =>
       (super.noSuchMethod(
         Invocation.method(

--- a/workmanager_android/android/src/main/kotlin/dev/fluttercommunity/workmanager/WorkmanagerPlugin.kt
+++ b/workmanager_android/android/src/main/kotlin/dev/fluttercommunity/workmanager/WorkmanagerPlugin.kt
@@ -1,7 +1,8 @@
 package dev.fluttercommunity.workmanager
 
-import dev.fluttercommunity.workmanager.pigeon.InitializeRequest
+import dev.fluttercommunity.workmanager.pigeon.ContinuedProcessingTaskRequest
 import dev.fluttercommunity.workmanager.pigeon.HealthResearchTaskRequest
+import dev.fluttercommunity.workmanager.pigeon.InitializeRequest
 import dev.fluttercommunity.workmanager.pigeon.OneOffTaskRequest
 import dev.fluttercommunity.workmanager.pigeon.PeriodicTaskRequest
 import dev.fluttercommunity.workmanager.pigeon.ProcessingTaskRequest
@@ -113,6 +114,20 @@ class WorkmanagerPlugin :
             Result.failure(
                 UnsupportedOperationException(
                     "Health research tasks are not supported on Android",
+                ),
+            ),
+        )
+    }
+
+    override fun registerContinuedProcessingTask(
+        request: ContinuedProcessingTaskRequest,
+        callback: (Result<Unit>) -> Unit,
+    ) {
+        // Continued processing tasks are iOS 26+-specific
+        callback(
+            Result.failure(
+                UnsupportedOperationException(
+                    "Continued processing tasks are not supported on Android",
                 ),
             ),
         )

--- a/workmanager_android/android/src/main/kotlin/dev/fluttercommunity/workmanager/pigeon/WorkmanagerApi.g.kt
+++ b/workmanager_android/android/src/main/kotlin/dev/fluttercommunity/workmanager/pigeon/WorkmanagerApi.g.kt
@@ -857,6 +857,56 @@ data class HealthResearchTaskRequest (
     return result
   }
 }
+
+/** Generated class from Pigeon that represents data sent in messages. */
+data class ContinuedProcessingTaskRequest (
+  val uniqueName: String,
+  val taskName: String,
+  val title: String? = null,
+  val subtitle: String? = null,
+  val inputData: Map<String?, Any?>? = null
+)
+ {
+  companion object {
+    fun fromList(pigeonVar_list: List<Any?>): ContinuedProcessingTaskRequest {
+      val uniqueName = pigeonVar_list[0] as String
+      val taskName = pigeonVar_list[1] as String
+      val title = pigeonVar_list[2] as String?
+      val subtitle = pigeonVar_list[3] as String?
+      val inputData = pigeonVar_list[4] as Map<String?, Any?>?
+      return ContinuedProcessingTaskRequest(uniqueName, taskName, title, subtitle, inputData)
+    }
+  }
+  fun toList(): List<Any?> {
+    return listOf(
+      uniqueName,
+      taskName,
+      title,
+      subtitle,
+      inputData,
+    )
+  }
+  override fun equals(other: Any?): Boolean {
+    if (other == null || other.javaClass != javaClass) {
+      return false
+    }
+    if (this === other) {
+      return true
+    }
+    val other = other as ContinuedProcessingTaskRequest
+    return WorkmanagerApiPigeonUtils.deepEquals(this.uniqueName, other.uniqueName) && WorkmanagerApiPigeonUtils.deepEquals(this.taskName, other.taskName) && WorkmanagerApiPigeonUtils.deepEquals(this.title, other.title) && WorkmanagerApiPigeonUtils.deepEquals(this.subtitle, other.subtitle) && WorkmanagerApiPigeonUtils.deepEquals(this.inputData, other.inputData)
+  }
+
+  override fun hashCode(): Int {
+    var result = javaClass.hashCode()
+    result = 31 * result + WorkmanagerApiPigeonUtils.deepHash(this.uniqueName)
+    result = 31 * result + WorkmanagerApiPigeonUtils.deepHash(this.taskName)
+    result = 31 * result + WorkmanagerApiPigeonUtils.deepHash(this.title)
+    result = 31 * result + WorkmanagerApiPigeonUtils.deepHash(this.subtitle)
+    result = 31 * result + WorkmanagerApiPigeonUtils.deepHash(this.inputData)
+    return result
+  }
+}
 private open class WorkmanagerApiPigeonCodec : StandardMessageCodec() {
   override fun readValueOfType(type: Byte, buffer: ByteBuffer): Any? {
     return when (type) {
@@ -935,6 +985,11 @@ private open class WorkmanagerApiPigeonCodec : StandardMessageCodec() {
           HealthResearchTaskRequest.fromList(it)
         }
       }
+      144.toByte() -> {
+        return (readValue(buffer) as? List<Any?>)?.let {
+          ContinuedProcessingTaskRequest.fromList(it)
+        }
+      }
       else -> super.readValueOfType(type, buffer)
     }
   }
@@ -1000,6 +1055,10 @@ private open class WorkmanagerApiPigeonCodec : StandardMessageCodec() {
         stream.write(143)
         writeValue(stream, value.toList())
       }
+      is ContinuedProcessingTaskRequest -> {
+        stream.write(144)
+        writeValue(stream, value.toList())
+      }
       else -> super.writeValue(stream, value)
     }
   }
@@ -1013,6 +1072,7 @@ interface WorkmanagerHostApi {
   fun registerPeriodicTask(request: PeriodicTaskRequest, callback: (Result<Unit>) -> Unit)
   fun registerProcessingTask(request: ProcessingTaskRequest, callback: (Result<Unit>) -> Unit)
   fun registerHealthResearchTask(request: HealthResearchTaskRequest, callback: (Result<Unit>) -> Unit)
+  fun registerContinuedProcessingTask(request: ContinuedProcessingTaskRequest, callback: (Result<Unit>) -> Unit)
   fun cancelByUniqueName(uniqueName: String, callback: (Result<Unit>) -> Unit)
   fun cancelByTag(tag: String, callback: (Result<Unit>) -> Unit)
   fun cancelAll(callback: (Result<Unit>) -> Unit)
@@ -1111,6 +1171,25 @@ interface WorkmanagerHostApi {
             val args = message as List<Any?>
             val requestArg = args[0] as HealthResearchTaskRequest
             api.registerHealthResearchTask(requestArg) { result: Result<Unit> ->
+              val error = result.exceptionOrNull()
+              if (error != null) {
+                reply.reply(WorkmanagerApiPigeonUtils.wrapError(error))
+              } else {
+                reply.reply(WorkmanagerApiPigeonUtils.wrapResult(null))
+              }
+            }
+          }
+        } else {
+          channel.setMessageHandler(null)
+        }
+      }
+      run {
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.workmanager_platform_interface.WorkmanagerHostApi.registerContinuedProcessingTask$separatedMessageChannelSuffix", codec)
+        if (api != null) {
+          channel.setMessageHandler { message, reply ->
+            val args = message as List<Any?>
+            val requestArg = args[0] as ContinuedProcessingTaskRequest
+            api.registerContinuedProcessingTask(requestArg) { result: Result<Unit> ->
               val error = result.exceptionOrNull()
               if (error != null) {
                 reply.reply(WorkmanagerApiPigeonUtils.wrapError(error))

--- a/workmanager_android/lib/workmanager_android.dart
+++ b/workmanager_android/lib/workmanager_android.dart
@@ -124,6 +124,19 @@ class WorkmanagerAndroid extends WorkmanagerPlatform {
   }
 
   @override
+  Future<void> registerContinuedProcessingTask(
+    String uniqueName,
+    String taskName, {
+    String? title,
+    String? subtitle,
+    Map<String, dynamic>? inputData,
+  }) async {
+    // Continued processing tasks are iOS 26+-specific, so this is a no-op on Android
+    throw UnsupportedError(
+        'Continued processing tasks are not supported on Android');
+  }
+
+  @override
   Future<void> cancelByUniqueName(String uniqueName) async {
     await _api.cancelByUniqueName(uniqueName);
   }

--- a/workmanager_apple/ios/workmanager_apple/Sources/workmanager_apple/BGContinuedProcessingTaskScheduler.swift
+++ b/workmanager_apple/ios/workmanager_apple/Sources/workmanager_apple/BGContinuedProcessingTaskScheduler.swift
@@ -1,0 +1,155 @@
+import Foundation
+
+#if os(iOS)
+import BackgroundTasks
+#endif
+
+/// Registration, scheduling and execution of BGContinuedProcessingTask (iOS 26+).
+///
+/// Continued processing tasks begin immediately or shortly after submission
+/// and continue running while the app is backgrounded. This API surface lives
+/// in its own file (mirroring the other task-type files) to keep
+/// `WorkmanagerPlugin.swift` within SwiftLint's file length limit.
+extension WorkmanagerPlugin {
+    // MARK: - WorkmanagerHostApi implementation (iOS)
+
+    #if os(iOS)
+    func registerContinuedProcessingTask(
+        request: ContinuedProcessingTaskRequest,
+        completion: @escaping (Result<Void, Error>) -> Void
+    ) {
+        guard validateCallbackHandle() else {
+            completion(.failure(createInitializationError()))
+            return
+        }
+
+        guard #available(iOS 26.0, *) else {
+            completion(.failure(PigeonError(
+                code: "99",
+                message: "ContinuedProcessingTask could not be registered",
+                details: "BGContinuedProcessingTaskRequest is only supported on iOS 26+"
+            )))
+            return
+        }
+
+        // The task is meant to begin immediately or shortly after submission;
+        // the scheduler ignores `earliestBeginDate`, so there is no
+        // initialDelay. Persist inputData keyed by the task identifier so it
+        // is available when the task is delivered (mirroring the periodic and
+        // health research task paths).
+        UserDefaultsHelper.storePeriodicTaskInputData(
+            request.inputData as? [String: Any],
+            forTaskIdentifier: request.uniqueName
+        )
+
+        WorkmanagerPlugin.scheduleContinuedProcessingTask(
+            withIdentifier: request.uniqueName,
+            title: request.title ?? request.taskName,
+            subtitle: request.subtitle ?? ""
+        )
+
+        let taskInfo = TaskDebugInfo(
+            taskName: request.taskName,
+            uniqueName: request.uniqueName,
+            inputData: request.inputData as? [String: Any],
+            startTime: Date().timeIntervalSince1970
+        )
+        WorkmanagerDebug.getCurrent().onTaskStatusUpdate(taskInfo: taskInfo, status: .scheduled, result: nil)
+        completion(.success(()))
+    }
+    #elseif os(macOS)
+    func registerContinuedProcessingTask(
+        request: ContinuedProcessingTaskRequest,
+        completion: @escaping (Result<Void, Error>) -> Void
+    ) {
+        // BGContinuedProcessingTaskRequest is iOS 26+-only and presents a Live
+        // Activity while running; it is not available on macOS.
+        completion(.failure(PigeonError(
+            code: "99",
+            message: "ContinuedProcessingTask could not be registered",
+            details: "BGContinuedProcessingTaskRequest is only supported on iOS 26+"
+        )))
+    }
+    #endif
+
+    // MARK: - Continued processing task scheduling (iOS only)
+
+    #if os(iOS)
+    /// Registers a continued processing task with iOS BGTaskScheduler.
+    ///
+    /// Continued processing tasks (iOS 26+) begin immediately or shortly after
+    /// submission and are allowed to continue running while the app is
+    /// backgrounded. The identifier must use wildcard notation ending in `.*`
+    /// (e.g. `<bundleID>.<context>.*`) and be listed in
+    /// `BGTaskSchedulerPermittedIdentifiers` in Info.plist.
+    ///
+    /// - Parameter identifier: Unique task identifier that matches the one used in Dart
+    @objc
+    public static func registerBGContinuedProcessingTask(withIdentifier identifier: String) {
+        guard #available(iOS 26.0, *) else {
+            return
+        }
+        UserDefaultsHelper.storeScheduledTask(
+            ScheduledTaskInfo(kind: .continuedProcessing, earliestBeginInSeconds: nil),
+            forTaskIdentifier: identifier
+        )
+        registerLaunchHandlerOnce(forTaskWithIdentifier: identifier, earliestBeginInSeconds: nil)
+    }
+
+    @available(iOS 26.0, *)
+    private static func scheduleContinuedProcessingTask(
+        withIdentifier uniqueTaskIdentifier: String,
+        title: String,
+        subtitle: String
+    ) {
+        let request = BGContinuedProcessingTaskRequest(
+            identifier: uniqueTaskIdentifier,
+            title: title,
+            subtitle: subtitle
+        )
+
+        do {
+            try BGTaskScheduler.shared.submit(request)
+            logInfo("BGContinuedProcessingTask submitted \(uniqueTaskIdentifier)")
+            UserDefaultsHelper.storeScheduledTask(
+                ScheduledTaskInfo(kind: .continuedProcessing, earliestBeginInSeconds: nil),
+                forTaskIdentifier: uniqueTaskIdentifier
+            )
+            registerLaunchHandlerOnce(forTaskWithIdentifier: uniqueTaskIdentifier, earliestBeginInSeconds: nil)
+        } catch {
+            logInfo(
+                "Could not schedule BGContinuedProcessingTask identifier:\(uniqueTaskIdentifier) " +
+                    "error:\(error.localizedDescription)"
+            )
+            logInfo(
+                "Possible issues: iOS 26+ required, the identifier must end with '.*' " +
+                    "(e.g. <bundleID>.<context>.*), or the task name is not registered " +
+                    "in BGTaskSchedulerPermittedIdentifiers"
+            )
+        }
+    }
+
+    /// Handles execution of a continued processing background task.
+    ///
+    /// BGContinuedProcessingTask starts near submission time and can continue
+    /// while the app is backgrounded; the system still enforces an expiration
+    /// based on changing system conditions (the handler cancels the operation).
+    @available(iOS 26.0, *)
+    static func handleBGContinuedProcessingTask(identifier: String, task: BGContinuedProcessingTask) {
+        let operationQueue = OperationQueue()
+        // Deliver the inputData stored at registration time (mirroring the
+        // periodic task path, keyed by task identifier).
+        let storedInputData = UserDefaultsHelper.getStoredPeriodicTaskInputData(forTaskIdentifier: task.identifier)
+        let operation = createBackgroundOperation(
+            identifier: task.identifier,
+            inputData: storedInputData,
+            backgroundMode: .backgroundContinuedProcessingTask(identifier: identifier)
+        )
+
+        task.expirationHandler = { operation.cancel() }
+        operation.completionBlock = { task.setTaskCompleted(success: !operation.isCancelled) }
+
+        operationQueue.addOperation(operation)
+    }
+    #endif
+}

--- a/workmanager_apple/ios/workmanager_apple/Sources/workmanager_apple/BackgroundWorker.swift
+++ b/workmanager_apple/ios/workmanager_apple/Sources/workmanager_apple/BackgroundWorker.swift
@@ -30,6 +30,7 @@ enum BackgroundMode {
     case backgroundPeriodicTask(identifier: String)
     case backgroundOneOffTask(identifier: String)
     case backgroundHealthResearchTask(identifier: String)
+    case backgroundContinuedProcessingTask(identifier: String)
 
     var flutterThreadlabelPrefix: String {
         switch self {
@@ -43,6 +44,8 @@ enum BackgroundMode {
             return "\(WorkmanagerPlugin.identifier).OneOffTask"
         case .backgroundHealthResearchTask:
             return "\(WorkmanagerPlugin.identifier).HealthResearchTask"
+        case .backgroundContinuedProcessingTask:
+            return "\(WorkmanagerPlugin.identifier).ContinuedProcessingTask"
         }
     }
 
@@ -57,6 +60,8 @@ enum BackgroundMode {
         case let .backgroundOneOffTask(identifier):
             return ["\(WorkmanagerPlugin.identifier).DART_TASK": identifier]
         case let .backgroundHealthResearchTask(identifier):
+            return ["\(WorkmanagerPlugin.identifier).DART_TASK": identifier]
+        case let .backgroundContinuedProcessingTask(identifier):
             return ["\(WorkmanagerPlugin.identifier).DART_TASK": identifier]
         }
     }

--- a/workmanager_apple/ios/workmanager_apple/Sources/workmanager_apple/UserDefaultsHelper.swift
+++ b/workmanager_apple/ios/workmanager_apple/Sources/workmanager_apple/UserDefaultsHelper.swift
@@ -12,6 +12,7 @@ enum ScheduledTaskKind: String, Codable {
     case refresh
     case processing
     case healthResearch
+    case continuedProcessing
 }
 
 /// Metadata persisted for a scheduled BGTask identifier so launch handlers

--- a/workmanager_apple/ios/workmanager_apple/Sources/workmanager_apple/WorkmanagerPlugin.swift
+++ b/workmanager_apple/ios/workmanager_apple/Sources/workmanager_apple/WorkmanagerPlugin.swift
@@ -202,50 +202,6 @@ public class WorkmanagerPlugin: WorkmanagerPluginBase, FlutterPlugin, Workmanage
         completion(.success(()))
     }
 
-    func registerContinuedProcessingTask(
-        request: ContinuedProcessingTaskRequest,
-        completion: @escaping (Result<Void, Error>) -> Void
-    ) {
-        guard validateCallbackHandle() else {
-            completion(.failure(createInitializationError()))
-            return
-        }
-
-        guard #available(iOS 26.0, *) else {
-            completion(.failure(PigeonError(
-                code: "99",
-                message: "ContinuedProcessingTask could not be registered",
-                details: "BGContinuedProcessingTaskRequest is only supported on iOS 26+"
-            )))
-            return
-        }
-
-        // The task is meant to begin immediately or shortly after submission;
-        // the scheduler ignores `earliestBeginDate`, so there is no
-        // initialDelay. Persist inputData keyed by the task identifier so it
-        // is available when the task is delivered (mirroring the periodic and
-        // health research task paths).
-        UserDefaultsHelper.storePeriodicTaskInputData(
-            request.inputData as? [String: Any],
-            forTaskIdentifier: request.uniqueName
-        )
-
-        WorkmanagerPlugin.scheduleContinuedProcessingTask(
-            withIdentifier: request.uniqueName,
-            title: request.title ?? request.taskName,
-            subtitle: request.subtitle ?? ""
-        )
-
-        let taskInfo = TaskDebugInfo(
-            taskName: request.taskName,
-            uniqueName: request.uniqueName,
-            inputData: request.inputData as? [String: Any],
-            startTime: Date().timeIntervalSince1970
-        )
-        WorkmanagerDebug.getCurrent().onTaskStatusUpdate(taskInfo: taskInfo, status: .scheduled, result: nil)
-        completion(.success(()))
-    }
-
     func cancelByUniqueName(uniqueName: String, completion: @escaping (Result<Void, Error>) -> Void) {
         executeIfSupportedVoid(completion: completion, feature: "cancelByUniqueName") {
             BGTaskScheduler.shared.cancel(taskRequestWithIdentifier: uniqueName)
@@ -300,11 +256,11 @@ public class WorkmanagerPlugin: WorkmanagerPluginBase, FlutterPlugin, Workmanage
 
     // MARK: - Helper methods
 
-    private func validateCallbackHandle() -> Bool {
+    func validateCallbackHandle() -> Bool {
         return UserDefaultsHelper.getStoredCallbackHandle() != nil
     }
 
-    private func createInitializationError() -> PigeonError {
+    func createInitializationError() -> PigeonError {
         return PigeonError(
             code: "1",
             message: "You have not properly initialized the Flutter WorkManager Package. " +
@@ -431,19 +387,6 @@ extension WorkmanagerPlugin {
             code: "99",
             message: "HealthResearchTask could not be registered",
             details: "BGHealthResearchTaskRequest is only supported on iOS 17+"
-        )))
-    }
-
-    func registerContinuedProcessingTask(
-        request: ContinuedProcessingTaskRequest,
-        completion: @escaping (Result<Void, Error>) -> Void
-    ) {
-        // BGContinuedProcessingTaskRequest is iOS 26+-only and presents a Live
-        // Activity while running; it is not available on macOS.
-        completion(.failure(PigeonError(
-            code: "99",
-            message: "ContinuedProcessingTask could not be registered",
-            details: "BGContinuedProcessingTaskRequest is only supported on iOS 26+"
         )))
     }
 
@@ -790,27 +733,6 @@ extension WorkmanagerPlugin {
         registerLaunchHandlerOnce(forTaskWithIdentifier: identifier, earliestBeginInSeconds: nil)
     }
 
-    /// Registers a continued processing task with iOS BGTaskScheduler.
-    ///
-    /// Continued processing tasks (iOS 26+) begin immediately or shortly after
-    /// submission and are allowed to continue running while the app is
-    /// backgrounded. The identifier must use wildcard notation ending in `.*`
-    /// (e.g. `<bundleID>.<context>.*`) and be listed in
-    /// `BGTaskSchedulerPermittedIdentifiers` in Info.plist.
-    ///
-    /// - Parameter identifier: Unique task identifier that matches the one used in Dart
-    @objc
-    public static func registerBGContinuedProcessingTask(withIdentifier identifier: String) {
-        guard #available(iOS 26.0, *) else {
-            return
-        }
-        UserDefaultsHelper.storeScheduledTask(
-            ScheduledTaskInfo(kind: .continuedProcessing, earliestBeginInSeconds: nil),
-            forTaskIdentifier: identifier
-        )
-        registerLaunchHandlerOnce(forTaskWithIdentifier: identifier, earliestBeginInSeconds: nil)
-    }
-
     @objc
     @available(iOS 13.0, *)
     private static func scheduleBackgroundProcessingTask(
@@ -838,39 +760,6 @@ extension WorkmanagerPlugin {
         }
     }
 
-    @available(iOS 26.0, *)
-    private static func scheduleContinuedProcessingTask(
-        withIdentifier uniqueTaskIdentifier: String,
-        title: String,
-        subtitle: String
-    ) {
-        let request = BGContinuedProcessingTaskRequest(
-            identifier: uniqueTaskIdentifier,
-            title: title,
-            subtitle: subtitle
-        )
-
-        do {
-            try BGTaskScheduler.shared.submit(request)
-            logInfo("BGContinuedProcessingTask submitted \(uniqueTaskIdentifier)")
-            UserDefaultsHelper.storeScheduledTask(
-                ScheduledTaskInfo(kind: .continuedProcessing, earliestBeginInSeconds: nil),
-                forTaskIdentifier: uniqueTaskIdentifier
-            )
-            registerLaunchHandlerOnce(forTaskWithIdentifier: uniqueTaskIdentifier, earliestBeginInSeconds: nil)
-        } catch {
-            logInfo(
-                "Could not schedule BGContinuedProcessingTask identifier:\(uniqueTaskIdentifier) " +
-                    "error:\(error.localizedDescription)"
-            )
-            logInfo(
-                "Possible issues: iOS 26+ required, the identifier must end with '.*' " +
-                    "(e.g. <bundleID>.<context>.*), or the task name is not registered " +
-                    "in BGTaskSchedulerPermittedIdentifiers"
-            )
-        }
-    }
-
     /// Handles execution of a health research background task.
     ///
     /// BGHealthResearchTask is a subclass of BGProcessingTask: the task can
@@ -886,29 +775,6 @@ extension WorkmanagerPlugin {
             identifier: task.identifier,
             inputData: storedInputData,
             backgroundMode: .backgroundHealthResearchTask(identifier: identifier)
-        )
-
-        task.expirationHandler = { operation.cancel() }
-        operation.completionBlock = { task.setTaskCompleted(success: !operation.isCancelled) }
-
-        operationQueue.addOperation(operation)
-    }
-
-    /// Handles execution of a continued processing background task.
-    ///
-    /// BGContinuedProcessingTask starts near submission time and can continue
-    /// while the app is backgrounded; the system still enforces an expiration
-    /// based on changing system conditions (the handler cancels the operation).
-    @available(iOS 26.0, *)
-    private static func handleBGContinuedProcessingTask(identifier: String, task: BGContinuedProcessingTask) {
-        let operationQueue = OperationQueue()
-        // Deliver the inputData stored at registration time (mirroring the
-        // periodic task path, keyed by task identifier).
-        let storedInputData = UserDefaultsHelper.getStoredPeriodicTaskInputData(forTaskIdentifier: task.identifier)
-        let operation = createBackgroundOperation(
-            identifier: task.identifier,
-            inputData: storedInputData,
-            backgroundMode: .backgroundContinuedProcessingTask(identifier: identifier)
         )
 
         task.expirationHandler = { operation.cancel() }
@@ -950,7 +816,7 @@ extension WorkmanagerPlugin {
     /// (BGHealthResearchTask) identifiers can be re-registered from persisted
     /// state at app launch.
     @available(iOS 13.0, *)
-    private static func registerLaunchHandlerOnce(
+    static func registerLaunchHandlerOnce(
         forTaskWithIdentifier identifier: String,
         earliestBeginInSeconds: NSNumber?
     ) {
@@ -1047,7 +913,7 @@ extension WorkmanagerPlugin {
     }
 
     @available(iOS 13.0, *)
-    private static func createBackgroundOperation(
+    static func createBackgroundOperation(
         identifier: String,
         inputData: [String: Any]?,
         backgroundMode: BackgroundMode

--- a/workmanager_apple/ios/workmanager_apple/Sources/workmanager_apple/WorkmanagerPlugin.swift
+++ b/workmanager_apple/ios/workmanager_apple/Sources/workmanager_apple/WorkmanagerPlugin.swift
@@ -202,6 +202,50 @@ public class WorkmanagerPlugin: WorkmanagerPluginBase, FlutterPlugin, Workmanage
         completion(.success(()))
     }
 
+    func registerContinuedProcessingTask(
+        request: ContinuedProcessingTaskRequest,
+        completion: @escaping (Result<Void, Error>) -> Void
+    ) {
+        guard validateCallbackHandle() else {
+            completion(.failure(createInitializationError()))
+            return
+        }
+
+        guard #available(iOS 26.0, *) else {
+            completion(.failure(PigeonError(
+                code: "99",
+                message: "ContinuedProcessingTask could not be registered",
+                details: "BGContinuedProcessingTaskRequest is only supported on iOS 26+"
+            )))
+            return
+        }
+
+        // The task is meant to begin immediately or shortly after submission;
+        // the scheduler ignores `earliestBeginDate`, so there is no
+        // initialDelay. Persist inputData keyed by the task identifier so it
+        // is available when the task is delivered (mirroring the periodic and
+        // health research task paths).
+        UserDefaultsHelper.storePeriodicTaskInputData(
+            request.inputData as? [String: Any],
+            forTaskIdentifier: request.uniqueName
+        )
+
+        WorkmanagerPlugin.scheduleContinuedProcessingTask(
+            withIdentifier: request.uniqueName,
+            title: request.title ?? request.taskName,
+            subtitle: request.subtitle ?? ""
+        )
+
+        let taskInfo = TaskDebugInfo(
+            taskName: request.taskName,
+            uniqueName: request.uniqueName,
+            inputData: request.inputData as? [String: Any],
+            startTime: Date().timeIntervalSince1970
+        )
+        WorkmanagerDebug.getCurrent().onTaskStatusUpdate(taskInfo: taskInfo, status: .scheduled, result: nil)
+        completion(.success(()))
+    }
+
     func cancelByUniqueName(uniqueName: String, completion: @escaping (Result<Void, Error>) -> Void) {
         executeIfSupportedVoid(completion: completion, feature: "cancelByUniqueName") {
             BGTaskScheduler.shared.cancel(taskRequestWithIdentifier: uniqueName)
@@ -387,6 +431,19 @@ extension WorkmanagerPlugin {
             code: "99",
             message: "HealthResearchTask could not be registered",
             details: "BGHealthResearchTaskRequest is only supported on iOS 17+"
+        )))
+    }
+
+    func registerContinuedProcessingTask(
+        request: ContinuedProcessingTaskRequest,
+        completion: @escaping (Result<Void, Error>) -> Void
+    ) {
+        // BGContinuedProcessingTaskRequest is iOS 26+-only and presents a Live
+        // Activity while running; it is not available on macOS.
+        completion(.failure(PigeonError(
+            code: "99",
+            message: "ContinuedProcessingTask could not be registered",
+            details: "BGContinuedProcessingTaskRequest is only supported on iOS 26+"
         )))
     }
 
@@ -733,6 +790,27 @@ extension WorkmanagerPlugin {
         registerLaunchHandlerOnce(forTaskWithIdentifier: identifier, earliestBeginInSeconds: nil)
     }
 
+    /// Registers a continued processing task with iOS BGTaskScheduler.
+    ///
+    /// Continued processing tasks (iOS 26+) begin immediately or shortly after
+    /// submission and are allowed to continue running while the app is
+    /// backgrounded. The identifier must use wildcard notation ending in `.*`
+    /// (e.g. `<bundleID>.<context>.*`) and be listed in
+    /// `BGTaskSchedulerPermittedIdentifiers` in Info.plist.
+    ///
+    /// - Parameter identifier: Unique task identifier that matches the one used in Dart
+    @objc
+    public static func registerBGContinuedProcessingTask(withIdentifier identifier: String) {
+        guard #available(iOS 26.0, *) else {
+            return
+        }
+        UserDefaultsHelper.storeScheduledTask(
+            ScheduledTaskInfo(kind: .continuedProcessing, earliestBeginInSeconds: nil),
+            forTaskIdentifier: identifier
+        )
+        registerLaunchHandlerOnce(forTaskWithIdentifier: identifier, earliestBeginInSeconds: nil)
+    }
+
     @objc
     @available(iOS 13.0, *)
     private static func scheduleBackgroundProcessingTask(
@@ -760,6 +838,39 @@ extension WorkmanagerPlugin {
         }
     }
 
+    @available(iOS 26.0, *)
+    private static func scheduleContinuedProcessingTask(
+        withIdentifier uniqueTaskIdentifier: String,
+        title: String,
+        subtitle: String
+    ) {
+        let request = BGContinuedProcessingTaskRequest(
+            identifier: uniqueTaskIdentifier,
+            title: title,
+            subtitle: subtitle
+        )
+
+        do {
+            try BGTaskScheduler.shared.submit(request)
+            logInfo("BGContinuedProcessingTask submitted \(uniqueTaskIdentifier)")
+            UserDefaultsHelper.storeScheduledTask(
+                ScheduledTaskInfo(kind: .continuedProcessing, earliestBeginInSeconds: nil),
+                forTaskIdentifier: uniqueTaskIdentifier
+            )
+            registerLaunchHandlerOnce(forTaskWithIdentifier: uniqueTaskIdentifier, earliestBeginInSeconds: nil)
+        } catch {
+            logInfo(
+                "Could not schedule BGContinuedProcessingTask identifier:\(uniqueTaskIdentifier) " +
+                    "error:\(error.localizedDescription)"
+            )
+            logInfo(
+                "Possible issues: iOS 26+ required, the identifier must end with '.*' " +
+                    "(e.g. <bundleID>.<context>.*), or the task name is not registered " +
+                    "in BGTaskSchedulerPermittedIdentifiers"
+            )
+        }
+    }
+
     /// Handles execution of a health research background task.
     ///
     /// BGHealthResearchTask is a subclass of BGProcessingTask: the task can
@@ -775,6 +886,29 @@ extension WorkmanagerPlugin {
             identifier: task.identifier,
             inputData: storedInputData,
             backgroundMode: .backgroundHealthResearchTask(identifier: identifier)
+        )
+
+        task.expirationHandler = { operation.cancel() }
+        operation.completionBlock = { task.setTaskCompleted(success: !operation.isCancelled) }
+
+        operationQueue.addOperation(operation)
+    }
+
+    /// Handles execution of a continued processing background task.
+    ///
+    /// BGContinuedProcessingTask starts near submission time and can continue
+    /// while the app is backgrounded; the system still enforces an expiration
+    /// based on changing system conditions (the handler cancels the operation).
+    @available(iOS 26.0, *)
+    private static func handleBGContinuedProcessingTask(identifier: String, task: BGContinuedProcessingTask) {
+        let operationQueue = OperationQueue()
+        // Deliver the inputData stored at registration time (mirroring the
+        // periodic task path, keyed by task identifier).
+        let storedInputData = UserDefaultsHelper.getStoredPeriodicTaskInputData(forTaskIdentifier: task.identifier)
+        let operation = createBackgroundOperation(
+            identifier: task.identifier,
+            inputData: storedInputData,
+            backgroundMode: .backgroundContinuedProcessingTask(identifier: identifier)
         )
 
         task.expirationHandler = { operation.cancel() }
@@ -837,6 +971,8 @@ extension WorkmanagerPlugin {
                     earliestBeginInSeconds: earliestBeginInSeconds,
                     inputData: storedInputData
                 )
+            } else if #available(iOS 26.0, *), let task = task as? BGContinuedProcessingTask {
+                handleBGContinuedProcessingTask(identifier: identifier, task: task)
             } else if #available(iOS 17.0, *), let task = task as? BGHealthResearchTask {
                 // BGHealthResearchTask is a subclass of BGProcessingTask, so it
                 // must be checked before the generic BGProcessingTask branch.

--- a/workmanager_apple/ios/workmanager_apple/Sources/workmanager_apple/pigeon/WorkmanagerApi.g.swift
+++ b/workmanager_apple/ios/workmanager_apple/Sources/workmanager_apple/pigeon/WorkmanagerApi.g.swift
@@ -774,6 +774,57 @@ struct HealthResearchTaskRequest: Hashable {
   }
 }
 
+/// Generated class from Pigeon that represents data sent in messages.
+struct ContinuedProcessingTaskRequest: Hashable {
+  var uniqueName: String
+  var taskName: String
+  var title: String? = nil
+  var subtitle: String? = nil
+  var inputData: [String?: Any?]? = nil
+
+
+  // swift-format-ignore: AlwaysUseLowerCamelCase
+  static func fromList(_ pigeonVar_list: [Any?]) -> ContinuedProcessingTaskRequest? {
+    let uniqueName = pigeonVar_list[0] as! String
+    let taskName = pigeonVar_list[1] as! String
+    let title: String? = nilOrValue(pigeonVar_list[2])
+    let subtitle: String? = nilOrValue(pigeonVar_list[3])
+    let inputData: [String?: Any?]? = nilOrValue(pigeonVar_list[4])
+
+    return ContinuedProcessingTaskRequest(
+      uniqueName: uniqueName,
+      taskName: taskName,
+      title: title,
+      subtitle: subtitle,
+      inputData: inputData
+    )
+  }
+  func toList() -> [Any?] {
+    return [
+      uniqueName,
+      taskName,
+      title,
+      subtitle,
+      inputData,
+    ]
+  }
+  static func == (lhs: ContinuedProcessingTaskRequest, rhs: ContinuedProcessingTaskRequest) -> Bool {
+    if Swift.type(of: lhs) != Swift.type(of: rhs) {
+      return false
+    }
+    return deepEqualsWorkmanagerApi(lhs.uniqueName, rhs.uniqueName) && deepEqualsWorkmanagerApi(lhs.taskName, rhs.taskName) && deepEqualsWorkmanagerApi(lhs.title, rhs.title) && deepEqualsWorkmanagerApi(lhs.subtitle, rhs.subtitle) && deepEqualsWorkmanagerApi(lhs.inputData, rhs.inputData)
+  }
+
+  func hash(into hasher: inout Hasher) {
+    hasher.combine("ContinuedProcessingTaskRequest")
+    deepHashWorkmanagerApi(value: uniqueName, hasher: &hasher)
+    deepHashWorkmanagerApi(value: taskName, hasher: &hasher)
+    deepHashWorkmanagerApi(value: title, hasher: &hasher)
+    deepHashWorkmanagerApi(value: subtitle, hasher: &hasher)
+    deepHashWorkmanagerApi(value: inputData, hasher: &hasher)
+  }
+}
+
 private class WorkmanagerApiPigeonCodecReader: FlutterStandardReader {
   override func readValue(ofType type: UInt8) -> Any? {
     switch type {
@@ -835,6 +886,8 @@ private class WorkmanagerApiPigeonCodecReader: FlutterStandardReader {
       return ProcessingTaskRequest.fromList(self.readValue() as! [Any?])
     case 143:
       return HealthResearchTaskRequest.fromList(self.readValue() as! [Any?])
+    case 144:
+      return ContinuedProcessingTaskRequest.fromList(self.readValue() as! [Any?])
     default:
       return super.readValue(ofType: type)
     }
@@ -888,6 +941,9 @@ private class WorkmanagerApiPigeonCodecWriter: FlutterStandardWriter {
     } else if let value = value as? HealthResearchTaskRequest {
       super.writeByte(143)
       super.writeValue(value.toList())
+    } else if let value = value as? ContinuedProcessingTaskRequest {
+      super.writeByte(144)
+      super.writeValue(value.toList())
     } else {
       super.writeValue(value)
     }
@@ -916,6 +972,7 @@ protocol WorkmanagerHostApi {
   func registerPeriodicTask(request: PeriodicTaskRequest, completion: @escaping (Result<Void, Error>) -> Void)
   func registerProcessingTask(request: ProcessingTaskRequest, completion: @escaping (Result<Void, Error>) -> Void)
   func registerHealthResearchTask(request: HealthResearchTaskRequest, completion: @escaping (Result<Void, Error>) -> Void)
+  func registerContinuedProcessingTask(request: ContinuedProcessingTaskRequest, completion: @escaping (Result<Void, Error>) -> Void)
   func cancelByUniqueName(uniqueName: String, completion: @escaping (Result<Void, Error>) -> Void)
   func cancelByTag(tag: String, completion: @escaping (Result<Void, Error>) -> Void)
   func cancelAll(completion: @escaping (Result<Void, Error>) -> Void)
@@ -1013,6 +1070,23 @@ class WorkmanagerHostApiSetup {
       }
     } else {
       registerHealthResearchTaskChannel.setMessageHandler(nil)
+    }
+    let registerContinuedProcessingTaskChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.workmanager_platform_interface.WorkmanagerHostApi.registerContinuedProcessingTask\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
+    if let api = api {
+      registerContinuedProcessingTaskChannel.setMessageHandler { message, reply in
+        let args = message as! [Any?]
+        let requestArg = args[0] as! ContinuedProcessingTaskRequest
+        api.registerContinuedProcessingTask(request: requestArg) { result in
+          switch result {
+          case .success:
+            reply(wrapResult(nil))
+          case .failure(let error):
+            reply(wrapError(error))
+          }
+        }
+      }
+    } else {
+      registerContinuedProcessingTaskChannel.setMessageHandler(nil)
     }
     let cancelByUniqueNameChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.workmanager_platform_interface.WorkmanagerHostApi.cancelByUniqueName\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
     if let api = api {

--- a/workmanager_apple/lib/workmanager_apple.dart
+++ b/workmanager_apple/lib/workmanager_apple.dart
@@ -132,6 +132,23 @@ class WorkmanagerApple extends WorkmanagerPlatform {
   }
 
   @override
+  Future<void> registerContinuedProcessingTask(
+    String uniqueName,
+    String taskName, {
+    String? title,
+    String? subtitle,
+    Map<String, dynamic>? inputData,
+  }) async {
+    await _api.registerContinuedProcessingTask(ContinuedProcessingTaskRequest(
+      uniqueName: uniqueName,
+      taskName: taskName,
+      title: title,
+      subtitle: subtitle,
+      inputData: inputData?.cast<String?, Object?>(),
+    ));
+  }
+
+  @override
   Future<void> cancelByUniqueName(String uniqueName) async {
     await _api.cancelByUniqueName(uniqueName);
   }

--- a/workmanager_apple/macos/workmanager_apple/Sources/workmanager_apple/BGContinuedProcessingTaskScheduler.swift
+++ b/workmanager_apple/macos/workmanager_apple/Sources/workmanager_apple/BGContinuedProcessingTaskScheduler.swift
@@ -1,0 +1,1 @@
+../../../../ios/workmanager_apple/Sources/workmanager_apple/BGContinuedProcessingTaskScheduler.swift

--- a/workmanager_apple/test/workmanager_apple_test.dart
+++ b/workmanager_apple/test/workmanager_apple_test.dart
@@ -165,6 +165,38 @@ void main() {
       });
     });
 
+    group('iOS-specific continued processing task request validation', () {
+      test('should handle ContinuedProcessingTaskRequest creation', () {
+        final continuedRequest = ContinuedProcessingTaskRequest(
+          uniqueName: 'com.example.app.continuedProcessing.*',
+          taskName: 'Continued Processing Task',
+          title: 'Example continued processing',
+          subtitle: 'Processing in progress',
+          inputData: {'model': 'inference', 'frames': 120},
+        );
+
+        expect(continuedRequest.uniqueName,
+            'com.example.app.continuedProcessing.*');
+        expect(continuedRequest.taskName, 'Continued Processing Task');
+        expect(continuedRequest.title, 'Example continued processing');
+        expect(continuedRequest.subtitle, 'Processing in progress');
+        expect(continuedRequest.inputData?['model'], 'inference');
+      });
+
+      test('should handle minimal continued processing task configuration', () {
+        final minimalRequest = ContinuedProcessingTaskRequest(
+          uniqueName: 'com.example.app.minimal.*',
+          taskName: 'Minimal Continued Task',
+        );
+
+        expect(minimalRequest.uniqueName, 'com.example.app.minimal.*');
+        expect(minimalRequest.taskName, 'Minimal Continued Task');
+        expect(minimalRequest.title, null);
+        expect(minimalRequest.subtitle, null);
+        expect(minimalRequest.inputData, null);
+      });
+    });
+
     group('iOS constraint handling differences', () {
       test('should handle battery constraints appropriately for iOS', () {
         // iOS handles battery constraints differently than Android

--- a/workmanager_platform_interface/lib/src/pigeon/workmanager_api.g.dart
+++ b/workmanager_platform_interface/lib/src/pigeon/workmanager_api.g.dart
@@ -774,6 +774,66 @@ class HealthResearchTaskRequest {
   int get hashCode => _deepHash(<Object?>[runtimeType, ..._toList()]);
 }
 
+class ContinuedProcessingTaskRequest {
+  ContinuedProcessingTaskRequest({
+    required this.uniqueName,
+    required this.taskName,
+    this.title,
+    this.subtitle,
+    this.inputData,
+  });
+
+  String uniqueName;
+
+  String taskName;
+
+  String? title;
+
+  String? subtitle;
+
+  Map<String?, Object?>? inputData;
+
+  List<Object?> _toList() {
+    return <Object?>[
+      uniqueName,
+      taskName,
+      title,
+      subtitle,
+      inputData,
+    ];
+  }
+
+  Object encode() {
+    return _toList();  }
+
+  static ContinuedProcessingTaskRequest decode(Object result) {
+    result as List<Object?>;
+    return ContinuedProcessingTaskRequest(
+      uniqueName: result[0]! as String,
+      taskName: result[1]! as String,
+      title: result[2] as String?,
+      subtitle: result[3] as String?,
+      inputData: (result[4] as Map<Object?, Object?>?)?.cast<String?, Object?>(),
+    );
+  }
+
+  @override
+  // ignore: avoid_equals_and_hash_code_on_mutable_classes
+  bool operator ==(Object other) {
+    if (other is! ContinuedProcessingTaskRequest || other.runtimeType != runtimeType) {
+      return false;
+    }
+    if (identical(this, other)) {
+      return true;
+    }
+    return _deepEquals(uniqueName, other.uniqueName) && _deepEquals(taskName, other.taskName) && _deepEquals(title, other.title) && _deepEquals(subtitle, other.subtitle) && _deepEquals(inputData, other.inputData);
+  }
+
+  @override
+  // ignore: avoid_equals_and_hash_code_on_mutable_classes
+  int get hashCode => _deepHash(<Object?>[runtimeType, ..._toList()]);
+}
+
 
 class _PigeonCodec extends StandardMessageCodec {
   const _PigeonCodec();
@@ -827,6 +887,9 @@ class _PigeonCodec extends StandardMessageCodec {
     }    else if (value is HealthResearchTaskRequest) {
       buffer.putUint8(143);
       writeValue(buffer, value.encode());
+    }    else if (value is ContinuedProcessingTaskRequest) {
+      buffer.putUint8(144);
+      writeValue(buffer, value.encode());
     } else {
       super.writeValue(buffer, value);
     }
@@ -872,6 +935,8 @@ class _PigeonCodec extends StandardMessageCodec {
         return ProcessingTaskRequest.decode(readValue(buffer)!);
       case 143:
         return HealthResearchTaskRequest.decode(readValue(buffer)!);
+      case 144:
+        return ContinuedProcessingTaskRequest.decode(readValue(buffer)!);
       default:
         return super.readValueOfType(type, buffer);
     }
@@ -965,6 +1030,24 @@ class WorkmanagerHostApi {
 
   Future<void> registerHealthResearchTask(HealthResearchTaskRequest request) async {
     final pigeonVar_channelName = 'dev.flutter.pigeon.workmanager_platform_interface.WorkmanagerHostApi.registerHealthResearchTask$pigeonVar_messageChannelSuffix';
+    final pigeonVar_channel = BasicMessageChannel<Object?>(
+      pigeonVar_channelName,
+      pigeonChannelCodec,
+      binaryMessenger: pigeonVar_binaryMessenger,
+    );
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[request]);
+    final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
+
+    _extractReplyValueOrThrow(
+        pigeonVar_replyList,
+        pigeonVar_channelName,
+        isNullValid: true,
+    )
+    ;
+  }
+
+  Future<void> registerContinuedProcessingTask(ContinuedProcessingTaskRequest request) async {
+    final pigeonVar_channelName = 'dev.flutter.pigeon.workmanager_platform_interface.WorkmanagerHostApi.registerContinuedProcessingTask$pigeonVar_messageChannelSuffix';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,

--- a/workmanager_platform_interface/lib/src/workmanager_platform_interface.dart
+++ b/workmanager_platform_interface/lib/src/workmanager_platform_interface.dart
@@ -140,6 +140,26 @@ abstract class WorkmanagerPlatform extends PlatformInterface {
         'registerHealthResearchTask() has not been implemented.');
   }
 
+  /// Register a continued processing task (iOS 26+ only).
+  ///
+  /// [uniqueName] is the unique identifier for this task. On iOS the
+  /// identifier must use wildcard notation ending in `.*` (e.g.
+  /// `<bundleID>.<context>.*`).
+  /// [taskName] is the name of the task that will be passed to the callback.
+  /// [title] and [subtitle] are the localized strings the system shows to the
+  /// user in the Live Activity while the task is running.
+  /// [inputData] is optional data that will be passed to the callback.
+  Future<void> registerContinuedProcessingTask(
+    String uniqueName,
+    String taskName, {
+    String? title,
+    String? subtitle,
+    Map<String, dynamic>? inputData,
+  }) {
+    throw UnimplementedError(
+        'registerContinuedProcessingTask() has not been implemented.');
+  }
+
   /// Cancel a task by its unique name.
   Future<void> cancelByUniqueName(String uniqueName) {
     throw UnimplementedError('cancelByUniqueName() has not been implemented.');
@@ -241,6 +261,19 @@ class _PlaceholderImplementation extends WorkmanagerPlatform {
     Duration? initialDelay,
     Map<String, dynamic>? inputData,
     Constraints? constraints,
+  }) async {
+    throw UnimplementedError(
+      'No implementation found for workmanager on this platform.',
+    );
+  }
+
+  @override
+  Future<void> registerContinuedProcessingTask(
+    String uniqueName,
+    String taskName, {
+    String? title,
+    String? subtitle,
+    Map<String, dynamic>? inputData,
   }) async {
     throw UnimplementedError(
       'No implementation found for workmanager on this platform.',

--- a/workmanager_platform_interface/pigeons/workmanager_api.dart
+++ b/workmanager_platform_interface/pigeons/workmanager_api.dart
@@ -339,6 +339,31 @@ class HealthResearchTaskRequest {
   bool? requiresCharging;
 }
 
+// iOS specific request
+// BGContinuedProcessingTaskRequest (iOS 26+) for workloads that must begin
+// immediately or shortly after submission and are allowed to continue running
+// while the app is backgrounded (e.g. ML inference on captured camera data).
+// The system presents a Live Activity to the user while the task is running.
+//
+// Unlike processing tasks, the identifier must use wildcard notation ending
+// in `.*` (e.g. `<bundleID>.<context>.*`), and the scheduler ignores
+// `earliestBeginDate` (so initialDelay does not apply).
+class ContinuedProcessingTaskRequest {
+  ContinuedProcessingTaskRequest({
+    required this.uniqueName,
+    required this.taskName,
+    this.title,
+    this.subtitle,
+    this.inputData,
+  });
+
+  String uniqueName;
+  String taskName;
+  String? title;
+  String? subtitle;
+  Map<String?, Object?>? inputData;
+}
+
 // Host API (Flutter calls native)
 @HostApi()
 abstract class WorkmanagerHostApi {
@@ -356,6 +381,9 @@ abstract class WorkmanagerHostApi {
 
   @async
   void registerHealthResearchTask(HealthResearchTaskRequest request);
+
+  @async
+  void registerContinuedProcessingTask(ContinuedProcessingTaskRequest request);
 
   @async
   void cancelByUniqueName(String uniqueName);


### PR DESCRIPTION
## What

Adds `BGContinuedProcessingTask` (iOS 26+) support to fluttercommunity/flutter_workmanager#638, following the existing BGTaskScheduler pattern (register identifier → submit → callback → `setTaskCompleted`).

Continued processing tasks begin immediately or shortly after submission and are allowed to **continue running while the app is backgrounded** (the use case from the issue: ML inference on a camera session that moves to background). The system presents a Live Activity to the user while the task runs.

## API

```dart
await Workmanager().registerContinuedProcessingTask(
  'com.yourapp.continuedProcessing.*', // wildcard identifier required
  'continuedProcessingTask',
  title: 'Example continued processing',
  subtitle: 'Processing in progress',
  inputData: {'frames': 120},
);
```

## Changes

- **Pigeon**: new `ContinuedProcessingTaskRequest` + `registerContinuedProcessingTask` host API (all generated outputs regenerated, not hand-edited)
- **iOS** (`workmanager_apple`): registration with `BGContinuedProcessingTaskRequest(identifier:title:subtitle:)`, submission + persistence (`ScheduledTaskKind.continuedProcessing`), launch-handler dispatch, `handleBGContinuedProcessingTask` (expiration → cancel → `setTaskCompleted`), and `WorkmanagerPlugin.registerBGContinuedProcessingTask(withIdentifier:)` for AppDelegate pre-registration
- **Dart**: `Workmanager.registerContinuedProcessingTask(uniqueName, taskName, {title, subtitle, inputData})` + platform interface + Apple/Android implementations
- **Android / macOS**: explicit unsupported error (iOS 26+ only)
- **Docs**: Quick Start "Option E" with the wildcard identifier + Info.plist requirements
- **Tests**: apple request-construction tests, RunnerTests scheduled-kind round trip, integration test that performs a real submission on iOS 26.5 and tolerates older runtimes / simulator rejection

## Key platform details (documented)

- Identifier **must** use wildcard notation ending in `.*` with a prefix containing the app bundle ID (e.g. `com.yourapp.continuedProcessing.*`)
- `earliestBeginDate` is ignored by the scheduler, so there is no `initialDelay`
- Not limited to idle devices, but the system still enforces expiration; Apple expects tasks to report progress via `NSProgress`, which the plugin does not plumb from Dart yet (noted as a follow-up)

## Verification

- `flutter analyze` clean across all 4 packages; `dart format` clean
- Dart tests: `workmanager` 15/15, `workmanager_apple` 28/28 (incl. new request tests)
- iOS RunnerTests pass (incl. new `continuedProcessing` round trip); full integration suite **18/18 on an iOS 26.5 simulator** (real `BGTaskScheduler.submit`), tolerant path verified on iOS 18.5
- `flutter build macos --debug` and `flutter build apk --debug` succeed; Android unit tests pass; ktlint clean
- `melos run generate` idempotent (only intended pigeon + mock diffs)