### PR TITLE
docs(ios): periodic timing reality + chaining guidance (fixes #306)

### DIFF
--- a/docs/customization.mdx
+++ b/docs/customization.mdx
@@ -193,6 +193,81 @@ to happen at a specific time, schedule a one-off task with `initialDelay` that
 registers the periodic task when it runs.
 </Warning>
 
+## iOS: Periodic Timing & Chaining One-off Tasks
+
+On iOS there is no fixed-interval scheduler. `registerPeriodicTask` submits a
+`BGAppRefreshTaskRequest` and hands all timing to the system: the `frequency`
+you pass from Dart is **ignored on iOS**, and `initialDelay` is used as the
+earliest-begin hint (`earliestBeginDate`). iOS then decides *when — and whether
+—* the task runs, based on app usage patterns, device state, and battery. 15
+minutes is the *minimum gap*, never a cadence: expect runs to be deferred by
+hours or skipped entirely.
+
+### Chaining one-off tasks
+
+The Apple-recommended way to approximate periodic work is to schedule the next
+run from inside the callback:
+
+```dart
+@pragma('vm:entry-point')
+void callbackDispatcher() {
+  Workmanager().executeTask((taskName, inputData) async {
+    // ... do the work ...
+
+    // Schedule the next run. Submitting to BGTaskScheduler (rather than a
+    // plain one-off) means the next link survives app relaunches; the plugin
+    // re-registers the launch handler from UserDefaults on the next launch.
+    Workmanager().registerPeriodicTask(
+      "com.example.sync",
+      "sync",
+      initialDelay: Duration(hours: 1),
+    );
+    return true;
+  });
+}
+```
+
+For work that should run when the device is idle (and may take minutes), chain
+`registerProcessingTask` the same way instead — `BGProcessingTask` gets a
+larger budget but only runs while the device is idle, often overnight.
+
+### What chaining buys you — and what it does not
+
+- **"At least N apart", never "every N".** `initialDelay` is a floor, not a
+  time. Each link runs whenever iOS chooses, so intervals drift and can
+  stretch to hours.
+- **The chain advances only when a link runs and re-submits.** If the app is
+  force-quit, iOS stops launching it for background work until the user opens
+  it again, so a chain that only re-submits from inside the callback stalls.
+- **App updates can break the chain.** BGTaskScheduler requests do not
+  reliably survive app updates. The plugin's UserDefaults persistence
+  re-registers the *launch handlers* on the next launch, but *requests* are
+  only re-submitted when your code registers the task again — re-seed the
+  chain from your normal startup path (e.g. `main`) if continuity across
+  updates matters.
+- **Failures reduce future scheduling.** Returning `false` reports the task
+  as failed to the system, and repeated failures cause iOS to defer future
+  runs. There is no Android-style backoff policy on iOS; implement your own
+  by choosing the next `initialDelay`.
+- **Energy is metered.** Each opportunistic run costs battery and network.
+  Asking for more than the user's usage justifies gets the chain throttled.
+
+### Periodic vs chaining
+
+- **Keep `registerPeriodicTask`** for best-effort content refresh (news,
+  sync, cleanup) that tolerates the system pacing it around the user's usage.
+- **Chain** when you need a tighter floor between runs, want to vary the gap
+  dynamically (e.g. backoff), or need idle-gated heavy work
+  (`registerProcessingTask`).
+- **Neither gives precision.** Exact-interval background work is not possible
+  on iOS. For work that must *start now* on a user action and keep running
+  while the app is backgrounded, use `registerContinuedProcessingTask`
+  (`BGContinuedProcessingTask`, iOS 26+, shipped in 0.10.0) instead — it is a
+  long-running complement, not a scheduling mechanism.
+
+See the [platform capability matrix](index#platform-capability-matrix) for a
+side-by-side summary of every task type.
+
 ## Advanced Configuration
 
 ### Task Identification

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -77,17 +77,11 @@ iOS offers several scheduling strategies. Workmanager wraps the three
 | `BGAppRefreshTaskRequest` | `registerPeriodicTask` | 13+ | ~30 seconds | Periodically, based on app usage; at least 15 minutes between launches | Best-effort; no guaranteed interval; does not run on a schedule |
 | `BGProcessingTaskRequest` | `registerProcessingTask` | 13+ | Minutes (typically 1–10, dynamically adjusted) | When the device is idle (often overnight, possibly while charging) | Best-effort but more generous than refresh; may be deferred or interrupted |
 | `BGHealthResearchTaskRequest` | `registerHealthResearchTask` | 17+ | Minutes, like processing tasks | When the device is idle, with additional priority for study-essential processing | Higher priority/reliability than plain processing, but only for health-research apps (entitlement + study container + user opt-in) |
-| `BGContinuedProcessingTaskRequest` | Not yet supported (planned) | 26+ | Starts in the foreground, continues in background | Immediately after submission, which must be a user action (e.g. button tap) | Continues as long as progress is reported (Live Activity + progress protocol); the system can terminate it abruptly under resource pressure |
+| `BGContinuedProcessingTaskRequest` | `registerContinuedProcessingTask` | 26+ | Starts in the foreground, continues in background | Immediately after submission, which must be a user action (e.g. button tap) | Continues as long as progress is reported (Live Activity + progress protocol); the system can terminate it abruptly under resource pressure |
 | Background fetch (`performFetchWithCompletionHandler`) | iOS < 13 fallback (`Workmanager.iOSBackgroundTask`) | 7–12 | ~30 seconds | System-managed; typically ~once per day based on usage | Best-effort |
 
 **Gaps in workmanager today:**
 
-- `BGContinuedProcessingTaskRequest` (iOS 26+) is not supported. It is a
-  *foreground-initiated* task (submitted as a result of a user action, showing
-  progress in a Live Activity), which does not fit the register-then-run-later
-  model of workmanager. A future API would need to run the Flutter engine in
-  the foreground and keep it alive across backgrounding — a distinct feature,
-  tracked in issue #638.
 - `registerProcessingTask` on iOS currently delivers the task without the
   `inputData` captured at registration time (only one-off and periodic tasks
   persist input data). Health research tasks persist input data like periodic


### PR DESCRIPTION
## What

Fixes #306's follow-up question ("is chaining one-off tasks a reliable alternative to periodic callbacks on iOS? any downsides?") by folding the answer into the docs.

## Changes

- **`docs/customization.mdx`** → new section "iOS: Periodic Timing & Chaining One-off Tasks":
  - How BGTaskScheduler timing actually works in this plugin: `registerPeriodicTask` submits a `BGAppRefreshTaskRequest`; `frequency` is ignored on iOS and `initialDelay` becomes the `earliestBeginDate` hint — no fixed intervals, system-decided runs.
  - The chaining pattern (schedule the next run from inside the callback) with a code example, plus `registerProcessingTask` for idle-gated chains.
  - Concrete tradeoffs: no guaranteed cadence, drift, force-quit stalls the chain, app updates can invalidate pending requests (re-seed from startup; UserDefaults persistence re-registers launch handlers but not requests), failures reduce future scheduling (no Android-style backoff), energy throttling, short run budgets.
  - When periodic vs chaining is the right tool, and a pointer to `registerContinuedProcessingTask` (#700, shipped in 0.10.0) for long-running work.
- **`docs/index.mdx`** → small adjacent correctness fix: the iOS strategy matrix still said `BGContinuedProcessingTaskRequest` was "not yet supported (planned)"; it shipped in 0.10.0 via #700, so the row now points at `registerContinuedProcessingTask` and the stale "Gaps" bullet is removed (kept the genuine remaining inputData gap for processing tasks).

The maintainer reply draft for #306 (same content, conversational form) is in the session and will be posted separately by the owner — nothing is posted from this PR.
