### PR TITLE
feat!: align minimum Flutter version to 3.38 across packages (prep for 0.10.0)

### DIFF
--- a/workmanager/pubspec.yaml
+++ b/workmanager/pubspec.yaml
@@ -8,7 +8,7 @@ issue_tracker: https://github.com/fluttercommunity/flutter_workmanager/issues
 
 environment:
   sdk: '>=3.5.0 <4.0.0'
-  flutter: ">=3.32.0"
+  flutter: ">=3.38.0"
 
 dependencies:
   flutter:

--- a/workmanager_android/pubspec.yaml
+++ b/workmanager_android/pubspec.yaml
@@ -8,7 +8,7 @@ issue_tracker: https://github.com/fluttercommunity/flutter_workmanager/issues
 
 environment:
   sdk: '>=3.5.0 <4.0.0'
-  flutter: ">=3.32.0"
+  flutter: ">=3.38.0"
 
 dependencies:
   flutter:

--- a/workmanager_platform_interface/pubspec.yaml
+++ b/workmanager_platform_interface/pubspec.yaml
@@ -8,7 +8,7 @@ issue_tracker: https://github.com/fluttercommunity/flutter_workmanager/issues
 
 environment:
   sdk: '>=3.5.0 <4.0.0'
-  flutter: ">=3.32.0"
+  flutter: ">=3.38.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
## What

Aligns the minimum Flutter version to **3.38.0** across the whole monorepo, so the next release can ship as the breaking **0.10.0**.

- `workmanager`: `flutter: ">=3.32.0"` → `">=3.38.0"`
- `workmanager_android`: `flutter: ">=3.32.0"` → `">=3.38.0"`
- `workmanager_platform_interface`: `flutter: ">=3.32.0"` → `">=3.38.0"`
- `workmanager_apple`: already `">=3.38.0"` (from the UIScene lifecycle migration, #696) — unchanged

## Breaking change

**BREAKING CHANGE:** consumers must now use Flutter >= 3.38.0. Marked with `feat!:` + `BREAKING CHANGE:` trailer so the melos release pipeline bumps all packages to 0.10.0. No version numbers or CHANGELOGs were edited (melos handles those at release time).

## Verification

- `melos bootstrap` succeeds with the new floor (CI uses Flutter 3.44.8 via `.fvmrc`)
- `flutter analyze` clean in `workmanager`, `workmanager_android`, `workmanager_platform_interface`
- `workmanager` test suite passes (15/15)
- No code changes; behavior unaffected