### PR TITLE
ci: skip platform builds for docs-only PRs

### DIFF
--- a/.github/actions/check-changes/action.yml
+++ b/.github/actions/check-changes/action.yml
@@ -1,0 +1,48 @@
+name: Check changes
+description: >-
+  Single source of truth for the paths-filter map shared by the examples and
+  test workflows. Detects whether docs, Android, or iOS files changed.
+inputs: {}
+
+outputs:
+  docs:
+    description: Whether docs-related files changed
+    value: ${{ steps.filter.outputs.docs }}
+  android:
+    description: Whether Android-related files changed
+    value: ${{ steps.filter.outputs.android }}
+  ios:
+    description: Whether iOS-related files changed
+    value: ${{ steps.filter.outputs.ios }}
+
+runs:
+  using: composite
+  steps:
+    - uses: dorny/paths-filter@v3
+      id: filter
+      with:
+        filters: |
+          docs:
+            - 'docs/**'
+            - 'README.md'
+            - '**/*.md'
+          android:
+            - 'workmanager_android/**'
+            - 'example/android/**'
+            - 'workmanager_platform_interface/**'
+            - 'workmanager/**'
+            - 'melos.yaml'
+            - '.fvmrc'
+            - 'pubspec.yaml'
+            - '.github/workflows/**'
+            - '.github/actions/**'
+          ios:
+            - 'workmanager_apple/**'
+            - 'example/ios/**'
+            - 'workmanager_platform_interface/**'
+            - 'workmanager/**'
+            - 'melos.yaml'
+            - '.fvmrc'
+            - 'pubspec.yaml'
+            - '.github/workflows/**'
+            - '.github/actions/**'

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -7,7 +7,45 @@ on:
     branches: [ main ]
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      docs: ${{ steps.filter.outputs.docs }}
+      android: ${{ steps.filter.outputs.android }}
+      ios: ${{ steps.filter.outputs.ios }}
+    steps:
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            docs:
+              - 'docs/**'
+              - 'README.md'
+              - '**/*.md'
+            android:
+              - 'workmanager_android/**'
+              - 'example/android/**'
+              - 'workmanager_platform_interface/**'
+              - 'workmanager/**'
+              - 'melos.yaml'
+              - '.fvmrc'
+              - 'pubspec.yaml'
+              - '.github/workflows/**'
+              - '.github/actions/**'
+            ios:
+              - 'workmanager_apple/**'
+              - 'example/ios/**'
+              - 'workmanager_platform_interface/**'
+              - 'workmanager/**'
+              - 'melos.yaml'
+              - '.fvmrc'
+              - 'pubspec.yaml'
+              - '.github/workflows/**'
+              - '.github/actions/**'
+
   example_android:
+    needs: changes
+    if: needs.changes.outputs.android == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -28,6 +66,8 @@ jobs:
           cd example && flutter build apk --debug
 
   example_ios:
+    needs: changes
+    if: needs.changes.outputs.ios == 'true'
     runs-on: macos-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -14,34 +14,9 @@ jobs:
       android: ${{ steps.filter.outputs.android }}
       ios: ${{ steps.filter.outputs.ios }}
     steps:
-      - uses: dorny/paths-filter@v3
+      - uses: actions/checkout@v7
+      - uses: ./.github/actions/check-changes
         id: filter
-        with:
-          filters: |
-            docs:
-              - 'docs/**'
-              - 'README.md'
-              - '**/*.md'
-            android:
-              - 'workmanager_android/**'
-              - 'example/android/**'
-              - 'workmanager_platform_interface/**'
-              - 'workmanager/**'
-              - 'melos.yaml'
-              - '.fvmrc'
-              - 'pubspec.yaml'
-              - '.github/workflows/**'
-              - '.github/actions/**'
-            ios:
-              - 'workmanager_apple/**'
-              - 'example/ios/**'
-              - 'workmanager_platform_interface/**'
-              - 'workmanager/**'
-              - 'melos.yaml'
-              - '.fvmrc'
-              - 'pubspec.yaml'
-              - '.github/workflows/**'
-              - '.github/actions/**'
 
   example_android:
     needs: changes

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,34 +14,9 @@ jobs:
       android: ${{ steps.filter.outputs.android }}
       ios: ${{ steps.filter.outputs.ios }}
     steps:
-      - uses: dorny/paths-filter@v3
+      - uses: actions/checkout@v7
+      - uses: ./.github/actions/check-changes
         id: filter
