### PR TITLE
fix(android): notify running callbacks when work is cancelled (fixes #432)

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,34 @@ await Workmanager().registerOneOffTask(
 See the [Quick Start guide](https://docs.page/fluttercommunity/flutter_workmanager/quickstart)
 for details and platform caveats.
 
+## 🛑 Cancelling Running Work (Android)
+
+`cancelByUniqueName`, `cancelByTag` and `cancelAll` stop the WorkManager worker
+immediately, but the Dart callback that is currently running keeps executing
+unless it reacts to the stop. Pass an `onTaskStopped` handler to `executeTask`
+inside your `callbackDispatcher` to be notified when a running task is stopped
+before it finishes:
+
+```dart
+@pragma('vm:entry-point')
+void callbackDispatcher() {
+  Workmanager().executeTask(
+    (taskName, inputData) async {
+      return true;
+    },
+    onTaskStopped: (taskName, stopReason) async {
+      // Mark the task as cancelled / persist state, then return promptly.
+    },
+  );
+}
+```
+
+The handler receives the task name and the WorkManager stop reason
+(`cancelledByApp`, `timeout`, `preempt`, ...); on Android < 12 the reason is
+`StopReason.unknown`. Android-only — iOS has no way to stop a running task.
+See the [Customization guide](https://docs.page/fluttercommunity/flutter_workmanager/customization)
+for details.
+
 
 ## 🐛 Issues & Support
 

--- a/docs/customization.mdx
+++ b/docs/customization.mdx
@@ -124,6 +124,45 @@ Workmanager().cancelByTag("sync-tasks");
 Workmanager().cancelAll();
 ```
 
+### Cancelling Running Work (Android)
+
+On Android, `cancelByUniqueName` (and `cancelByTag` / `cancelAll`) stops the
+WorkManager worker immediately. The Dart callback that is *currently running*
+keeps executing unless it reacts to the stop — register an `onTaskStopped`
+handler on `executeTask` inside your `callbackDispatcher` to be notified:
+
+```dart
+@pragma('vm:entry-point')
+void callbackDispatcher() {
+  Workmanager().executeTask(
+    (taskName, inputData) async {
+      // The task itself...
+      return true;
+    },
+    onTaskStopped: (taskName, stopReason) async {
+      // Persist progress or mark the task as cancelled before the engine
+      // shuts down. Return promptly — the platform tears down the task's
+      // engine as soon as this handler completes.
+      await myDatabase.markCancelled(taskName, stopReason);
+    },
+  );
+}
+```
+
+The handler fires whenever WorkManager stops a running worker — not only for
+app-initiated cancellation, but also for timeouts, preemption, Doze / App
+Standby, and background restrictions. The `stopReason` tells you which case it
+was: it mirrors Android's
+[`StopReason`](https://developer.android.com/reference/androidx/work/StopReason)
+(`cancelledByApp`, `timeout`, `preempt`, ...). On Android versions before 12
+(API 31) the reason is always `StopReason.unknown`.
+
+<Info>
+**iOS has no equivalent.** `cancelByUniqueName` on iOS only removes *pending*
+BGTaskScheduler requests; there is no way to stop a task that is already
+running, so `onTaskStopped` is Android-only and never fires on iOS.
+</Info>
+
 ### Task Scheduling Options
 
 ```dart

--- a/workmanager/lib/src/workmanager_impl.dart
+++ b/workmanager/lib/src/workmanager_impl.dart
@@ -23,6 +23,24 @@ import 'package:workmanager_apple/workmanager_apple.dart';
 typedef BackgroundTaskHandler = Future<bool> Function(
     String taskName, Map<String, dynamic>? inputData);
 
+/// Callback invoked when a running background task is stopped by the platform
+/// before it finished.
+///
+/// This is Android-only: it fires when WorkManager stops a worker that is
+/// currently running (cancelled, timed out, preempted, ...). iOS has no
+/// equivalent concept — `cancelByUniqueName` there only removes pending
+/// BGTaskScheduler requests.
+///
+/// [taskName] is the same value passed to the [BackgroundTaskHandler].
+/// [stopReason] describes why the task was stopped; on Android versions
+/// before 12 (API 31) it is always [StopReason.unknown].
+///
+/// Return promptly: the platform tears the task's engine down once this
+/// handler completes, so long-running work should be kept to quick state
+/// persistence and cleanup.
+typedef BackgroundTaskStoppedHandler = Future<void> Function(
+    String taskName, StopReason stopReason);
+
 /// Make sure you followed the platform setup steps first before trying to register any task.
 ///
 /// Android:
@@ -110,6 +128,7 @@ class Workmanager {
   static const String iOSBackgroundTask = "iOSPerformFetch";
 
   static BackgroundTaskHandler? _backgroundTaskHandler;
+  static BackgroundTaskStoppedHandler? _onTaskStoppedHandler;
   static late final WorkmanagerFlutterApi _flutterApi;
 
   /// The callback dispatcher registered via [initialize], kept so in-process
@@ -174,7 +193,14 @@ class Workmanager {
   /// You can perfectly call other Flutter plugins inside this callback, as the callback is simply running within a Flutter background isolate.
   ///
   /// Scheduling other background tasks inside the [BackgroundTaskHandler] is allowed.
-  void executeTask(BackgroundTaskHandler backgroundTaskHandler) async {
+  ///
+  /// [onTaskStopped] is an optional handler invoked when the platform stops a
+  /// running task before it finishes (Android only, see
+  /// [BackgroundTaskStoppedHandler]).
+  void executeTask(
+    BackgroundTaskHandler backgroundTaskHandler, {
+    BackgroundTaskStoppedHandler? onTaskStopped,
+  }) async {
     WidgetsFlutterBinding.ensureInitialized();
     try {
       final marker =
@@ -183,6 +209,7 @@ class Workmanager {
     } catch (_) {}
 
     _backgroundTaskHandler = backgroundTaskHandler;
+    _onTaskStoppedHandler = onTaskStopped;
     _flutterApi = _WorkmanagerFlutterApiImpl();
     WorkmanagerFlutterApi.setUp(_flutterApi);
 
@@ -540,5 +567,13 @@ class _WorkmanagerFlutterApiImpl extends WorkmanagerFlutterApi {
     final result = await Workmanager._backgroundTaskHandler
         ?.call(taskName, convertedInputData);
     return result ?? false;
+  }
+
+  @override
+  Future<void> onTaskStopped(String taskName, int stopReason) async {
+    final handler = Workmanager._onTaskStoppedHandler;
+    if (handler != null) {
+      await handler(taskName, StopReason.fromRawValue(stopReason));
+    }
   }
 }

--- a/workmanager/lib/workmanager.dart
+++ b/workmanager/lib/workmanager.dart
@@ -1,4 +1,5 @@
 library workmanager;
 
-export 'src/workmanager_impl.dart' show Workmanager, BackgroundTaskHandler;
+export 'src/workmanager_impl.dart'
+    show Workmanager, BackgroundTaskHandler, BackgroundTaskStoppedHandler;
 export 'package:workmanager_platform_interface/workmanager_platform_interface.dart';

--- a/workmanager/test/on_task_stopped_test.dart
+++ b/workmanager/test/on_task_stopped_test.dart
@@ -1,0 +1,80 @@
+import 'dart:typed_data';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:workmanager/workmanager.dart';
+import 'package:workmanager_apple/workmanager_apple.dart';
+
+const String _channelPrefix =
+    'dev.flutter.pigeon.workmanager_platform_interface.WorkmanagerFlutterApi.';
+
+/// Fake platform that records initialize() calls without touching real
+/// platform channels. Extends [WorkmanagerApple] so Workmanager's platform
+/// auto-selection (which runs on macOS/iOS/Android hosts) does not replace it.
+class _FakeApplePlatform extends WorkmanagerApple {
+  @override
+  Future<void> initialize(
+    Function callbackDispatcher, {
+    @Deprecated(
+        'Use WorkmanagerDebug handlers instead. This parameter has no effect.')
+    bool isInDebugMode = false,
+  }) async {}
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    WorkmanagerPlatform.instance = _FakeApplePlatform();
+  });
+
+  Future<void> sendMessage(String channel, List<Object?>? message) async {
+    final messenger =
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+    final codec = WorkmanagerFlutterApi.pigeonChannelCodec;
+    ByteData? reply;
+    await messenger.handlePlatformMessage(
+      channel,
+      codec.encodeMessage(message),
+      (data) {
+        reply = data;
+      },
+    );
+    expect(reply, isNotNull);
+    expect(codec.decodeMessage(reply) as List<Object?>?, isEmpty);
+  }
+
+  test('onTaskStopped notifies the registered handler with the stop reason',
+      () async {
+    final stopped = <(String, StopReason)>[];
+
+    void callbackDispatcher() {
+      Workmanager().executeTask(
+        (taskName, inputData) async => true,
+        onTaskStopped: (taskName, stopReason) async {
+          stopped.add((taskName, stopReason));
+        },
+      );
+    }
+
+    await Workmanager().initialize(callbackDispatcher);
+
+    // Before the dispatcher has run, no handler is registered: the message is
+    // acknowledged and nothing is delivered.
+    await sendMessage('${_channelPrefix}onTaskStopped', <Object?>['task', 3]);
+    expect(stopped, isEmpty);
+
+    // Run the dispatcher so the stop handler is registered (the native side
+    // does this via backgroundChannelInitialized before executing tasks).
+    await sendMessage('${_channelPrefix}backgroundChannelInitialized', null);
+
+    await sendMessage('${_channelPrefix}onTaskStopped',
+        <Object?>['dev.fluttercommunity.test.sync', 3]);
+    await sendMessage('${_channelPrefix}onTaskStopped', <Object?>['task', 99]);
+
+    expect(stopped, [
+      ('dev.fluttercommunity.test.sync', StopReason.cancelledByApp),
+      ('task', StopReason.unknown),
+    ]);
+  });
+}

--- a/workmanager/test/stop_reason_test.dart
+++ b/workmanager/test/stop_reason_test.dart
@@ -1,0 +1,30 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:workmanager/workmanager.dart';
+
+void main() {
+  group('StopReason', () {
+    test('maps known WorkManager stop reasons', () {
+      expect(StopReason.unknown.rawValue, 0);
+      expect(StopReason.timeout.rawValue, 1);
+      expect(StopReason.preempt.rawValue, 2);
+      expect(StopReason.cancelledByApp.rawValue, 3);
+      expect(StopReason.systemIgnoredCancelledByApp.rawValue, 4);
+      expect(StopReason.backgroundRestriction.rawValue, 5);
+      expect(StopReason.estimatedAppGpuLimit.rawValue, 6);
+      expect(StopReason.deviceState.rawValue, 7);
+      expect(StopReason.appStandby.rawValue, 8);
+      expect(StopReason.deviceIdle.rawValue, 9);
+    });
+
+    test('fromRawValue round-trips every known reason', () {
+      for (final reason in StopReason.values) {
+        expect(StopReason.fromRawValue(reason.rawValue), reason);
+      }
+    });
+
+    test('fromRawValue falls back to unknown for unrecognized values', () {
+      expect(StopReason.fromRawValue(-1), StopReason.unknown);
+      expect(StopReason.fromRawValue(42), StopReason.unknown);
+    });
+  });
+}

--- a/workmanager/test/workmanager_test.mocks.dart
+++ b/workmanager/test/workmanager_test.mocks.dart
@@ -50,11 +50,15 @@ class MockWorkmanager extends _i1.Mock implements _i2.Workmanager {
       ) as _i3.Future<void>);
 
   @override
-  void executeTask(_i2.BackgroundTaskHandler? backgroundTaskHandler) =>
+  void executeTask(
+    _i2.BackgroundTaskHandler? backgroundTaskHandler, {
+    _i2.BackgroundTaskStoppedHandler? onTaskStopped,
+  }) =>
       super.noSuchMethod(
         Invocation.method(
           #executeTask,
           [backgroundTaskHandler],
+          {#onTaskStopped: onTaskStopped},
         ),
         returnValueForMissingStub: null,
       );

--- a/workmanager_android/android/src/main/kotlin/dev/fluttercommunity/workmanager/BackgroundWorker.kt
+++ b/workmanager_android/android/src/main/kotlin/dev/fluttercommunity/workmanager/BackgroundWorker.kt
@@ -1,6 +1,7 @@
 package dev.fluttercommunity.workmanager
 
 import android.content.Context
+import android.os.Build
 import android.os.Handler
 import android.os.Looper
 import androidx.concurrent.futures.CallbackToFutureAdapter
@@ -173,12 +174,37 @@ class BackgroundWorker(
     }
 
     override fun onStopped() {
-        stopEngine(null)
+        val localDartTask = dartTask
+        val stopReason = workerStopReason()
+
+        // Notify the running Dart callback that WorkManager stopped the worker
+        // (cancelled, timed out, preempted, ...) so it can persist state or
+        // release resources before the engine is torn down.
+        if (localDartTask != null && ::flutterApi.isInitialized && engine != null) {
+            try {
+                flutterApi.onTaskStopped(localDartTask, stopReason.toLong()) {
+                    stopEngine(null, stopReason = stopReason)
+                }
+                return
+            } catch (e: Exception) {
+                WorkmanagerDebug.onExceptionEncountered(
+                    applicationContext,
+                    TaskDebugInfo(
+                        taskName = localDartTask,
+                        inputData = payload,
+                        startTime = startTime,
+                    ),
+                    e,
+                )
+            }
+        }
+        stopEngine(null, stopReason = stopReason)
     }
 
     private fun stopEngine(
         result: Result?,
         errorMessage: String? = null,
+        stopReason: Int = StopReasonUtils.STOP_REASON_UNKNOWN,
     ) {
         val fetchDuration = System.currentTimeMillis() - startTime
 
@@ -213,7 +239,7 @@ class BackgroundWorker(
             when (result) {
                 is Result.Success -> TaskStatus.COMPLETED
                 is Result.Retry -> TaskStatus.RESCHEDULED
-                else -> TaskStatus.FAILED
+                else -> StopReasonUtils.toTaskStatus(stopReason)
             }
         WorkmanagerDebug.onTaskStatusUpdate(applicationContext, taskInfo, status, taskResult)
 
@@ -229,6 +255,19 @@ class BackgroundWorker(
             engine = null
         }
     }
+
+    /**
+     * Returns the WorkManager stop reason for the current stop.
+     *
+     * The value is only populated on Android 12 (API 31) and newer; on older
+     * versions [StopReasonUtils.STOP_REASON_UNKNOWN] is reported.
+     */
+    private fun workerStopReason(): Int =
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            stopReason
+        } else {
+            StopReasonUtils.STOP_REASON_UNKNOWN
+        }
 
     private fun executeBackgroundTask() {
         // Convert payload to the format expected by Pigeon (Map<String?, Object?>)

--- a/workmanager_android/android/src/main/kotlin/dev/fluttercommunity/workmanager/StopReasonUtils.kt
+++ b/workmanager_android/android/src/main/kotlin/dev/fluttercommunity/workmanager/StopReasonUtils.kt
@@ -1,0 +1,30 @@
+package dev.fluttercommunity.workmanager
+
+import dev.fluttercommunity.workmanager.pigeon.TaskStatus
+
+/**
+ * WorkManager [StopReason](https://developer.android.com/reference/androidx/work/StopReason)
+ * constants and helpers.
+ *
+ * WorkManager only populates the actual stop reason on Android 12 (API 31)
+ * and newer; below that [STOP_REASON_UNKNOWN] is reported.
+ */
+object StopReasonUtils {
+    const val STOP_REASON_UNKNOWN = 0
+    const val STOP_REASON_CANCELLED_BY_APP = 3
+    const val STOP_REASON_SYSTEM_IGNORED_CANCELLED_BY_APP = 4
+
+    /**
+     * Maps a stop reason to the debug [TaskStatus] reported by the plugin.
+     *
+     * App-initiated cancellations surface as [TaskStatus.CANCELLED]; every
+     * other stop keeps the previous [TaskStatus.FAILED] behavior.
+     */
+    fun toTaskStatus(stopReason: Int): TaskStatus =
+        when (stopReason) {
+            STOP_REASON_CANCELLED_BY_APP,
+            STOP_REASON_SYSTEM_IGNORED_CANCELLED_BY_APP,
+            -> TaskStatus.CANCELLED
+            else -> TaskStatus.FAILED
+        }
+}

--- a/workmanager_android/android/src/main/kotlin/dev/fluttercommunity/workmanager/pigeon/WorkmanagerApi.g.kt
+++ b/workmanager_android/android/src/main/kotlin/dev/fluttercommunity/workmanager/pigeon/WorkmanagerApi.g.kt
@@ -1343,4 +1343,30 @@ class WorkmanagerFlutterApi(private val binaryMessenger: BinaryMessenger, privat
       } 
     }
   }
+  /**
+   * Notifies the Dart callback that a running task was stopped by the
+   * platform before it finished (cancelled, timed out, preempted, ...).
+   *
+   * [stopReason] carries the Android WorkManager stop reason (see
+   * [StopReason](https://developer.android.com/reference/androidx/work/StopReason)).
+   * It is `0` (unknown) on Android versions before 12 (API 31) and on
+   * platforms without an equivalent concept.
+   */
+  fun onTaskStopped(taskNameArg: String, stopReasonArg: Long, callback: (Result<Unit>) -> Unit)
+{
+    val separatedMessageChannelSuffix = if (messageChannelSuffix.isNotEmpty()) ".$messageChannelSuffix" else ""
+    val channelName = "dev.flutter.pigeon.workmanager_platform_interface.WorkmanagerFlutterApi.onTaskStopped$separatedMessageChannelSuffix"
+    val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
+    channel.send(listOf(taskNameArg, stopReasonArg)) {
+      if (it is List<*>) {
+        if (it.size > 1) {
+          callback(Result.failure(FlutterError(it[0] as String, it[1] as String, it[2] as String?)))
+        } else {
+          callback(Result.success(Unit))
+        }
+      } else {
+        callback(Result.failure(WorkmanagerApiPigeonUtils.createConnectionError(channelName)))
+      } 
+    }
+  }
 }

--- a/workmanager_android/android/src/test/kotlin/dev/fluttercommunity/workmanager/StopReasonUtilsTest.kt
+++ b/workmanager_android/android/src/test/kotlin/dev/fluttercommunity/workmanager/StopReasonUtilsTest.kt
@@ -1,0 +1,22 @@
+package dev.fluttercommunity.workmanager
+
+import dev.fluttercommunity.workmanager.pigeon.TaskStatus
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class StopReasonUtilsTest {
+    @Test
+    fun `app cancellations map to the cancelled status`() {
+        assertEquals(TaskStatus.CANCELLED, StopReasonUtils.toTaskStatus(StopReasonUtils.STOP_REASON_CANCELLED_BY_APP))
+        assertEquals(TaskStatus.CANCELLED, StopReasonUtils.toTaskStatus(StopReasonUtils.STOP_REASON_SYSTEM_IGNORED_CANCELLED_BY_APP))
+    }
+
+    @Test
+    fun `other stop reasons keep the failed status`() {
+        assertEquals(TaskStatus.FAILED, StopReasonUtils.toTaskStatus(StopReasonUtils.STOP_REASON_UNKNOWN))
+        assertEquals(TaskStatus.FAILED, StopReasonUtils.toTaskStatus(1))
+        assertEquals(TaskStatus.FAILED, StopReasonUtils.toTaskStatus(2))
+        assertEquals(TaskStatus.FAILED, StopReasonUtils.toTaskStatus(5))
+        assertEquals(TaskStatus.FAILED, StopReasonUtils.toTaskStatus(99))
+    }
+}

--- a/workmanager_apple/ios/workmanager_apple/Sources/workmanager_apple/pigeon/WorkmanagerApi.g.swift
+++ b/workmanager_apple/ios/workmanager_apple/Sources/workmanager_apple/pigeon/WorkmanagerApi.g.swift
@@ -1175,6 +1175,14 @@ class WorkmanagerHostApiSetup {
 protocol WorkmanagerFlutterApiProtocol {
   func backgroundChannelInitialized(completion: @escaping (Result<Void, PigeonError>) -> Void)
   func executeTask(taskName taskNameArg: String, inputData inputDataArg: [String?: Any?]?, completion: @escaping (Result<Bool, PigeonError>) -> Void)
+  /// Notifies the Dart callback that a running task was stopped by the
+  /// platform before it finished (cancelled, timed out, preempted, ...).
+  ///
+  /// [stopReason] carries the Android WorkManager stop reason (see
+  /// [StopReason](https://developer.android.com/reference/androidx/work/StopReason)).
+  /// It is `0` (unknown) on Android versions before 12 (API 31) and on
+  /// platforms without an equivalent concept.
+  func onTaskStopped(taskName taskNameArg: String, stopReason stopReasonArg: Int64, completion: @escaping (Result<Void, PigeonError>) -> Void)
 }
 class WorkmanagerFlutterApi: WorkmanagerFlutterApiProtocol {
   private let binaryMessenger: FlutterBinaryMessenger
@@ -1222,6 +1230,31 @@ class WorkmanagerFlutterApi: WorkmanagerFlutterApiProtocol {
       } else {
         let result = listResponse[0] as! Bool
         completion(.success(result))
+      }
+    }
+  }
+  /// Notifies the Dart callback that a running task was stopped by the
+  /// platform before it finished (cancelled, timed out, preempted, ...).
+  ///
+  /// [stopReason] carries the Android WorkManager stop reason (see
+  /// [StopReason](https://developer.android.com/reference/androidx/work/StopReason)).
+  /// It is `0` (unknown) on Android versions before 12 (API 31) and on
+  /// platforms without an equivalent concept.
+  func onTaskStopped(taskName taskNameArg: String, stopReason stopReasonArg: Int64, completion: @escaping (Result<Void, PigeonError>) -> Void) {
+    let channelName: String = "dev.flutter.pigeon.workmanager_platform_interface.WorkmanagerFlutterApi.onTaskStopped\(messageChannelSuffix)"
+    let channel = FlutterBasicMessageChannel(name: channelName, binaryMessenger: binaryMessenger, codec: codec)
+    channel.sendMessage([taskNameArg, stopReasonArg] as [Any?]) { response in
+      guard let listResponse = response as? [Any?] else {
+        completion(.failure(createConnectionError(withChannelName: channelName)))
+        return
+      }
+      if listResponse.count > 1 {
+        let code: String = listResponse[0] as! String
+        let message: String? = nilOrValue(listResponse[1])
+        let details: String? = nilOrValue(listResponse[2])
+        completion(.failure(PigeonError(code: code, message: message, details: details)))
+      } else {
+        completion(.success(()))
       }
     }
   }

--- a/workmanager_platform_interface/lib/src/pigeon/workmanager_api.g.dart
+++ b/workmanager_platform_interface/lib/src/pigeon/workmanager_api.g.dart
@@ -1164,6 +1164,15 @@ abstract class WorkmanagerFlutterApi {
 
   Future<bool> executeTask(String taskName, Map<String?, Object?>? inputData);
 
+  /// Notifies the Dart callback that a running task was stopped by the
+  /// platform before it finished (cancelled, timed out, preempted, ...).
+  ///
+  /// [stopReason] carries the Android WorkManager stop reason (see
+  /// [StopReason](https://developer.android.com/reference/androidx/work/StopReason)).
+  /// It is `0` (unknown) on Android versions before 12 (API 31) and on
+  /// platforms without an equivalent concept.
+  Future<void> onTaskStopped(String taskName, int stopReason);
+
   static void setUp(WorkmanagerFlutterApi? api, {BinaryMessenger? binaryMessenger, String messageChannelSuffix = '',}) {
     messageChannelSuffix = messageChannelSuffix.isNotEmpty ? '.$messageChannelSuffix' : '';
     {
@@ -1199,6 +1208,28 @@ abstract class WorkmanagerFlutterApi {
           try {
             final bool output = await api.executeTask(arg_taskName, arg_inputData);
             return wrapResponse(result: output);
+          } on PlatformException catch (e) {
+            return wrapResponse(error: e);
+          }          catch (e) {
+            return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
+          }
+        });
+      }
+    }
+    {
+      final pigeonVar_channel = BasicMessageChannel<Object?>(
+          'dev.flutter.pigeon.workmanager_platform_interface.WorkmanagerFlutterApi.onTaskStopped$messageChannelSuffix', pigeonChannelCodec,
+          binaryMessenger: binaryMessenger);
+      if (api == null) {
+        pigeonVar_channel.setMessageHandler(null);
+      } else {
+        pigeonVar_channel.setMessageHandler((Object? message) async {
+          final List<Object?> args = message! as List<Object?>;
+          final String arg_taskName = args[0]! as String;
+          final int arg_stopReason = args[1]! as int;
+          try {
+            await api.onTaskStopped(arg_taskName, arg_stopReason);
+            return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
           }          catch (e) {

--- a/workmanager_platform_interface/lib/src/stop_reason.dart
+++ b/workmanager_platform_interface/lib/src/stop_reason.dart
@@ -1,0 +1,55 @@
+/// The reason a running background task was stopped by the platform before it
+/// finished.
+///
+/// The values mirror Android's WorkManager
+/// [StopReason](https://developer.android.com/reference/androidx/work/StopReason)
+/// constants. Android 12 (API 31) is the first version where WorkManager
+/// reports the actual reason; on older Android versions and on platforms
+/// without an equivalent concept the reason is reported as [unknown].
+enum StopReason {
+  /// The reason could not be determined (Android < 12, or a platform with no
+  /// equivalent concept).
+  unknown(0),
+
+  /// The task ran for longer than its allowed time limit.
+  timeout(1),
+
+  /// The task was stopped because a higher-priority task preempted it.
+  preempt(2),
+
+  /// The task was cancelled by the app.
+  cancelledByApp(3),
+
+  /// The task was cancelled by the app, but the system ignored the
+  /// cancellation and the worker ran to completion.
+  systemIgnoredCancelledByApp(4),
+
+  /// The app is in a background restriction state.
+  backgroundRestriction(5),
+
+  /// The app reached an estimated GPU memory limit.
+  estimatedAppGpuLimit(6),
+
+  /// The device entered a state that stops the task (e.g. battery saver).
+  deviceState(7),
+
+  /// The app entered App Standby.
+  appStandby(8),
+
+  /// The device entered Doze mode.
+  deviceIdle(9);
+
+  const StopReason(this.rawValue);
+
+  /// The integer value as reported by the platform.
+  final int rawValue;
+
+  /// Maps a platform-reported [rawValue] to the closest [StopReason].
+  ///
+  /// Values that are not recognized (e.g. new stop reasons added by future
+  /// WorkManager releases) map to [StopReason.unknown].
+  static StopReason fromRawValue(int rawValue) => values.firstWhere(
+        (reason) => reason.rawValue == rawValue,
+        orElse: () => StopReason.unknown,
+      );
+}

--- a/workmanager_platform_interface/lib/workmanager_platform_interface.dart
+++ b/workmanager_platform_interface/lib/workmanager_platform_interface.dart
@@ -2,3 +2,4 @@ library workmanager_platform_interface;
 
 export 'src/workmanager_platform_interface.dart';
 export 'src/pigeon/workmanager_api.g.dart';
+export 'src/stop_reason.dart';

--- a/workmanager_platform_interface/pigeons/workmanager_api.dart
+++ b/workmanager_platform_interface/pigeons/workmanager_api.dart
@@ -409,4 +409,14 @@ abstract class WorkmanagerFlutterApi {
 
   @async
   bool executeTask(String taskName, Map<String?, Object?>? inputData);
+
+  /// Notifies the Dart callback that a running task was stopped by the
+  /// platform before it finished (cancelled, timed out, preempted, ...).
+  ///
+  /// [stopReason] carries the Android WorkManager stop reason (see
+  /// [StopReason](https://developer.android.com/reference/androidx/work/StopReason)).
+  /// It is `0` (unknown) on Android versions before 12 (API 31) and on
+  /// platforms without an equivalent concept.
+  @async
+  void onTaskStopped(String taskName, int stopReason);
 }


### PR DESCRIPTION
## What

Fixes #432: when WorkManager stops a worker that is currently running (app cancellation via `cancelByUniqueName` / `cancelByTag` / `cancelAll`, timeout, preemption, Doze/App Standby, ...), the Dart callback now gets notified before the background engine is torn down.

## Why the `executeTask` handler (not `registerOneOffTask` / `registerPeriodicTask`)

The register calls run in the **main isolate**, while the task callback runs in the **background engine isolate** (`callbackDispatcher`). A closure passed to `registerOneOffTask` cannot be invoked from the background isolate, so the stop handler has to be registered where the notification arrives — next to the task handler in `executeTask`, which is the plugin's existing ergonomics for callback-shaped APIs.

## API

```dart
Workmanager().executeTask(
  (taskName, inputData) async { ... },
  onTaskStopped: (taskName, stopReason) async {
    // Persist state / mark cancelled, then return promptly.
  },
);
```

- New `StopReason` enum in `workmanager_platform_interface`, mirroring Android's WorkManager `StopReason` values (0–9), with a safe fallback to `unknown` for future values.
- Android `BackgroundWorker.onStopped()` now calls a new Pigeon `WorkmanagerFlutterApi.onTaskStopped(taskName, stopReason)`; the engine is torn down once the Dart handler completes. The real `stopReason` is surfaced on Android 12+ (API 31); older versions report `unknown` (WorkManager only populates the reason there).
- App-initiated cancellations now also surface as `TaskStatus.CANCELLED` in the debug handlers instead of `FAILED`.
- iOS is intentionally untouched at runtime: `cancelByUniqueName` there only removes *pending* BGTaskScheduler requests, there is no equivalent to stopping a running task, so `onTaskStopped` never fires on iOS (documented).

## Tests

- `workmanager/test/stop_reason_test.dart` — enum mapping round-trip + unknown fallback.
- `workmanager/test/on_task_stopped_test.dart` — Pigeon `onTaskStopped` delivery through the in-process messenger (known + unknown reason, no-handler ack).
- `StopReasonUtilsTest.kt` — stop-reason → debug status mapping (ran in all unit-test variants).
- Regenerated Pigeon for all platforms (`melos run generate` zero-diff).

## Docs

- `docs/customization.mdx` → "Cancelling Running Work (Android)" section under Canceling Tasks.
- README → short "Cancelling Running Work (Android)" section.