-        with:
-          filters: |
-            docs:
-              - 'docs/**'
-              - 'README.md'
-              - '**/*.md'
-            android:
-              - 'workmanager_android/**'
-              - 'example/android/**'
-              - 'workmanager_platform_interface/**'
-              - 'workmanager/**'
-              - 'melos.yaml'
-              - '.fvmrc'
-              - 'pubspec.yaml'
-              - '.github/workflows/**'
-              - '.github/actions/**'
-            ios:
-              - 'workmanager_apple/**'
-              - 'example/ios/**'
-              - 'workmanager_platform_interface/**'
-              - 'workmanager/**'
-              - 'melos.yaml'
-              - '.fvmrc'
-              - 'pubspec.yaml'
-              - '.github/workflows/**'
-              - '.github/actions/**'
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,42 @@ on:
     branches: [ main ]
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      docs: ${{ steps.filter.outputs.docs }}
+      android: ${{ steps.filter.outputs.android }}
+      ios: ${{ steps.filter.outputs.ios }}
+    steps:
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            docs:
+              - 'docs/**'
+              - 'README.md'
+              - '**/*.md'
+            android:
+              - 'workmanager_android/**'
+              - 'example/android/**'
+              - 'workmanager_platform_interface/**'
+              - 'workmanager/**'
+              - 'melos.yaml'
+              - '.fvmrc'
+              - 'pubspec.yaml'
+              - '.github/workflows/**'
+              - '.github/actions/**'
+            ios:
+              - 'workmanager_apple/**'
+              - 'example/ios/**'
+              - 'workmanager_platform_interface/**'
+              - 'workmanager/**'
+              - 'melos.yaml'
+              - '.fvmrc'
+              - 'pubspec.yaml'
+              - '.github/workflows/**'
+              - '.github/actions/**'
+
   test:
     runs-on: ubuntu-latest
     steps:
@@ -23,6 +59,8 @@ jobs:
           flutter test
 
   native_ios_tests:
+    needs: changes
+    if: needs.changes.outputs.ios == 'true'
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v7
@@ -49,6 +87,8 @@ jobs:
         run: cd example/ios && xcodebuild -workspace Runner.xcworkspace -scheme Runner -sdk iphonesimulator -destination "platform=iOS Simulator,id=${{ steps.sim.outputs.udid }}" test
 
   native_android_tests:
+    needs: changes
+    if: needs.changes.outputs.android == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -68,6 +108,8 @@ jobs:
         run: cd example/android && ./gradlew :workmanager_android:test
 
   drive_ios:
+    needs: changes
+    if: needs.changes.outputs.ios == 'true'
     runs-on: macos-latest
     timeout-minutes: 45
     steps:
@@ -113,6 +155,8 @@ jobs:
 
 
   drive_android:
+    needs: changes
+    if: needs.changes.outputs.android == 'true'
     runs-on: ubuntu-latest
     #creates a build matrix for your jobs
     strategy:


### PR DESCRIPTION
## Summary

Docs-only PRs currently run all 19 checks, including the expensive platform builds (Android APK, iOS CocoaPods + SPM, native/drive tests on simulators/emulators). This PR makes the heavy jobs in `examples.yml` and `test.yml` conditional on whether the PR actually touches platform code.

## How it works

Each workflow gets one shared `changes` job using `dorny/paths-filter@v3` (major-pin, consistent with the repo's `@v7`/`@v5`/`@v3` pinning convention). Heavy jobs guard on its outputs with a job-level `if:`, so for a docs-only PR they are **skipped** — and GitHub reports skipped jobs as Success for branch protection, so required checks do not block merges:

- `examples.yml`: `example_android` guards on `android == 'true'`, `example_ios` (cocoapods/spm matrix) on `ios == 'true'`
- `test.yml`: `native_ios_tests` and `drive_ios` guard on `ios == 'true'`; `native_android_tests` and `drive_android` on `android == 'true'`
- The pure-Dart `test` job stays unconditional (cheap, catches platform-interface bugs)
- Light workflows (`analysis`, `format`, `generated-files`) are untouched and always run

Job names are unchanged, so existing branch-protection check names keep matching (now reporting skipped-as-success on docs-only PRs).

## Filter map

```yaml
docs:
  - 'docs/**'
  - 'README.md'
  - '**/*.md'
android:
  - 'workmanager_android/**'
  - 'example/android/**'
  - 'workmanager_platform_interface/**'
  - 'workmanager/**'
  - 'melos.yaml'
  - '.fvmrc'
  - 'pubspec.yaml'
  - '.github/workflows/**'
  - '.github/actions/**'
ios:
  - 'workmanager_apple/**'
  - 'example/ios/**'
  - 'workmanager_platform_interface/**'
  - 'workmanager/**'
  - 'melos.yaml'
  - '.fvmrc'
  - 'pubspec.yaml'
  - '.github/workflows/**'
  - '.github/actions/**'
```

Platform interface + base package changes affect both platforms, so they appear in both `android` and `ios`. `.github/workflows/**` (and `.github/actions/**`, which feeds the iOS jobs) is included in both so CI-infra changes still run the full matrix.

## Verification

- All workflow files pass `actionlint` (v1.7.12) and YAML parsing
- Filter outputs validated against real diff scenarios using picomatch (same matcher dorny uses): root-level docs-only changes → `android=false, ios=false` (heavy jobs skip); code/CI changes → unchanged behavior
- This PR itself touches `.github/workflows/**`, so all heavy jobs should run — confirming parse + unchanged behavior for code PRs
- Note: a package-level doc (e.g. `workmanager/CHANGELOG.md`) still matches `workmanager/**` in the platform filters and will run builds; tightening that would need exclusion support, left out to keep the filter simple