### PR TITLE
feat(web): bidirectional message channel between page and background worker

### DIFF
--- a/.github/workflows/pages-demo.yml
+++ b/.github/workflows/pages-demo.yml
@@ -1,0 +1,46 @@
+name: pages-demo
+
+on:
+  push:
+    branches: [feat/web-worker-messaging]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: pages-demo
+  cancel-in-progress: true
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          flutter-version-file: .fvmrc
+
+      - name: Bootstrap workspace (melos)
+        run: |
+          dart pub global activate melos
+          melos bootstrap
+
+      - name: Build web demo (GitHub Pages subpath)
+        working-directory: example
+        run: flutter build web --release --base-href=/flutter_workmanager/
+
+      - name: Deploy to gh-pages
+        working-directory: example
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          cd build/web
+          git init -q
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add -A
+          git commit -q -m "deploy: web demo $(date -u +%Y%m%dT%H%M%SZ)"
+          git push -f "https://x-access-token:${GITHUB_TOKEN}@github.com/FlutterCommunity/flutter_workmanager.git" HEAD:gh-pages

--- a/.github/workflows/pages-demo.yml
+++ b/.github/workflows/pages-demo.yml
@@ -37,6 +37,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          # CanvasKit loads from gstatic (--web-resources-cdn); don't ship the
+          # 26MB local bundle to gh-pages.
+          rm -rf build/web/canvaskit
           cd build/web
           git init -q
           git config user.name "github-actions[bot]"

--- a/.github/workflows/pages-demo.yml
+++ b/.github/workflows/pages-demo.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Build web demo (GitHub Pages subpath)
         working-directory: example
-        run: flutter build web --release --base-href=/flutter_workmanager/
+        run: flutter build web --release --base-href=/flutter_workmanager/ --web-resources-cdn
 
       - name: Deploy to gh-pages
         working-directory: example

--- a/example/README.md
+++ b/example/README.md
@@ -70,7 +70,7 @@ localhost) to get the web-only demo. It demonstrates the experimental
 and no API keys needed:
 
 - **Two-way worker messaging** — the page and the background worker talk
-  over `postMessage` (Worker chat tab). Tap "Watch Cardiff" and the worker
+  over `postMessage` (Chat tab). Tap "Watch Cardiff" and the worker
   streams simulated temperatures, alerting when it drops below the
   threshold; type any text and it echoes back. Page → worker via
   `sendMessageToWorker()`, worker → page via `sendToPage()` (surfaced on
@@ -80,10 +80,13 @@ and no API keys needed:
   the task's CPU loop runs). "Run check now" fires a one-off task; a
   periodic temperature check is registered automatically every 15 minutes.
   Results appear in the Task log tab.
-- **Service Worker execution** — install the PWA, trigger Periodic Background
-  Sync from DevTools, close the page, trigger it again and reopen: the task
-  ran inside the Service Worker (compiled Dart dispatcher) and the result is
-  replayed from IndexedDB into the event log.
+- **Service Worker execution + notifications** — install the PWA, allow
+  notifications, close the tab, trigger Periodic Background Sync from
+  DevTools and reopen: the task ran inside the Service Worker (compiled
+  Dart dispatcher) and showed a notification while the tab was closed; the
+  result is replayed from IndexedDB into the event log on the next load.
+
+The demo has a **Guide tab** that walks through all of this step by step.
 
 The background handler lives in `lib/web/background_tasks.dart` — a
 Flutter-free file compiled with plain `dart compile js` into

--- a/example/README.md
+++ b/example/README.md
@@ -61,3 +61,35 @@ The demo includes practical examples:
 ## Documentation
 
 For detailed guides and real-world use cases, visit: **[docs.page/fluttercommunity/flutter_workmanager →](https://docs.page/fluttercommunity/flutter_workmanager)**
+
+## Web Demo (experimental)
+
+Run `flutter run -d chrome` (or `flutter build web` and serve over HTTPS or
+localhost) to get the web-only demo. It demonstrates the experimental
+`workmanager_web` package:
+
+- **Background tasks in a Web Worker** — register one-off / periodic tasks
+  and watch them execute off the main thread (the UI stays responsive while
+  the task's CPU loop runs).
+- **Worker chat** — a two-way `postMessage` conversation between the page and
+  the background worker (suggestions: watch a simulated BTC/ETH price, stop
+  the watch, or run an on-demand background check). Replies arrive on
+  `WorkmanagerWeb.workerMessages`; the same pattern applies to real data.
+- **Service Worker execution** — install the PWA, trigger Periodic Background
+  Sync from DevTools, close the page, trigger it again and reopen: the task
+  ran inside the Service Worker (compiled Dart dispatcher) and the result is
+  replayed from IndexedDB into the event log.
+
+The background handler lives in `lib/web/background_tasks.dart` — a
+Flutter-free file compiled with plain `dart compile js` into
+`web/background.dart.js` (see `tool/build_web_background.sh`). Prices in the
+demo are simulated so it works offline; swap `_simulatedPrice()` for a real
+fetch to see the same pattern with live data.
+
+## Key Files
+
+- `lib/main.dart` - Main app with task scheduling UI
+- `lib/web/` - Web-only demo (Flutter-free dispatcher, worker chat, PWA install glue)
+- `lib/callback_dispatcher.dart` - Background task execution logic
+- `ios/Runner/AppDelegate.swift` - iOS background task registration
+- `ios/Runner/Info.plist` - iOS background modes configuration

--- a/example/README.md
+++ b/example/README.md
@@ -66,15 +66,20 @@ For detailed guides and real-world use cases, visit: **[docs.page/fluttercommuni
 
 Run `flutter run -d chrome` (or `flutter build web` and serve over HTTPS or
 localhost) to get the web-only demo. It demonstrates the experimental
-`workmanager_web` package:
+`workmanager_web` package with a simulated **weather watch** — no network
+and no API keys needed:
 
+- **Two-way worker messaging** — the page and the background worker talk
+  over `postMessage` (Worker chat tab). Tap "Watch Cardiff" and the worker
+  streams simulated temperatures, alerting when it drops below the
+  threshold; type any text and it echoes back. Page → worker via
+  `sendMessageToWorker()`, worker → page via `sendToPage()` (surfaced on
+  `WorkmanagerWeb.workerMessages`).
 - **Background tasks in a Web Worker** — register one-off / periodic tasks
   and watch them execute off the main thread (the UI stays responsive while
-  the task's CPU loop runs).
-- **Worker chat** — a two-way `postMessage` conversation between the page and
-  the background worker (suggestions: watch a simulated BTC/ETH price, stop
-  the watch, or run an on-demand background check). Replies arrive on
-  `WorkmanagerWeb.workerMessages`; the same pattern applies to real data.
+  the task's CPU loop runs). "Run check now" fires a one-off task; a
+  periodic temperature check is registered automatically every 15 minutes.
+  Results appear in the Task log tab.
 - **Service Worker execution** — install the PWA, trigger Periodic Background
   Sync from DevTools, close the page, trigger it again and reopen: the task
   ran inside the Service Worker (compiled Dart dispatcher) and the result is
@@ -82,8 +87,8 @@ localhost) to get the web-only demo. It demonstrates the experimental
 
 The background handler lives in `lib/web/background_tasks.dart` — a
 Flutter-free file compiled with plain `dart compile js` into
-`web/background.dart.js` (see `tool/build_web_background.sh`). Prices in the
-demo are simulated so it works offline; swap `_simulatedPrice()` for a real
+`web/background.dart.js` (see `tool/build_web_background.sh`). Temperatures
+are simulated so the demo works offline; swap `_simulatedTemp()` for a real
 fetch to see the same pattern with live data.
 
 ## Key Files

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -10,7 +10,7 @@ import 'package:permission_handler/permission_handler.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:workmanager/workmanager.dart';
 
-import 'web/web_demo_page.dart';
+import 'web/web_app.dart';
 
 void main() {
   if (kIsWeb) {

--- a/example/lib/web/app_theme.dart
+++ b/example/lib/web/app_theme.dart
@@ -1,0 +1,79 @@
+// Copyright 2024 The Flutter Workmanager Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+
+/// Shared high-contrast palette and theme for the web demo app (landing page
+/// and demo), so both stay visually consistent.
+abstract final class AppTheme {
+  // High-contrast status colors, readable on white.
+  static const Color okGreen = Color(0xFF1E8E3E);
+  static const Color alertRed = Color(0xFFC5221F);
+  static const Color warnOrange = Color(0xFFB06000);
+  static const Color infoBlue = Color(0xFF174EA6);
+  static const Color mutedGrey = Color(0xFF5B6670);
+
+  // Surfaces.
+  static const Color primaryBlue = Color(0xFF0B57D0);
+  static const Color primaryContainer = Color(0xFFD3E3FD);
+  static const Color onPrimaryContainer = Color(0xFF001B3F);
+  static const Color cardFill = Color(0xFFF1F4F8);
+  static const Color borderGrey = Color(0xFFB0B8BF);
+  static const Color surfaceHighest = Color(0xFFE1E5E8);
+  static const Color textPrimary = Color(0xFF111111);
+  static const Color textSecondary = Color(0xFF1F1F1F);
+
+  static ThemeData light() {
+    return ThemeData(
+      useMaterial3: true,
+      colorScheme: ColorScheme.fromSeed(
+        seedColor: primaryBlue,
+      ).copyWith(
+        primary: primaryBlue,
+        onPrimary: Colors.white,
+        primaryContainer: primaryContainer,
+        onPrimaryContainer: onPrimaryContainer,
+        surface: Colors.white,
+        onSurface: textPrimary,
+        onSurfaceVariant: textSecondary,
+        outline: mutedGrey,
+        outlineVariant: borderGrey,
+        surfaceContainerHighest: surfaceHighest,
+      ),
+      textTheme: const TextTheme(
+        titleLarge: TextStyle(
+          fontSize: 20,
+          fontWeight: FontWeight.w600,
+          color: textPrimary,
+        ),
+        titleSmall: TextStyle(
+          fontSize: 15,
+          fontWeight: FontWeight.w700,
+          color: textPrimary,
+        ),
+        bodyLarge: TextStyle(fontSize: 16, color: textPrimary),
+        bodyMedium: TextStyle(fontSize: 15, color: textPrimary),
+        bodySmall: TextStyle(fontSize: 14, color: textSecondary),
+        labelLarge: TextStyle(fontSize: 14, color: textPrimary),
+      ),
+      appBarTheme: const AppBarTheme(
+        backgroundColor: primaryBlue,
+        foregroundColor: Colors.white,
+        titleTextStyle: TextStyle(
+          fontSize: 20,
+          fontWeight: FontWeight.w600,
+          color: Colors.white,
+        ),
+      ),
+      tabBarTheme: const TabBarThemeData(
+        labelColor: Colors.white,
+        unselectedLabelColor: primaryContainer,
+        indicatorColor: Colors.white,
+        labelStyle: TextStyle(fontSize: 14, fontWeight: FontWeight.w600),
+        unselectedLabelStyle: TextStyle(fontSize: 14),
+      ),
+      dividerTheme: const DividerThemeData(color: borderGrey),
+    );
+  }
+}

--- a/example/lib/web/background_tasks.dart
+++ b/example/lib/web/background_tasks.dart
@@ -8,6 +8,8 @@
 // the Service Worker, neither of which can run the Flutter engine.
 
 import 'dart:async';
+import 'dart:js_interop';
+import 'dart:js_interop_unsafe';
 
 import 'package:workmanager_web/execution.dart';
 
@@ -173,7 +175,38 @@ Future<bool> handleWebBackgroundTask(
     'tempC': tempC,
     'below': below,
   });
+  _notify(
+    below
+        ? '❄️ $city below the alert threshold'
+        : 'Temperature check: ${_capitalize(city)}',
+    '${tempC.toStringAsFixed(1)}°C — '
+        '${below ? 'below the alert threshold' : 'all good'}',
+  );
   // The task result itself stays a plain success/failure bool; the
   // temperature detail is delivered via the chat messages above.
   return true;
+}
+
+/// Shows a browser notification when a background task finishes inside the
+/// Service Worker (i.e. while the page is closed). The dedicated Web Worker
+/// has no `registration`, so there the page shows the notification instead.
+void _notify(String title, String body) {
+  final self = globalContext;
+  if (!self.has('registration')) {
+    return;
+  }
+  final registration = self['registration'] as JSObject;
+  final promise = registration.callMethod(
+    'showNotification'.toJS,
+    title.toJS,
+    <String, Object?>{'body': body, 'tag': 'workmanager-demo'}.jsify(),
+  ) as JSPromise<JSAny?>;
+  promise.toDart.catchError((Object _) => null);
+}
+
+String _capitalize(String input) {
+  if (input.isEmpty) {
+    return input;
+  }
+  return input[0].toUpperCase() + input.substring(1);
 }

--- a/example/lib/web/background_tasks.dart
+++ b/example/lib/web/background_tasks.dart
@@ -21,24 +21,23 @@ void webCallbackDispatcher() {
 }
 
 // ---------------------------------------------------------------------------
-// Use case: a tiny "price watch".
+// Use case: a simulated "weather watch".
 //
-// The demo simulates a market feed so it stays self-contained (no network, no
-// API key). The same shape applies to any real background work:
+// The demo simulates a temperature feed so it stays self-contained (no
+// network, no API key). The same shape applies to any real background work:
 //
-// * the page sends a message to the worker  -> messageHandler runs in the
-//   Web Worker (off the main thread),
-// * the worker pushes updates back          -> sendToPage surfaces them on
-//   `WorkmanagerWeb.workerMessages`,
+// * the page sends a message to the worker       -> messageHandler runs in
+//   the Web Worker (off the main thread),
+// * the worker pushes updates back              -> sendToPage surfaces them
+//   on `WorkmanagerWeb.workerMessages`,
 // * background tasks (also while the page is closed, via the Service Worker)
 //   run the same handler and their results are replayed into the event log.
 // ---------------------------------------------------------------------------
 
-/// Base prices per ticker, in USD. Simulated.
-const Map<String, double> _basePrices = <String, double>{
-  'btc': 60000,
-  'eth': 2500,
-  'ada': 0.60,
+/// Simulated baseline temperature per city, in °C.
+const Map<String, double> _baseTemps = <String, double>{
+  'cardiff': 11.0,
+  'taipei': 26.0,
 };
 
 Timer? _watchTimer;
@@ -47,10 +46,13 @@ Timer? _watchTimer;
 /// `WorkmanagerWeb().sendMessageToWorker(...)`.
 ///
 /// Messages:
-/// * `{'op': 'watch', 'ticker': 'btc', 'threshold': 58000}` — start pushing
-///   simulated prices every few seconds; stops itself when the price drops
-///   below [threshold].
+/// * `{'op': 'watch', 'city': 'cardiff', 'threshold': 5.0}` — start pushing
+///   simulated temperatures every few seconds; stops itself when the
+///   temperature drops below [threshold].
 /// * `{'op': 'stop'}` — stop the current watch.
+/// * `{'op': 'check', 'city': ..., 'threshold': ...}` — run a one-off
+///   background check (same logic as the task path).
+/// * `{'op': 'text', 'text': ...}` — echo arbitrary text back.
 void handleWorkerMessage(Object? payload) {
   if (payload is! Map) {
     return;
@@ -58,18 +60,18 @@ void handleWorkerMessage(Object? payload) {
   final op = payload['op'];
   switch (op) {
     case 'watch':
-      final ticker = (payload['ticker'] as String?)?.toLowerCase() ?? 'btc';
+      final city = (payload['city'] as String?)?.toLowerCase() ?? 'cardiff';
       final threshold = (payload['threshold'] as num?)?.toDouble();
       _watchTimer?.cancel();
       _post(<String, Object?>{
         'kind': 'watching',
-        'ticker': ticker,
+        'city': city,
         'threshold': threshold,
       });
-      _postTick(ticker, threshold);
+      _postTick(city, threshold);
       _watchTimer = Timer.periodic(
         const Duration(seconds: 3),
-        (_) => _postTick(ticker, threshold),
+        (_) => _postTick(city, threshold),
       );
     case 'stop':
       _watchTimer?.cancel();
@@ -77,15 +79,15 @@ void handleWorkerMessage(Object? payload) {
       _post(<String, Object?>{'kind': 'stopped'});
     case 'check':
       // One-off background check on demand (same logic as the task path).
-      final ticker = (payload['ticker'] as String?)?.toLowerCase() ?? 'btc';
+      final city = (payload['city'] as String?)?.toLowerCase() ?? 'cardiff';
       final threshold = (payload['threshold'] as num?)?.toDouble();
-      _post(<String, Object?>{'kind': 'task-start', 'ticker': ticker});
-      final price = _simulatedPrice(ticker);
-      final below = threshold != null && price < threshold;
+      _post(<String, Object?>{'kind': 'task-start', 'city': city});
+      final tempC = _simulatedTemp(city);
+      final below = threshold != null && tempC < threshold;
       _post(<String, Object?>{
         'kind': 'task-done',
-        'ticker': ticker,
-        'price': price,
+        'city': city,
+        'tempC': tempC,
         'below': below,
       });
     case 'text':
@@ -93,13 +95,13 @@ void handleWorkerMessage(Object? payload) {
   }
 }
 
-void _postTick(String ticker, double? threshold) {
-  final price = _simulatedPrice(ticker);
-  final below = threshold != null && price < threshold;
+void _postTick(String city, double? threshold) {
+  final tempC = _simulatedTemp(city);
+  final below = threshold != null && tempC < threshold;
   _post(<String, Object?>{
     'kind': below ? 'alert' : 'tick',
-    'ticker': ticker,
-    'price': price,
+    'city': city,
+    'tempC': tempC,
     'threshold': threshold,
   });
   if (below) {
@@ -113,12 +115,12 @@ void _post(Object? payload) {
   WorkmanagerExecution.instance.sendToPage?.call(payload);
 }
 
-/// Deterministic, time-varying simulated price: stable within a 30s bucket so
-/// consecutive ticks change, but the demo never needs the network.
-double _simulatedPrice(String ticker) {
-  final base = _basePrices[ticker] ?? 100.0;
+/// Deterministic, time-varying simulated temperature: stable within a 30s
+/// bucket so consecutive ticks change, but the demo never needs the network.
+double _simulatedTemp(String city) {
+  final base = _baseTemps[city] ?? 15.0;
   final bucket = DateTime.now().millisecondsSinceEpoch ~/ 30000;
-  final hash = _hash('$ticker:$bucket');
+  final hash = _hash('$city:$bucket');
   final wiggle = (hash % 1000) / 1000 * 0.10 - 0.05; // ±5%
   return base * (1 + wiggle);
 }
@@ -133,12 +135,12 @@ int _hash(String input) {
 
 /// Pure-Dart background task handler.
 ///
-/// With `inputData['ticker']` it behaves like a background "price check":
-/// it pushes progress messages to the page while running and returns the
-/// price + alert state as the task result. The result is recorded by the
-/// runtime: when the page is open it appears in the status panel immediately;
-/// when the Service Worker ran the task while the page was closed, it is
-/// replayed on the next page load.
+/// With `inputData['city']` it behaves like a background "temperature
+/// check": it pushes progress messages to the page while running and returns
+/// the temperature + alert state as the task result. The result is recorded
+/// by the runtime: when the page is open it appears in the event log
+/// immediately; when the Service Worker ran the task while the page was
+/// closed, it is replayed on the next page load.
 Future<bool> handleWebBackgroundTask(
   String taskName,
   Map<String, dynamic>? inputData,
@@ -147,7 +149,7 @@ Future<bool> handleWebBackgroundTask(
   if (input != null && input['fail'] == true) {
     return false;
   }
-  final ticker = (input?['ticker'] as String?)?.toLowerCase() ?? 'btc';
+  final city = (input?['city'] as String?)?.toLowerCase() ?? 'cardiff';
   final threshold = (input?['threshold'] as num?)?.toDouble();
 
   // A small CPU loop so the Web Worker's parallel execution is observable:
@@ -160,18 +162,18 @@ Future<bool> handleWebBackgroundTask(
 
   _post(<String, Object?>{
     'kind': 'task-start',
-    'ticker': ticker,
+    'city': city,
     'threshold': threshold,
   });
-  final price = _simulatedPrice(ticker);
-  final below = threshold != null && price < threshold;
+  final tempC = _simulatedTemp(city);
+  final below = threshold != null && tempC < threshold;
   _post(<String, Object?>{
     'kind': 'task-done',
-    'ticker': ticker,
-    'price': price,
+    'city': city,
+    'tempC': tempC,
     'below': below,
   });
-  // The task result itself stays a plain success/failure bool; the price
-  // detail is delivered via the chat messages above.
+  // The task result itself stays a plain success/failure bool; the
+  // temperature detail is delivered via the chat messages above.
   return true;
 }

--- a/example/lib/web/background_tasks.dart
+++ b/example/lib/web/background_tasks.dart
@@ -8,10 +8,10 @@
 // the Service Worker, neither of which can run the Flutter engine.
 
 import 'dart:async';
-import 'dart:js_interop';
-import 'dart:js_interop_unsafe';
 
 import 'package:workmanager_web/execution.dart';
+
+import 'web_glue.dart';
 
 /// Dispatcher used on the web: wired into the compiled worker bundle
 /// (`web/background.dart`) and passed to `WorkmanagerWeb().initialize(...)` on
@@ -180,7 +180,7 @@ Future<bool> handleWebBackgroundTask(
         ? '❄️ $city below the alert threshold'
         : 'Temperature check: ${_capitalize(city)}',
     '${tempC.toStringAsFixed(1)}°C — '
-        '${below ? 'below the alert threshold' : 'all good'}',
+    '${below ? 'below the alert threshold' : 'all good'}',
   );
   // The task result itself stays a plain success/failure bool; the
   // temperature detail is delivered via the chat messages above.
@@ -191,17 +191,7 @@ Future<bool> handleWebBackgroundTask(
 /// Service Worker (i.e. while the page is closed). The dedicated Web Worker
 /// has no `registration`, so there the page shows the notification instead.
 void _notify(String title, String body) {
-  final self = globalContext;
-  if (!self.has('registration')) {
-    return;
-  }
-  final registration = self['registration'] as JSObject;
-  final promise = registration.callMethod(
-    'showNotification'.toJS,
-    title.toJS,
-    <String, Object?>{'body': body, 'tag': 'workmanager-demo'}.jsify(),
-  ) as JSPromise<JSAny?>;
-  promise.toDart.catchError((Object _) => null);
+  showServiceWorkerNotification(title, body);
 }
 
 String _capitalize(String input) {

--- a/example/lib/web/background_tasks.dart
+++ b/example/lib/web/background_tasks.dart
@@ -7,6 +7,8 @@
 // `web/background.dart.js` and executed both by the in-page Web Worker and by
 // the Service Worker, neither of which can run the Flutter engine.
 
+import 'dart:async';
+
 import 'package:workmanager_web/execution.dart';
 
 /// Dispatcher used on the web: wired into the compiled worker bundle
@@ -15,17 +17,139 @@ import 'package:workmanager_web/execution.dart';
 @pragma('vm:entry-point')
 void webCallbackDispatcher() {
   WorkmanagerExecution.instance.executeTask(handleWebBackgroundTask);
+  WorkmanagerExecution.instance.messageHandler = handleWorkerMessage;
+}
+
+// ---------------------------------------------------------------------------
+// Use case: a tiny "price watch".
+//
+// The demo simulates a market feed so it stays self-contained (no network, no
+// API key). The same shape applies to any real background work:
+//
+// * the page sends a message to the worker  -> messageHandler runs in the
+//   Web Worker (off the main thread),
+// * the worker pushes updates back          -> sendToPage surfaces them on
+//   `WorkmanagerWeb.workerMessages`,
+// * background tasks (also while the page is closed, via the Service Worker)
+//   run the same handler and their results are replayed into the event log.
+// ---------------------------------------------------------------------------
+
+/// Base prices per ticker, in USD. Simulated.
+const Map<String, double> _basePrices = <String, double>{
+  'btc': 60000,
+  'eth': 2500,
+  'ada': 0.60,
+};
+
+Timer? _watchTimer;
+
+/// Handler for free-form messages sent by the page with
+/// `WorkmanagerWeb().sendMessageToWorker(...)`.
+///
+/// Messages:
+/// * `{'op': 'watch', 'ticker': 'btc', 'threshold': 58000}` — start pushing
+///   simulated prices every few seconds; stops itself when the price drops
+///   below [threshold].
+/// * `{'op': 'stop'}` — stop the current watch.
+void handleWorkerMessage(Object? payload) {
+  if (payload is! Map) {
+    return;
+  }
+  final op = payload['op'];
+  switch (op) {
+    case 'watch':
+      final ticker = (payload['ticker'] as String?)?.toLowerCase() ?? 'btc';
+      final threshold = (payload['threshold'] as num?)?.toDouble();
+      _watchTimer?.cancel();
+      _post(<String, Object?>{
+        'kind': 'watching',
+        'ticker': ticker,
+        'threshold': threshold,
+      });
+      _postTick(ticker, threshold);
+      _watchTimer = Timer.periodic(
+        const Duration(seconds: 3),
+        (_) => _postTick(ticker, threshold),
+      );
+    case 'stop':
+      _watchTimer?.cancel();
+      _watchTimer = null;
+      _post(<String, Object?>{'kind': 'stopped'});
+    case 'check':
+      // One-off background check on demand (same logic as the task path).
+      final ticker = (payload['ticker'] as String?)?.toLowerCase() ?? 'btc';
+      final threshold = (payload['threshold'] as num?)?.toDouble();
+      _post(<String, Object?>{'kind': 'task-start', 'ticker': ticker});
+      final price = _simulatedPrice(ticker);
+      final below = threshold != null && price < threshold;
+      _post(<String, Object?>{
+        'kind': 'task-done',
+        'ticker': ticker,
+        'price': price,
+        'below': below,
+      });
+    case 'text':
+      _post(<String, Object?>{'kind': 'echo', 'text': payload['text']});
+  }
+}
+
+void _postTick(String ticker, double? threshold) {
+  final price = _simulatedPrice(ticker);
+  final below = threshold != null && price < threshold;
+  _post(<String, Object?>{
+    'kind': below ? 'alert' : 'tick',
+    'ticker': ticker,
+    'price': price,
+    'threshold': threshold,
+  });
+  if (below) {
+    _watchTimer?.cancel();
+    _watchTimer = null;
+  }
+}
+
+/// Sends a free-form message back to the page (if a page is reachable).
+void _post(Object? payload) {
+  WorkmanagerExecution.instance.sendToPage?.call(payload);
+}
+
+/// Deterministic, time-varying simulated price: stable within a 30s bucket so
+/// consecutive ticks change, but the demo never needs the network.
+double _simulatedPrice(String ticker) {
+  final base = _basePrices[ticker] ?? 100.0;
+  final bucket = DateTime.now().millisecondsSinceEpoch ~/ 30000;
+  final hash = _hash('$ticker:$bucket');
+  final wiggle = (hash % 1000) / 1000 * 0.10 - 0.05; // ±5%
+  return base * (1 + wiggle);
+}
+
+int _hash(String input) {
+  var hash = 0;
+  for (final codeUnit in input.codeUnits) {
+    hash = (hash * 31 + codeUnit) & 0x7fffffff;
+  }
+  return hash;
 }
 
 /// Pure-Dart background task handler.
 ///
-/// The result is recorded by the runtime: when the page is open it appears in
-/// the status panel immediately; when the Service Worker ran the task while
-/// the page was closed, it is replayed on the next page load.
+/// With `inputData['ticker']` it behaves like a background "price check":
+/// it pushes progress messages to the page while running and returns the
+/// price + alert state as the task result. The result is recorded by the
+/// runtime: when the page is open it appears in the status panel immediately;
+/// when the Service Worker ran the task while the page was closed, it is
+/// replayed on the next page load.
 Future<bool> handleWebBackgroundTask(
   String taskName,
   Map<String, dynamic>? inputData,
 ) async {
+  final input = inputData;
+  if (input != null && input['fail'] == true) {
+    return false;
+  }
+  final ticker = (input?['ticker'] as String?)?.toLowerCase() ?? 'btc';
+  final threshold = (input?['threshold'] as num?)?.toDouble();
+
   // A small CPU loop so the Web Worker's parallel execution is observable:
   // the UI stays responsive while this runs off the main thread.
   // ignore: unused_local_variable
@@ -33,6 +157,21 @@ Future<bool> handleWebBackgroundTask(
   for (var i = 0; i < 2000000; i++) {
     checksum += i;
   }
-  final input = inputData;
-  return input != null && input['fail'] == true ? false : true;
+
+  _post(<String, Object?>{
+    'kind': 'task-start',
+    'ticker': ticker,
+    'threshold': threshold,
+  });
+  final price = _simulatedPrice(ticker);
+  final below = threshold != null && price < threshold;
+  _post(<String, Object?>{
+    'kind': 'task-done',
+    'ticker': ticker,
+    'price': price,
+    'below': below,
+  });
+  // The task result itself stays a plain success/failure bool; the price
+  // detail is delivered via the chat messages above.
+  return true;
 }

--- a/example/lib/web/install_glue_stub.dart
+++ b/example/lib/web/install_glue_stub.dart
@@ -7,11 +7,18 @@
 class InstallGlue {
   InstallGlue._();
 
-  /// Listens for `beforeinstallprompt` (no-op on non-web platforms).
+  /// Listens for `beforeinstallprompt`/`appinstalled` (no-op on non-web
+  /// platforms).
   static void listen() {}
 
   /// Whether the browser fired `beforeinstallprompt`.
   static bool get canPrompt => false;
+
+  /// Whether the app is installed as a PWA (always false on non-web).
+  static bool installed = false;
+
+  /// Called whenever [installed] becomes true.
+  static void Function()? onInstalled;
 
   /// Shows the browser's PWA install prompt (no-op on non-web platforms).
   static Future<bool> promptInstall() async => false;

--- a/example/lib/web/install_glue_web.dart
+++ b/example/lib/web/install_glue_web.dart
@@ -7,15 +7,29 @@ import 'dart:js_interop_unsafe';
 
 /// Captures the browser's `beforeinstallprompt` event so the demo can offer an
 /// explicit "Install PWA" button (required for Periodic Background Sync).
+///
+/// Installing means the browser adds the app to the device like a native app
+/// (launcher icon, standalone window) — that is what allows background tasks
+/// to run with no tab open.
 class InstallGlue {
   InstallGlue._();
 
   static JSAny? _deferredPrompt;
 
-  /// Whether the browser fired `beforeinstallprompt`.
+  /// Whether the demo app is installed as a PWA (set via the `appinstalled`
+  /// event, which fires for both the in-app button and the browser's own
+  /// address-bar install flow).
+  static bool installed = false;
+
+  /// Called whenever [installed] becomes true.
+  static void Function()? onInstalled;
+
+  /// Whether the browser fired `beforeinstallprompt` (i.e. a prompt can be
+  /// shown right now).
   static bool get canPrompt => _deferredPrompt != null;
 
-  /// Listens for `beforeinstallprompt` (called once at app startup).
+  /// Listens for `beforeinstallprompt` and `appinstalled` (called once at app
+  /// startup).
   static void listen() {
     final window = globalContext['window'] as JSObject?;
     if (window == null) {
@@ -29,11 +43,23 @@ class InstallGlue {
         _deferredPrompt = event;
       }).toJS,
     );
+    window.callMethod(
+      'addEventListener'.toJS,
+      'appinstalled'.toJS,
+      ((JSObject _) {
+        installed = true;
+        onInstalled?.call();
+      }).toJS,
+    );
   }
 
-  /// Shows the browser's PWA install prompt. Returns whether the app was
-  /// installed.
+  /// Shows the browser's PWA install prompt. Returns `true` when the user
+  /// accepted (or the app is already installed); `false` when the browser has
+  /// not offered a prompt yet or the user dismissed it.
   static Future<bool> promptInstall() async {
+    if (installed) {
+      return true;
+    }
     final prompt = _deferredPrompt;
     if (prompt == null) {
       return false;
@@ -41,7 +67,13 @@ class InstallGlue {
     _deferredPrompt = null;
     final promise =
         (prompt as JSObject).callMethod('prompt'.toJS) as JSPromise<JSAny?>;
-    await promise.toDart;
-    return true;
+    final result = await promise.toDart;
+    final outcome = (result as JSObject?)?['outcome']?.dartify();
+    final accepted = outcome == 'accepted';
+    if (accepted) {
+      installed = true;
+      onInstalled?.call();
+    }
+    return accepted;
   }
 }

--- a/example/lib/web/landing_page.dart
+++ b/example/lib/web/landing_page.dart
@@ -2,13 +2,11 @@
 // Use of this source code is governed by a MIT-style license that can be
 // found in the LICENSE file.
 
-import 'dart:js_interop';
-import 'dart:js_interop_unsafe';
-
 import 'package:flutter/material.dart';
 
 import 'app_theme.dart';
 import 'web_demo_page.dart';
+import 'web_glue.dart';
 
 /// Intro page for the web demo site: what workmanager is, what the demo
 /// shows, and links to the upstream project (pub.dev, GitHub, docs).
@@ -24,10 +22,7 @@ class LandingPage extends StatelessWidget {
       'https://github.com/fluttercommunity/flutter_workmanager/issues';
 
   void _openUrl(String url) {
-    final window = globalContext['window'] as JSObject?;
-    if (window != null) {
-      window.callMethod('open'.toJS, url.toJS);
-    }
+    openUrl(url);
   }
 
   void _openDemo(BuildContext context) {

--- a/example/lib/web/landing_page.dart
+++ b/example/lib/web/landing_page.dart
@@ -1,0 +1,329 @@
+// Copyright 2024 The Flutter Workmanager Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style license that can be
+// found in the LICENSE file.
+
+import 'dart:js_interop';
+import 'dart:js_interop_unsafe';
+
+import 'package:flutter/material.dart';
+
+import 'app_theme.dart';
+import 'web_demo_page.dart';
+
+/// Intro page for the web demo site: what workmanager is, what the demo
+/// shows, and links to the upstream project (pub.dev, GitHub, docs).
+class LandingPage extends StatelessWidget {
+  const LandingPage({super.key});
+
+  static const String _pubDevUrl = 'https://pub.dev/packages/workmanager';
+  static const String _githubUrl =
+      'https://github.com/fluttercommunity/flutter_workmanager';
+  static const String _docsUrl =
+      'https://docs.page/fluttercommunity/flutter_workmanager';
+  static const String _issuesUrl =
+      'https://github.com/fluttercommunity/flutter_workmanager/issues';
+
+  void _openUrl(String url) {
+    final window = globalContext['window'] as JSObject?;
+    if (window != null) {
+      window.callMethod('open'.toJS, url.toJS);
+    }
+  }
+
+  void _openDemo(BuildContext context) {
+    Navigator.of(context).push(
+      MaterialPageRoute<void>(builder: (_) => const WebDemoPage()),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Scaffold(
+      body: SingleChildScrollView(
+        child: Center(
+          child: ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: 760),
+            child: Padding(
+              padding: const EdgeInsets.fromLTRB(20, 48, 20, 32),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: <Widget>[
+                  _buildHero(context),
+                  const SizedBox(height: 40),
+                  Text('What it is', style: theme.textTheme.titleLarge),
+                  const SizedBox(height: 12),
+                  const _FeatureCard(
+                    icon: Icons.schedule,
+                    title: 'One-off & periodic tasks',
+                    body: 'Schedule a task to run once — or repeat on an '
+                        'interval — with input data, constraints and '
+                        'frequency control.',
+                  ),
+                  const SizedBox(height: 10),
+                  const _FeatureCard(
+                    icon: Icons.memory,
+                    title: 'Runs off the main thread',
+                    body: 'Execution happens on the platform\'s own '
+                        'schedulers (WorkManager, BGTaskScheduler, Service '
+                        'Workers), so your UI never blocks and work keeps '
+                        'running when the app is in the background.',
+                  ),
+                  const SizedBox(height: 10),
+                  const _FeatureCard(
+                    icon: Icons.devices,
+                    title: 'One API, all platforms',
+                    body: 'The same callback-dispatcher pattern on Android, '
+                        'iOS, Web, Linux and Windows. Web, Linux and '
+                        'Windows support is experimental and developed in '
+                        'this repository.',
+                  ),
+                  const SizedBox(height: 40),
+                  Text('Try the web demo', style: theme.textTheme.titleLarge),
+                  const SizedBox(height: 12),
+                  _buildDemoCard(context),
+                  const SizedBox(height: 40),
+                  Text('Resources', style: theme.textTheme.titleLarge),
+                  const SizedBox(height: 12),
+                  _buildResourceCard(
+                    context,
+                    icon: Icons.published_with_changes,
+                    title: 'pub.dev',
+                    body: 'The published workmanager package.',
+                    url: _pubDevUrl,
+                  ),
+                  const SizedBox(height: 10),
+                  _buildResourceCard(
+                    context,
+                    icon: Icons.code,
+                    title: 'GitHub repository',
+                    body: 'Source code, releases and the platform packages '
+                        '(workmanager_android, workmanager_apple, '
+                        'workmanager_web, …).',
+                    url: _githubUrl,
+                  ),
+                  const SizedBox(height: 10),
+                  _buildResourceCard(
+                    context,
+                    icon: Icons.menu_book,
+                    title: 'Documentation',
+                    body: 'Setup guides and API docs on docs.page.',
+                    url: _docsUrl,
+                  ),
+                  const SizedBox(height: 10),
+                  _buildResourceCard(
+                    context,
+                    icon: Icons.bug_report_outlined,
+                    title: 'Issues & feature requests',
+                    body: 'Report a bug or ask for a feature on GitHub.',
+                    url: _issuesUrl,
+                  ),
+                  const SizedBox(height: 40),
+                  Text(
+                    'MIT licensed · maintained by the Flutter Community',
+                    textAlign: TextAlign.center,
+                    style: theme.textTheme.bodySmall,
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildHero(BuildContext context) {
+    final theme = Theme.of(context);
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        Text(
+          'workmanager',
+          style: theme.textTheme.displaySmall?.copyWith(
+            color: AppTheme.primaryBlue,
+            fontWeight: FontWeight.w800,
+          ),
+        ),
+        const SizedBox(height: 8),
+        Text(
+          'Flutter background tasks, done right.',
+          style: theme.textTheme.headlineSmall?.copyWith(
+            fontWeight: FontWeight.w600,
+          ),
+        ),
+        const SizedBox(height: 12),
+        Text(
+          'Schedule one-off and periodic work that runs even when your app '
+          'is in the background — or closed. One callback-dispatcher API '
+          'across Android, iOS, Web, Linux and Windows.',
+          style: theme.textTheme.bodyLarge,
+        ),
+        const SizedBox(height: 16),
+        Wrap(
+          spacing: 8,
+          runSpacing: 8,
+          children: const <Widget>[
+            _PlatformChip(icon: Icons.android, label: 'Android'),
+            _PlatformChip(icon: Icons.phone_iphone, label: 'iOS'),
+            _PlatformChip(icon: Icons.language, label: 'Web'),
+            _PlatformChip(icon: Icons.laptop_mac, label: 'Linux'),
+            _PlatformChip(icon: Icons.desktop_windows, label: 'Windows'),
+          ],
+        ),
+        const SizedBox(height: 24),
+        Wrap(
+          spacing: 12,
+          runSpacing: 12,
+          children: <Widget>[
+            FilledButton.icon(
+              onPressed: () => _openDemo(context),
+              icon: const Icon(Icons.play_arrow),
+              label: const Text('Try the live demo'),
+            ),
+            FilledButton.tonalIcon(
+              onPressed: () => _openUrl(_pubDevUrl),
+              icon: const Icon(Icons.open_in_new),
+              label: const Text('View on pub.dev'),
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+
+  Widget _buildDemoCard(BuildContext context) {
+    final theme = Theme.of(context);
+    return Container(
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: AppTheme.cardFill,
+        border: Border.all(color: AppTheme.borderGrey),
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          Text(
+            'A live, self-contained demo of the experimental web support.',
+            style: theme.textTheme.titleSmall,
+          ),
+          const SizedBox(height: 8),
+          Text(
+            'Two-way messaging between the page and a background worker, a '
+            'persistent queue of background-task runs (single source of '
+            'truth), Service Worker execution and notifications. Everything '
+            'is simulated — no sign-up, no server, nothing to install to '
+            'explore. Install it as a PWA to unlock the "close the tab and '
+            'it still runs" path.',
+            style: theme.textTheme.bodyMedium,
+          ),
+          const SizedBox(height: 12),
+          FilledButton.icon(
+            onPressed: () => _openDemo(context),
+            icon: const Icon(Icons.rocket_launch_outlined),
+            label: const Text('Open the demo'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildResourceCard(
+    BuildContext context, {
+    required IconData icon,
+    required String title,
+    required String body,
+    required String url,
+  }) {
+    final theme = Theme.of(context);
+    return InkWell(
+      onTap: () => _openUrl(url),
+      borderRadius: BorderRadius.circular(12),
+      child: Container(
+        padding: const EdgeInsets.all(16),
+        decoration: BoxDecoration(
+          border: Border.all(color: AppTheme.borderGrey),
+          borderRadius: BorderRadius.circular(12),
+        ),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            Icon(icon, size: 22, color: AppTheme.primaryBlue),
+            const SizedBox(width: 12),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: <Widget>[
+                  Text(title, style: theme.textTheme.titleSmall),
+                  const SizedBox(height: 2),
+                  Text(body, style: theme.textTheme.bodyMedium),
+                ],
+              ),
+            ),
+            const Icon(Icons.open_in_new, size: 18, color: AppTheme.mutedGrey),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _PlatformChip extends StatelessWidget {
+  const _PlatformChip({required this.icon, required this.label});
+
+  final IconData icon;
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return Chip(
+      avatar: Icon(icon, size: 18, color: AppTheme.primaryBlue),
+      label: Text(label),
+      side: const BorderSide(color: AppTheme.borderGrey),
+      backgroundColor: Colors.white,
+    );
+  }
+}
+
+class _FeatureCard extends StatelessWidget {
+  const _FeatureCard({
+    required this.icon,
+    required this.title,
+    required this.body,
+  });
+
+  final IconData icon;
+  final String title;
+  final String body;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Container(
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: AppTheme.cardFill,
+        border: Border.all(color: AppTheme.borderGrey),
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          Icon(icon, size: 22, color: AppTheme.primaryBlue),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: <Widget>[
+                Text(title, style: theme.textTheme.titleSmall),
+                const SizedBox(height: 2),
+                Text(body, style: theme.textTheme.bodyMedium),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/example/lib/web/web_app.dart
+++ b/example/lib/web/web_app.dart
@@ -1,0 +1,23 @@
+// Copyright 2024 The Flutter Workmanager Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+
+import 'app_theme.dart';
+import 'landing_page.dart';
+
+/// Root widget for the web demo site: an intro page (what workmanager is,
+/// links to the project) plus the runnable demo, sharing one theme.
+class WebDemoApp extends StatelessWidget {
+  const WebDemoApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'Workmanager Web Demo',
+      theme: AppTheme.light(),
+      home: const LandingPage(),
+    );
+  }
+}

--- a/example/lib/web/web_demo_page.dart
+++ b/example/lib/web/web_demo_page.dart
@@ -2,6 +2,9 @@
 // Use of this source code is governed by a MIT-style license that can be
 // found in the LICENSE file.
 
+import 'dart:js_interop';
+import 'dart:js_interop_unsafe';
+
 import 'package:flutter/material.dart';
 import 'package:workmanager_web/workmanager_web.dart';
 
@@ -97,6 +100,7 @@ class _WebDemoPageState extends State<WebDemoPage> {
   final TextEditingController _messageController = TextEditingController();
   bool _initializing = true;
   bool _periodicRegistered = false;
+  bool _notificationsGranted = false;
 
   @override
   void initState() {
@@ -140,6 +144,13 @@ class _WebDemoPageState extends State<WebDemoPage> {
       return;
     }
     setState(() => _events.insert(0, event));
+    if (event.state == 'executed' && _notificationsGranted) {
+      _showPageNotification(
+        'Workmanager demo',
+        '${event.taskName ?? 'Background task'} finished'
+        '${event.result == null ? '' : ' — result: $event.result'}.',
+      );
+    }
   }
 
   void _onWorkerMessage(Object? payload) {
@@ -185,17 +196,57 @@ class _WebDemoPageState extends State<WebDemoPage> {
     }
   }
 
+  /// Requests the Web Notifications permission (must be called from a user
+  /// gesture in most browsers).
+  Future<void> _requestNotifications() async {
+    final notification = globalContext['Notification'];
+    if (notification == null) {
+      return;
+    }
+    final notificationObj = notification as JSObject;
+    final permission = notificationObj['permission']?.dartify();
+    if (permission == 'granted') {
+      setState(() => _notificationsGranted = true);
+      return;
+    }
+    if (permission == 'denied') {
+      return;
+    }
+    final result = await (notificationObj
+            .callMethod('requestPermission'.toJS) as JSPromise<JSAny?>)
+        .toDart;
+    if (!mounted) {
+      return;
+    }
+    setState(() => _notificationsGranted = result?.dartify() == 'granted');
+  }
+
+  /// Shows a page-side notification (only used when the page is open; the
+  /// Service Worker shows its own when the page is closed — see
+  /// `_notify` in `background_tasks.dart`).
+  void _showPageNotification(String title, String body) {
+    final notification = globalContext['Notification'];
+    if (notification == null) {
+      return;
+    }
+    (notification as JSFunction).callAsConstructor<JSObject>(
+      title.toJS,
+      <String, Object?>{'body': body}.jsify(),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     return DefaultTabController(
-      length: 2,
+      length: 3,
       child: Scaffold(
         appBar: AppBar(
           title: const Text('Workmanager Web Demo'),
           bottom: const TabBar(
             tabs: <Widget>[
-              Tab(icon: Icon(Icons.chat_bubble_outline), text: 'Worker chat'),
+              Tab(icon: Icon(Icons.chat_bubble_outline), text: 'Chat'),
               Tab(icon: Icon(Icons.receipt_long_outlined), text: 'Task log'),
+              Tab(icon: Icon(Icons.flag_outlined), text: 'Guide'),
             ],
           ),
           actions: <Widget>[
@@ -224,6 +275,7 @@ class _WebDemoPageState extends State<WebDemoPage> {
                 children: <Widget>[
                   _buildChatTab(context),
                   _buildTaskLogTab(context),
+                  _buildGuideTab(context),
                 ],
               ),
             ),
@@ -262,64 +314,26 @@ class _WebDemoPageState extends State<WebDemoPage> {
     );
   }
 
-  Widget _buildHowItWorksCard(BuildContext context) {
-    final theme = Theme.of(context);
-    return Card(
-      elevation: 0,
-      margin: EdgeInsets.zero,
-      color: const Color(0xFFF1F4F8),
-      shape: RoundedRectangleBorder(
-        side: const BorderSide(color: Color(0xFFB0B8BF)),
-        borderRadius: BorderRadius.circular(10),
-      ),
-      child: Padding(
-        padding: const EdgeInsets.all(12),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: <Widget>[
-            Text('How this demo works', style: theme.textTheme.titleSmall),
-            const SizedBox(height: 8),
-            const _InfoLine(
-              icon: Icons.forum_outlined,
-              iconColor: _infoBlue,
-              text: 'Messaging — you talk to the background worker, which '
-                  'runs on its own thread; it replies via postMessage '
-                  '(this tab).',
-            ),
-            const SizedBox(height: 6),
-            const _InfoLine(
-              icon: Icons.play_circle_outline,
-              iconColor: _okGreen,
-              text: 'Background tasks — registered tasks run off the page: '
-                  '"Run check now" fires one immediately, and one runs every '
-                  '15 min. Results appear in the Task log tab.',
-            ),
-            const SizedBox(height: 6),
-            const _InfoLine(
-              icon: Icons.cloud_outlined,
-              iconColor: _warnOrange,
-              text: 'Service Worker — install the app as a PWA and tasks '
-                  'also run while the page is closed; their results are '
-                  'replayed into the Task log when you reopen the page.',
-            ),
-            const SizedBox(height: 10),
-            Text(
-              'Try it: tap "Watch Cardiff" below, type any message, or run '
-              'a check in the Task log tab. All data is simulated — no '
-              'network needed.',
-              style: theme.textTheme.bodySmall,
-            ),
-          ],
-        ),
-      ),
-    );
-  }
-
   Widget _buildChatTab(BuildContext context) {
+    final theme = Theme.of(context);
     return ListView(
       padding: const EdgeInsets.all(12),
       children: <Widget>[
-        _buildHowItWorksCard(context),
+        Container(
+          padding: const EdgeInsets.all(12),
+          decoration: BoxDecoration(
+            color: const Color(0xFFF1F4F8),
+            border: Border.all(color: const Color(0xFFB0B8BF)),
+            borderRadius: BorderRadius.circular(10),
+          ),
+          child: Text(
+            'This tab talks to the background worker, which runs on its own '
+            'thread — it replies via postMessage. Tap a chip below or type '
+            'any message. For the full walkthrough (notifications, closing '
+            'the tab, Service Worker), see the Guide tab.',
+            style: theme.textTheme.bodyMedium,
+          ),
+        ),
         const SizedBox(height: 12),
         Container(
           height: 220,
@@ -386,7 +400,7 @@ class _WebDemoPageState extends State<WebDemoPage> {
                   : () => _sendToWorker(<String, Object?>{
                         'op': 'watch',
                         'city': 'cardiff',
-                        'threshold': 5.0,
+                        'threshold': 10.9,
                       }),
             ),
             ActionChip(
@@ -397,7 +411,7 @@ class _WebDemoPageState extends State<WebDemoPage> {
                   : () => _sendToWorker(<String, Object?>{
                         'op': 'watch',
                         'city': 'taipei',
-                        'threshold': 20.0,
+                        'threshold': 24.0,
                       }),
             ),
             ActionChip(
@@ -429,6 +443,14 @@ class _WebDemoPageState extends State<WebDemoPage> {
                 icon: const Icon(Icons.play_arrow),
                 label: const Text('Run check now'),
               ),
+              if (_notificationsGranted)
+                const _NotificationStatus()
+              else
+                FilledButton.tonalIcon(
+                  onPressed: _requestNotifications,
+                  icon: const Icon(Icons.notifications_active_outlined),
+                  label: const Text('Allow notifications'),
+                ),
               if (InstallGlue.canPrompt)
                 FilledButton.icon(
                   onPressed: InstallGlue.promptInstall,
@@ -469,6 +491,73 @@ class _WebDemoPageState extends State<WebDemoPage> {
                     return _EventTile(event: _events[index]);
                   },
                 ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildGuideTab(BuildContext context) {
+    final theme = Theme.of(context);
+    return ListView(
+      padding: const EdgeInsets.all(12),
+      children: <Widget>[
+        Container(
+          padding: const EdgeInsets.all(12),
+          decoration: BoxDecoration(
+            color: const Color(0xFFF1F4F8),
+            border: Border.all(color: const Color(0xFFB0B8BF)),
+            borderRadius: BorderRadius.circular(10),
+          ),
+          child: Text(
+            'What this demo tests\n\n'
+            '1. Messaging — the page and the background worker talk over '
+            'postMessage (Chat tab).\n'
+            '2. Background tasks — one-off and periodic tasks execute off '
+            'the page (Task log tab).\n'
+            '3. Service Worker — with the app installed, tasks keep running '
+            'even when no tab is open, and notify you when they finish.',
+            style: theme.textTheme.bodyMedium,
+          ),
+        ),
+        const SizedBox(height: 16),
+        Text('Try it — step by step', style: theme.textTheme.titleSmall),
+        const SizedBox(height: 8),
+        const _GuideStep(
+          number: '1',
+          title: 'Talk to the worker',
+          body: 'Open the Chat tab and tap "Watch Cardiff", or type any '
+              'message. The worker answers from its own thread.',
+        ),
+        const _GuideStep(
+          number: '2',
+          title: 'Allow notifications',
+          body: 'Tap "Allow notifications" on the Task log tab. Finished '
+              'tasks will then ping you — even with the tab closed.',
+        ),
+        const _GuideStep(
+          number: '3',
+          title: 'Install the app',
+          body: 'Tap "Install app". Installed apps can run background tasks '
+              'without an open tab.',
+        ),
+        const _GuideStep(
+          number: '4',
+          title: 'Close this tab — yes, really',
+          body: 'Close the tab. The Service Worker keeps running your '
+              'registered tasks in the background.',
+        ),
+        const _GuideStep(
+          number: '5',
+          title: 'Trigger a background check',
+          body: 'In DevTools (F12) → Application → Periodic Background '
+              'Sync, select the task and press "Sync now". A notification '
+              'appears even though the tab is closed.',
+        ),
+        const _GuideStep(
+          number: '6',
+          title: 'Reopen the app',
+          body: 'Results from closed-page runs are replayed from IndexedDB '
+              'into the Task log.',
         ),
       ],
     );
@@ -532,28 +621,68 @@ class _WebDemoPageState extends State<WebDemoPage> {
   }
 }
 
-class _InfoLine extends StatelessWidget {
-  const _InfoLine({required this.icon, required this.iconColor, required this.text});
-
-  final IconData icon;
-  final Color iconColor;
-  final String text;
+class _NotificationStatus extends StatelessWidget {
+  const _NotificationStatus();
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     return Row(
-      crossAxisAlignment: CrossAxisAlignment.start,
+      mainAxisSize: MainAxisSize.min,
       children: <Widget>[
-        Padding(
-          padding: const EdgeInsets.only(top: 2),
-          child: Icon(icon, size: 18, color: iconColor),
-        ),
-        const SizedBox(width: 8),
-        Expanded(
-          child: Text(text, style: theme.textTheme.bodyMedium),
-        ),
+        const Icon(Icons.notifications_active, size: 18, color: _okGreen),
+        const SizedBox(width: 6),
+        Text('Notifications on', style: theme.textTheme.bodyMedium),
       ],
+    );
+  }
+}
+
+class _GuideStep extends StatelessWidget {
+  const _GuideStep({required this.number, required this.title, required this.body});
+
+  final String number;
+  final String title;
+  final String body;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 8),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          Container(
+            width: 26,
+            height: 26,
+            alignment: Alignment.center,
+            decoration: const BoxDecoration(
+              color: Color(0xFF0B57D0),
+              shape: BoxShape.circle,
+            ),
+            child: Text(
+              number,
+              style: const TextStyle(
+                color: Colors.white,
+                fontSize: 14,
+                fontWeight: FontWeight.w700,
+              ),
+            ),
+          ),
+          const SizedBox(width: 10),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: <Widget>[
+                Text(title, style: theme.textTheme.titleSmall),
+                const SizedBox(height: 2),
+                Text(body, style: theme.textTheme.bodyMedium),
+              ],
+            ),
+          ),
+        ],
+      ),
     );
   }
 }

--- a/example/lib/web/web_demo_page.dart
+++ b/example/lib/web/web_demo_page.dart
@@ -158,12 +158,23 @@ class _WebDemoPageState extends State<WebDemoPage> {
       return;
     }
     setState(() => _events.insert(0, event));
-    if (event.state == 'executed' && _notificationsGranted) {
-      _showPageNotification(
-        'Workmanager demo',
-        '${event.taskName ?? 'Background task'} finished'
-        '${event.result == null ? '' : ' — result: $event.result'}.',
-      );
+    // The foreground stays in sync with background runs: every executed
+    // task also lands in the chat, including runs that happened while the
+    // page was closed (replayed from the IndexedDB queue on load).
+    if (event.state == 'executed') {
+      _chat.add(_ChatLine(
+        text: '↩️ background: ${event.taskName ?? 'task'} finished'
+            '${event.result == null ? '' : ' → result: $event.result'}'
+            ' (${event.source})',
+        fromWorker: true,
+      ));
+      if (_notificationsGranted) {
+        _showPageNotification(
+          'Workmanager demo',
+          '${event.taskName ?? 'Background task'} finished'
+          '${event.result == null ? '' : ' — result: $event.result'}.',
+        );
+      }
     }
   }
 
@@ -514,9 +525,10 @@ class _WebDemoPageState extends State<WebDemoPage> {
         Padding(
           padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
           child: Text(
-            'Event states: executed = task ran · relayed = message routed · '
-            'missed/error = failure · warning = retried. Events from runs '
-            'while the page was closed are replayed here on load.',
+            'This log is the persistent background queue (single source of '
+            'truth): executed = task ran · relayed = message routed · '
+            'missed/error = failure · warning = retried. Runs from when the '
+            'page was closed are replayed here on load.',
             style: theme.textTheme.bodySmall,
           ),
         ),
@@ -566,7 +578,10 @@ class _WebDemoPageState extends State<WebDemoPage> {
             '2. Background tasks — one-off and periodic tasks execute off '
             'the page (Task log tab).\n'
             '3. Service Worker — with the app installed, tasks keep running '
-            'even when no tab is open, and notify you when they finish.',
+            'even when no tab is open, and notify you when they finish.\n'
+            '4. Single source of truth — every background run is recorded in '
+            'a persistent queue (Task log) and replayed when you reopen the '
+            'app, so the foreground always sees what the background did.',
             style: theme.textTheme.bodyMedium,
           ),
         ),
@@ -619,8 +634,26 @@ class _WebDemoPageState extends State<WebDemoPage> {
         const _GuideStep(
           number: '6',
           title: 'Reopen the app',
-          body: 'Results from closed-page runs are replayed from IndexedDB '
-              'into the Task log.',
+          body: 'Results from closed-page runs are replayed from the '
+              'persistent queue (IndexedDB) into the Task log — and the '
+              'chat shows a "background: …" line for each run, so the '
+              'foreground always reflects what the background did.',
+        ),
+        const SizedBox(height: 4),
+        Container(
+          padding: const EdgeInsets.all(12),
+          decoration: BoxDecoration(
+            color: const Color(0xFFFFF3D6),
+            border: Border.all(color: const Color(0xFFB06000)),
+            borderRadius: BorderRadius.circular(10),
+          ),
+          child: Text(
+            'Developer note: when running via `flutter run -d chrome`, use a '
+            'full reload after code changes — hot restart is buggy on web '
+            '(can throw "disposed EngineFlutterView" errors; a page refresh '
+            'fixes it).',
+            style: theme.textTheme.bodySmall,
+          ),
         ),
       ],
     );

--- a/example/lib/web/web_demo_page.dart
+++ b/example/lib/web/web_demo_page.dart
@@ -2,15 +2,13 @@
 // Use of this source code is governed by a MIT-style license that can be
 // found in the LICENSE file.
 
-import 'dart:js_interop';
-import 'dart:js_interop_unsafe';
-
 import 'package:flutter/material.dart';
 import 'package:workmanager_web/workmanager_web.dart';
 
 import 'app_theme.dart';
 import 'background_tasks.dart';
 import 'install_glue.dart';
+import 'web_glue.dart';
 
 const String _oneOffTask = 'dev.fluttercommunity.workmanagerExample.webOneOff';
 const String _periodicTask =
@@ -105,7 +103,7 @@ class _WebDemoPageState extends State<WebDemoPage> {
         _showPageNotification(
           'Workmanager demo',
           '${event.taskName ?? 'Background task'} finished'
-          '${event.result == null ? '' : ' — result: $event.result'}.',
+              '${event.result == null ? '' : ' — result: $event.result'}.',
         );
       }
     }
@@ -196,40 +194,18 @@ class _WebDemoPageState extends State<WebDemoPage> {
   /// Requests the Web Notifications permission (must be called from a user
   /// gesture in most browsers).
   Future<void> _requestNotifications() async {
-    final notification = globalContext['Notification'];
-    if (notification == null) {
-      return;
-    }
-    final notificationObj = notification as JSObject;
-    final permission = notificationObj['permission']?.dartify();
-    if (permission == 'granted') {
-      setState(() => _notificationsGranted = true);
-      return;
-    }
-    if (permission == 'denied') {
-      return;
-    }
-    final result = await (notificationObj
-            .callMethod('requestPermission'.toJS) as JSPromise<JSAny?>)
-        .toDart;
+    final granted = await requestNotificationPermission();
     if (!mounted) {
       return;
     }
-    setState(() => _notificationsGranted = result?.dartify() == 'granted');
+    setState(() => _notificationsGranted = granted);
   }
 
   /// Shows a page-side notification (only used when the page is open; the
-  /// Service Worker shows its own when the page is closed — see
-  /// `_notify` in `background_tasks.dart`).
+  /// Service Worker shows its own when the page is closed — see `_notify`
+  /// in `background_tasks.dart`).
   void _showPageNotification(String title, String body) {
-    final notification = globalContext['Notification'];
-    if (notification == null) {
-      return;
-    }
-    (notification as JSFunction).callAsConstructor<JSObject>(
-      title.toJS,
-      <String, Object?>{'body': body}.jsify(),
-    );
+    showPageNotification(title, body);
   }
 
   @override
@@ -679,7 +655,8 @@ class _NotificationStatus extends StatelessWidget {
     return Row(
       mainAxisSize: MainAxisSize.min,
       children: <Widget>[
-        const Icon(Icons.notifications_active, size: 18, color: AppTheme.okGreen),
+        const Icon(Icons.notifications_active,
+            size: 18, color: AppTheme.okGreen),
         const SizedBox(width: 6),
         Text('Notifications on', style: theme.textTheme.bodyMedium),
       ],
@@ -688,7 +665,8 @@ class _NotificationStatus extends StatelessWidget {
 }
 
 class _GuideStep extends StatelessWidget {
-  const _GuideStep({required this.number, required this.title, required this.body});
+  const _GuideStep(
+      {required this.number, required this.title, required this.body});
 
   final String number;
   final String title;
@@ -754,8 +732,9 @@ class _ChatBubble extends StatelessWidget {
     final fromWorker = line.fromWorker;
     final Color background =
         fromWorker ? Colors.white : theme.colorScheme.primaryContainer;
-    final Color foreground =
-        fromWorker ? AppTheme.textPrimary : theme.colorScheme.onPrimaryContainer;
+    final Color foreground = fromWorker
+        ? AppTheme.textPrimary
+        : theme.colorScheme.onPrimaryContainer;
     final BoxBorder border = Border.all(
       color: fromWorker ? AppTheme.borderGrey : Colors.transparent,
     );

--- a/example/lib/web/web_demo_page.dart
+++ b/example/lib/web/web_demo_page.dart
@@ -162,12 +162,15 @@ class _WebDemoPageState extends State<WebDemoPage> {
     // task also lands in the chat, including runs that happened while the
     // page was closed (replayed from the IndexedDB queue on load).
     if (event.state == 'executed') {
-      _chat.add(_ChatLine(
-        text: '↩️ background: ${event.taskName ?? 'task'} finished'
-            '${event.result == null ? '' : ' → result: $event.result'}'
-            ' (${event.source})',
-        fromWorker: true,
-      ));
+      _chat.insert(
+        0,
+        _ChatLine(
+          text: '↩️ background: ${event.taskName ?? 'task'} finished'
+              '${event.result == null ? '' : ' → result: $event.result'}'
+              ' (${event.source})',
+          fromWorker: true,
+        ),
+      );
       if (_notificationsGranted) {
         _showPageNotification(
           'Workmanager demo',
@@ -183,8 +186,10 @@ class _WebDemoPageState extends State<WebDemoPage> {
       return;
     }
     setState(() {
-      _chat.add(
-          _ChatLine(text: _formatWorkerMessage(payload), fromWorker: true));
+      _chat.insert(
+        0,
+        _ChatLine(text: _formatWorkerMessage(payload), fromWorker: true),
+      );
     });
   }
 
@@ -192,8 +197,10 @@ class _WebDemoPageState extends State<WebDemoPage> {
   /// `handleWorkerMessage` in `background_tasks.dart`).
   void _sendToWorker(Map<String, Object?> message) {
     setState(() {
-      _chat
-          .add(_ChatLine(text: _formatSentMessage(message), fromWorker: false));
+      _chat.insert(
+        0,
+        _ChatLine(text: _formatSentMessage(message), fromWorker: false),
+      );
     });
     WorkmanagerWeb().sendMessageToWorker(message);
   }
@@ -376,114 +383,118 @@ class _WebDemoPageState extends State<WebDemoPage> {
 
   Widget _buildChatTab(BuildContext context) {
     final theme = Theme.of(context);
-    return ListView(
+    return Padding(
       padding: const EdgeInsets.all(12),
-      children: <Widget>[
-        Container(
-          padding: const EdgeInsets.all(12),
-          decoration: BoxDecoration(
-            color: const Color(0xFFF1F4F8),
-            border: Border.all(color: const Color(0xFFB0B8BF)),
-            borderRadius: BorderRadius.circular(10),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: <Widget>[
+          Container(
+            padding: const EdgeInsets.all(12),
+            decoration: BoxDecoration(
+              color: const Color(0xFFF1F4F8),
+              border: Border.all(color: const Color(0xFFB0B8BF)),
+              borderRadius: BorderRadius.circular(10),
+            ),
+            child: Text(
+              'This tab talks to the background worker, which runs on its own '
+              'thread — it replies via postMessage. Tap a chip below or type '
+              'any message. For the full walkthrough (notifications, closing '
+              'the tab, Service Worker), see the Guide tab.',
+              style: theme.textTheme.bodyMedium,
+            ),
           ),
-          child: Text(
-            'This tab talks to the background worker, which runs on its own '
-            'thread — it replies via postMessage. Tap a chip below or type '
-            'any message. For the full walkthrough (notifications, closing '
-            'the tab, Service Worker), see the Guide tab.',
-            style: theme.textTheme.bodyMedium,
-          ),
-        ),
-        const SizedBox(height: 12),
-        Container(
-          height: 220,
-          decoration: BoxDecoration(
-            border: Border.all(color: const Color(0xFFB0B8BF)),
-            borderRadius: BorderRadius.circular(10),
-          ),
-          child: _chat.isEmpty
-              ? const Center(
-                  child: Padding(
-                    padding: EdgeInsets.all(16),
-                    child: Text(
-                      'Messages appear here — yours and the worker\'s '
-                      'replies.\n\nTap "Watch Cardiff" to see a live '
-                      'conversation, or just type anything.',
-                      textAlign: TextAlign.center,
-                      style: TextStyle(fontSize: 14, height: 1.4),
+          const SizedBox(height: 12),
+          Expanded(
+            child: Container(
+              decoration: BoxDecoration(
+                border: Border.all(color: const Color(0xFFB0B8BF)),
+                borderRadius: BorderRadius.circular(10),
+              ),
+              child: _chat.isEmpty
+                  ? const Center(
+                      child: Padding(
+                        padding: EdgeInsets.all(16),
+                        child: Text(
+                          'Messages appear here — yours and the worker\'s '
+                          'replies.\n\nTap "Watch Cardiff" to see a live '
+                          'conversation, or just type anything.',
+                          textAlign: TextAlign.center,
+                          style: TextStyle(fontSize: 14, height: 1.4),
+                        ),
+                      ),
+                    )
+                  : ListView.builder(
+                      reverse: true,
+                      padding: const EdgeInsets.all(8),
+                      itemCount: _chat.length,
+                      itemBuilder: (BuildContext context, int index) {
+                        return _ChatBubble(line: _chat[index]);
+                      },
                     ),
+            ),
+          ),
+          const SizedBox(height: 10),
+          Row(
+            children: <Widget>[
+              Expanded(
+                child: TextField(
+                  controller: _messageController,
+                  onSubmitted: _sendFreeText,
+                  decoration: const InputDecoration(
+                    isDense: true,
+                    hintText: 'Message the worker…',
+                    border: OutlineInputBorder(),
                   ),
-                )
-              : ListView.builder(
-                  reverse: true,
-                  padding: const EdgeInsets.all(8),
-                  itemCount: _chat.length,
-                  itemBuilder: (BuildContext context, int index) {
-                    return _ChatBubble(line: _chat[index]);
-                  },
-                ),
-        ),
-        const SizedBox(height: 10),
-        Row(
-          children: <Widget>[
-            Expanded(
-              child: TextField(
-                controller: _messageController,
-                onSubmitted: _sendFreeText,
-                decoration: const InputDecoration(
-                  isDense: true,
-                  hintText: 'Message the worker…',
-                  border: OutlineInputBorder(),
                 ),
               ),
-            ),
-            const SizedBox(width: 8),
-            IconButton.filled(
-              onPressed: _initializing
-                  ? null
-                  : () => _sendFreeText(_messageController.text),
-              icon: const Icon(Icons.send),
-              tooltip: 'Send to worker',
-            ),
-          ],
-        ),
-        const SizedBox(height: 10),
-        Wrap(
-          spacing: 8,
-          runSpacing: 8,
-          children: <Widget>[
-            ActionChip(
-              avatar: const Icon(Icons.thermostat, size: 18),
-              label: const Text('Watch Cardiff'),
-              onPressed: _initializing
-                  ? null
-                  : () => _sendToWorker(<String, Object?>{
-                        'op': 'watch',
-                        'city': 'cardiff',
-                        'threshold': 10.9,
-                      }),
-            ),
-            ActionChip(
-              avatar: const Icon(Icons.thermostat, size: 18),
-              label: const Text('Watch Taipei'),
-              onPressed: _initializing
-                  ? null
-                  : () => _sendToWorker(<String, Object?>{
-                        'op': 'watch',
-                        'city': 'taipei',
-                        'threshold': 24.0,
-                      }),
-            ),
-            ActionChip(
-              avatar: const Icon(Icons.stop, size: 18),
-              label: const Text('Stop'),
-              onPressed: _initializing
-                  ? null
-                  : () => _sendToWorker(<String, Object?>{'op': 'stop'}),
-            ),
-          ],
-        ),
-      ],
+              const SizedBox(width: 8),
+              IconButton.filled(
+                onPressed: _initializing
+                    ? null
+                    : () => _sendFreeText(_messageController.text),
+                icon: const Icon(Icons.send),
+                tooltip: 'Send to worker',
+              ),
+            ],
+          ),
+          const SizedBox(height: 10),
+          Wrap(
+            spacing: 8,
+            runSpacing: 8,
+            children: <Widget>[
+              ActionChip(
+                avatar: const Icon(Icons.thermostat, size: 18),
+                label: const Text('Watch Cardiff'),
+                onPressed: _initializing
+                    ? null
+                    : () => _sendToWorker(<String, Object?>{
+                          'op': 'watch',
+                          'city': 'cardiff',
+                          'threshold': 10.9,
+                        }),
+              ),
+              ActionChip(
+                avatar: const Icon(Icons.thermostat, size: 18),
+                label: const Text('Watch Taipei'),
+                onPressed: _initializing
+                    ? null
+                    : () => _sendToWorker(<String, Object?>{
+                          'op': 'watch',
+                          'city': 'taipei',
+                          'threshold': 24.0,
+                        }),
+              ),
+              ActionChip(
+                avatar: const Icon(Icons.stop, size: 18),
+                label: const Text('Stop'),
+                onPressed: _initializing
+                    ? null
+                    : () => _sendToWorker(<String, Object?>{'op': 'stop'}),
+              ),
+            ],
+          ),
+        ],
+      ),
     );
   }
 

--- a/example/lib/web/web_demo_page.dart
+++ b/example/lib/web/web_demo_page.dart
@@ -403,7 +403,18 @@ class _WebDemoPageState extends State<WebDemoPage> {
               style: theme.textTheme.bodyMedium,
             ),
           ),
-          const SizedBox(height: 12),
+          const SizedBox(height: 10),
+          Align(
+            alignment: Alignment.centerLeft,
+            child: _appInstalled
+                ? const _InstalledStatus()
+                : FilledButton.icon(
+                    onPressed: _installApp,
+                    icon: const Icon(Icons.download),
+                    label: const Text('Install the app'),
+                  ),
+          ),
+          const SizedBox(height: 10),
           Expanded(
             child: Container(
               decoration: BoxDecoration(

--- a/example/lib/web/web_demo_page.dart
+++ b/example/lib/web/web_demo_page.dart
@@ -650,22 +650,6 @@ class _WebDemoPageState extends State<WebDemoPage> {
               'chat shows a "background: …" line for each run, so the '
               'foreground always reflects what the background did.',
         ),
-        const SizedBox(height: 4),
-        Container(
-          padding: const EdgeInsets.all(12),
-          decoration: BoxDecoration(
-            color: const Color(0xFFFFF3D6),
-            border: Border.all(color: const Color(0xFFB06000)),
-            borderRadius: BorderRadius.circular(10),
-          ),
-          child: Text(
-            'Developer note: when running via `flutter run -d chrome`, use a '
-            'full reload after code changes — hot restart is buggy on web '
-            '(can throw "disposed EngineFlutterView" errors; a page refresh '
-            'fixes it).',
-            style: theme.textTheme.bodySmall,
-          ),
-        ),
       ],
     );
   }

--- a/example/lib/web/web_demo_page.dart
+++ b/example/lib/web/web_demo_page.dart
@@ -12,17 +12,74 @@ const String _oneOffTask = 'dev.fluttercommunity.workmanagerExample.webOneOff';
 const String _periodicTask =
     'dev.fluttercommunity.workmanagerExample.webPeriodic';
 
+/// High-contrast status colors, readable on white.
+const Color _okGreen = Color(0xFF1E8E3E);
+const Color _alertRed = Color(0xFFC5221F);
+const Color _warnOrange = Color(0xFFB06000);
+const Color _infoBlue = Color(0xFF174EA6);
+const Color _mutedGrey = Color(0xFF5B6670);
+
 /// Web-only demo: registers tasks through [WorkmanagerWeb], shows a two-way
 /// "worker chat" (page <-> background worker via postMessage) and a task log
 /// with background-execution events (incl. Service Worker replay).
+///
+/// The simulated use case is a "weather watch": the page asks the worker to
+/// watch a city, and the worker streams simulated temperatures, alerting when
+/// the temperature drops below a threshold. Simulated, so the demo needs no
+/// network and no API keys.
 class WebDemoApp extends StatelessWidget {
   const WebDemoApp({super.key});
 
+  static final ThemeData _theme = ThemeData(
+    useMaterial3: true,
+    colorScheme: ColorScheme.fromSeed(
+      seedColor: const Color(0xFF0B57D0),
+    ).copyWith(
+      primary: const Color(0xFF0B57D0),
+      onPrimary: Colors.white,
+      primaryContainer: const Color(0xFFD3E3FD),
+      onPrimaryContainer: const Color(0xFF001B3F),
+      surface: Colors.white,
+      onSurface: const Color(0xFF111111),
+      onSurfaceVariant: const Color(0xFF1F1F1F),
+      outline: _mutedGrey,
+      outlineVariant: const Color(0xFFB0B8BF),
+      surfaceContainerHighest: const Color(0xFFE1E5E8),
+    ),
+    textTheme: const TextTheme(
+      titleLarge: TextStyle(
+        fontSize: 20,
+        fontWeight: FontWeight.w600,
+        color: Color(0xFF111111),
+      ),
+      titleSmall: TextStyle(
+        fontSize: 15,
+        fontWeight: FontWeight.w700,
+        color: Color(0xFF111111),
+      ),
+      bodyLarge: TextStyle(fontSize: 16, color: Color(0xFF111111)),
+      bodyMedium: TextStyle(fontSize: 15, color: Color(0xFF111111)),
+      bodySmall: TextStyle(fontSize: 14, color: Color(0xFF1F1F1F)),
+      labelLarge: TextStyle(fontSize: 14, color: Color(0xFF111111)),
+    ),
+    appBarTheme: const AppBarTheme(
+      backgroundColor: Color(0xFF0B57D0),
+      foregroundColor: Colors.white,
+      titleTextStyle: TextStyle(
+        fontSize: 20,
+        fontWeight: FontWeight.w600,
+        color: Colors.white,
+      ),
+    ),
+    dividerTheme: const DividerThemeData(color: Color(0xFFB0B8BF)),
+  );
+
   @override
   Widget build(BuildContext context) {
-    return const MaterialApp(
+    return MaterialApp(
       title: 'Workmanager Web Demo',
-      home: WebDemoPage(),
+      theme: _theme,
+      home: const WebDemoPage(),
     );
   }
 }
@@ -67,7 +124,7 @@ class _WebDemoPageState extends State<WebDemoPage> {
     await WorkmanagerWeb().registerPeriodicTask(
       _periodicTask,
       _periodicTask,
-      inputData: <String, dynamic>{'ticker': 'eth', 'threshold': 2400},
+      inputData: <String, dynamic>{'city': 'taipei', 'threshold': 20.0},
       frequency: const Duration(minutes: 15),
     );
     if (mounted) {
@@ -117,7 +174,7 @@ class _WebDemoPageState extends State<WebDemoPage> {
   Future<void> _runCheckNow() async {
     await WorkmanagerWeb().triggerTask(
       _oneOffTask,
-      inputData: <String, dynamic>{'ticker': 'btc', 'threshold': 60000},
+      inputData: <String, dynamic>{'city': 'cardiff', 'threshold': 5.0},
     );
   }
 
@@ -135,7 +192,6 @@ class _WebDemoPageState extends State<WebDemoPage> {
       child: Scaffold(
         appBar: AppBar(
           title: const Text('Workmanager Web Demo'),
-          backgroundColor: Theme.of(context).colorScheme.inversePrimary,
           bottom: const TabBar(
             tabs: <Widget>[
               Tab(icon: Icon(Icons.chat_bubble_outline), text: 'Worker chat'),
@@ -186,21 +242,19 @@ class _WebDemoPageState extends State<WebDemoPage> {
         children: <Widget>[
           Icon(
             ready ? Icons.check_circle : Icons.hourglass_top,
-            size: 16,
-            color: ready ? Colors.green : theme.colorScheme.outline,
+            size: 18,
+            color: ready ? _okGreen : _mutedGrey,
           ),
-          const SizedBox(width: 6),
+          const SizedBox(width: 8),
           Expanded(
             child: Text(
               _initializing
                   ? 'Starting worker…'
                   : _periodicRegistered
-                      ? 'Worker online · price check scheduled every 15 min '
-                          '(runs in the background via Service Worker)'
+                      ? 'Worker online · temperature check scheduled every '
+                          '15 min (runs in the background via Service Worker)'
                       : 'Worker online · no tasks scheduled',
-              style: theme.textTheme.bodySmall,
-              maxLines: 2,
-              overflow: TextOverflow.ellipsis,
+              style: theme.textTheme.bodyMedium,
             ),
           ),
         ],
@@ -208,106 +262,154 @@ class _WebDemoPageState extends State<WebDemoPage> {
     );
   }
 
-  Widget _buildChatTab(BuildContext context) {
+  Widget _buildHowItWorksCard(BuildContext context) {
     final theme = Theme.of(context);
-    return Padding(
-      padding: const EdgeInsets.all(12),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.stretch,
-        children: <Widget>[
-          Text(
-            'Talk to the worker — it replies from a separate thread '
-            '(postMessage). Try a watch, or type anything.',
-            style: theme.textTheme.bodySmall,
-          ),
-          const SizedBox(height: 8),
-          Expanded(
-            child: Container(
-              decoration: BoxDecoration(
-                border: Border.all(color: theme.colorScheme.outlineVariant),
-                borderRadius: BorderRadius.circular(8),
-              ),
-              child: _chat.isEmpty
-                  ? const Center(
-                      child: Text(
-                        'Messages appear here.\n'
-                        'Tap "Watch BTC" below to see live replies.',
-                        textAlign: TextAlign.center,
-                        style: TextStyle(fontSize: 12),
-                      ),
-                    )
-                  : ListView.builder(
-                      reverse: true,
-                      padding: const EdgeInsets.all(6),
-                      itemCount: _chat.length,
-                      itemBuilder: (BuildContext context, int index) {
-                        return _ChatBubble(line: _chat[index]);
-                      },
-                    ),
+    return Card(
+      elevation: 0,
+      margin: EdgeInsets.zero,
+      color: const Color(0xFFF1F4F8),
+      shape: RoundedRectangleBorder(
+        side: const BorderSide(color: Color(0xFFB0B8BF)),
+        borderRadius: BorderRadius.circular(10),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.all(12),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            Text('How this demo works', style: theme.textTheme.titleSmall),
+            const SizedBox(height: 8),
+            const _InfoLine(
+              icon: Icons.forum_outlined,
+              iconColor: _infoBlue,
+              text: 'Messaging — you talk to the background worker, which '
+                  'runs on its own thread; it replies via postMessage '
+                  '(this tab).',
             ),
+            const SizedBox(height: 6),
+            const _InfoLine(
+              icon: Icons.play_circle_outline,
+              iconColor: _okGreen,
+              text: 'Background tasks — registered tasks run off the page: '
+                  '"Run check now" fires one immediately, and one runs every '
+                  '15 min. Results appear in the Task log tab.',
+            ),
+            const SizedBox(height: 6),
+            const _InfoLine(
+              icon: Icons.cloud_outlined,
+              iconColor: _warnOrange,
+              text: 'Service Worker — install the app as a PWA and tasks '
+                  'also run while the page is closed; their results are '
+                  'replayed into the Task log when you reopen the page.',
+            ),
+            const SizedBox(height: 10),
+            Text(
+              'Try it: tap "Watch Cardiff" below, type any message, or run '
+              'a check in the Task log tab. All data is simulated — no '
+              'network needed.',
+              style: theme.textTheme.bodySmall,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildChatTab(BuildContext context) {
+    return ListView(
+      padding: const EdgeInsets.all(12),
+      children: <Widget>[
+        _buildHowItWorksCard(context),
+        const SizedBox(height: 12),
+        Container(
+          height: 220,
+          decoration: BoxDecoration(
+            border: Border.all(color: const Color(0xFFB0B8BF)),
+            borderRadius: BorderRadius.circular(10),
           ),
-          const SizedBox(height: 8),
-          Row(
-            children: <Widget>[
-              Expanded(
-                child: TextField(
-                  controller: _messageController,
-                  onSubmitted: _sendFreeText,
-                  decoration: const InputDecoration(
-                    isDense: true,
-                    hintText: 'Message the worker…',
-                    border: OutlineInputBorder(),
+          child: _chat.isEmpty
+              ? const Center(
+                  child: Padding(
+                    padding: EdgeInsets.all(16),
+                    child: Text(
+                      'Messages appear here — yours and the worker\'s '
+                      'replies.\n\nTap "Watch Cardiff" to see a live '
+                      'conversation, or just type anything.',
+                      textAlign: TextAlign.center,
+                      style: TextStyle(fontSize: 14, height: 1.4),
+                    ),
                   ),
+                )
+              : ListView.builder(
+                  reverse: true,
+                  padding: const EdgeInsets.all(8),
+                  itemCount: _chat.length,
+                  itemBuilder: (BuildContext context, int index) {
+                    return _ChatBubble(line: _chat[index]);
+                  },
+                ),
+        ),
+        const SizedBox(height: 10),
+        Row(
+          children: <Widget>[
+            Expanded(
+              child: TextField(
+                controller: _messageController,
+                onSubmitted: _sendFreeText,
+                decoration: const InputDecoration(
+                  isDense: true,
+                  hintText: 'Message the worker…',
+                  border: OutlineInputBorder(),
                 ),
               ),
-              const SizedBox(width: 6),
-              IconButton.filled(
-                onPressed: _initializing
-                    ? null
-                    : () => _sendFreeText(_messageController.text),
-                icon: const Icon(Icons.send),
-                tooltip: 'Send to worker',
-              ),
-            ],
-          ),
-          const SizedBox(height: 8),
-          Wrap(
-            spacing: 6,
-            runSpacing: 6,
-            children: <Widget>[
-              ActionChip(
-                avatar: const Icon(Icons.trending_up, size: 16),
-                label: const Text('Watch BTC'),
-                onPressed: _initializing
-                    ? null
-                    : () => _sendToWorker(<String, Object?>{
-                          'op': 'watch',
-                          'ticker': 'btc',
-                          'threshold': 58000,
-                        }),
-              ),
-              ActionChip(
-                avatar: const Icon(Icons.trending_up, size: 16),
-                label: const Text('Watch ETH'),
-                onPressed: _initializing
-                    ? null
-                    : () => _sendToWorker(<String, Object?>{
-                          'op': 'watch',
-                          'ticker': 'eth',
-                          'threshold': 2500,
-                        }),
-              ),
-              ActionChip(
-                avatar: const Icon(Icons.stop, size: 16),
-                label: const Text('Stop'),
-                onPressed: _initializing
-                    ? null
-                    : () => _sendToWorker(<String, Object?>{'op': 'stop'}),
-              ),
-            ],
-          ),
-        ],
-      ),
+            ),
+            const SizedBox(width: 8),
+            IconButton.filled(
+              onPressed: _initializing
+                  ? null
+                  : () => _sendFreeText(_messageController.text),
+              icon: const Icon(Icons.send),
+              tooltip: 'Send to worker',
+            ),
+          ],
+        ),
+        const SizedBox(height: 10),
+        Wrap(
+          spacing: 8,
+          runSpacing: 8,
+          children: <Widget>[
+            ActionChip(
+              avatar: const Icon(Icons.thermostat, size: 18),
+              label: const Text('Watch Cardiff'),
+              onPressed: _initializing
+                  ? null
+                  : () => _sendToWorker(<String, Object?>{
+                        'op': 'watch',
+                        'city': 'cardiff',
+                        'threshold': 5.0,
+                      }),
+            ),
+            ActionChip(
+              avatar: const Icon(Icons.thermostat, size: 18),
+              label: const Text('Watch Taipei'),
+              onPressed: _initializing
+                  ? null
+                  : () => _sendToWorker(<String, Object?>{
+                        'op': 'watch',
+                        'city': 'taipei',
+                        'threshold': 20.0,
+                      }),
+            ),
+            ActionChip(
+              avatar: const Icon(Icons.stop, size: 18),
+              label: const Text('Stop'),
+              onPressed: _initializing
+                  ? null
+                  : () => _sendToWorker(<String, Object?>{'op': 'stop'}),
+            ),
+          ],
+        ),
+      ],
     );
   }
 
@@ -317,7 +419,7 @@ class _WebDemoPageState extends State<WebDemoPage> {
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: <Widget>[
         Padding(
-          padding: const EdgeInsets.all(12),
+          padding: const EdgeInsets.fromLTRB(12, 12, 12, 4),
           child: Wrap(
             spacing: 8,
             runSpacing: 8,
@@ -336,6 +438,15 @@ class _WebDemoPageState extends State<WebDemoPage> {
             ],
           ),
         ),
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+          child: Text(
+            'Event states: executed = task ran · relayed = message routed · '
+            'missed/error = failure · warning = retried. Events from runs '
+            'while the page was closed are replayed here on load.',
+            style: theme.textTheme.bodySmall,
+          ),
+        ),
         const Divider(height: 1),
         Expanded(
           child: _events.isEmpty
@@ -343,12 +454,13 @@ class _WebDemoPageState extends State<WebDemoPage> {
                   padding: const EdgeInsets.all(24),
                   child: Text(
                     'No background events yet.\n\n'
-                    'Events executed by the Web Worker (page open) or the '
-                    'Service Worker (page closed, via Periodic Background '
-                    'Sync / Push) appear here, replayed from IndexedDB on '
-                    'load.',
+                    'Events appear whenever a registered task runs: press '
+                    '"Run check now" to fire one immediately. While the page '
+                    'is open, tasks run in the Web Worker; once the app is '
+                    'installed as a PWA, they also run in the Service Worker '
+                    'when the page is closed.',
                     textAlign: TextAlign.center,
-                    style: theme.textTheme.bodySmall,
+                    style: theme.textTheme.bodyMedium,
                   ),
                 )
               : ListView.builder(
@@ -367,8 +479,9 @@ class _WebDemoPageState extends State<WebDemoPage> {
     switch (op) {
       case 'watch':
         final threshold = (message['threshold'] as num?)?.toDouble();
-        return '📨 watch ${message['ticker']}'
-            '${threshold == null ? '' : ' (< \$${threshold.toStringAsFixed(0)})'}';
+        final city = _capitalize(message['city'] as String? ?? '?');
+        return '📨 watch $city'
+            '${threshold == null ? '' : ' (alert < ${threshold.toStringAsFixed(0)}°C)'}';
       case 'stop':
         return '📨 stop';
       case 'text':
@@ -383,31 +496,65 @@ class _WebDemoPageState extends State<WebDemoPage> {
       return '${payload ?? '(empty)'}';
     }
     final kind = payload['kind'];
-    final ticker = payload['ticker'] as String?;
-    final price = (payload['price'] as num?)?.toDouble();
-    final priceText = price == null ? '' : '\$${price.toStringAsFixed(2)}';
+    final city = _capitalize(payload['city'] as String? ?? '?');
+    final tempC = (payload['tempC'] as num?)?.toDouble();
+    final tempText = tempC == null ? '' : '${tempC.toStringAsFixed(1)}°C';
     switch (kind) {
       case 'watching':
         final threshold = (payload['threshold'] as num?)?.toDouble();
-        return '👀 watching $ticker${threshold == null ? '' : ' · alert < \$${threshold.toStringAsFixed(0)}'}';
+        return '👀 watching $city'
+            '${threshold == null ? '' : ' · alert below ${threshold.toStringAsFixed(0)}°C'}';
       case 'tick':
-        return '📈 $ticker $priceText';
+        return '🌡️ $city $tempText';
       case 'alert':
         final threshold = (payload['threshold'] as num?)?.toDouble();
-        return '🚨 $ticker $priceText below '
-            '\$${threshold?.toStringAsFixed(0) ?? '?'} — stopping';
+        return '🚨 $city $tempText below '
+            '${threshold?.toStringAsFixed(0) ?? '?'}°C — stopping';
       case 'stopped':
         return '🛑 watch stopped';
       case 'echo':
         return '↩︎ ${payload['text']}';
       case 'task-start':
-        return '▶ background check: $ticker…';
+        return '▶ background check: $city…';
       case 'task-done':
         final below = payload['below'] == true;
-        return '✅ $ticker $priceText${below ? ' · BELOW threshold' : ' · ok'}';
+        return '✅ $city $tempText${below ? ' · BELOW threshold' : ' · ok'}';
       default:
         return '$payload';
     }
+  }
+
+  static String _capitalize(String input) {
+    if (input.isEmpty) {
+      return input;
+    }
+    return input[0].toUpperCase() + input.substring(1);
+  }
+}
+
+class _InfoLine extends StatelessWidget {
+  const _InfoLine({required this.icon, required this.iconColor, required this.text});
+
+  final IconData icon;
+  final Color iconColor;
+  final String text;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        Padding(
+          padding: const EdgeInsets.only(top: 2),
+          child: Icon(icon, size: 18, color: iconColor),
+        ),
+        const SizedBox(width: 8),
+        Expanded(
+          child: Text(text, style: theme.textTheme.bodyMedium),
+        ),
+      ],
+    );
   }
 }
 
@@ -426,20 +573,29 @@ class _ChatBubble extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final color = line.fromWorker
-        ? theme.colorScheme.surfaceContainerHighest
-        : theme.colorScheme.primaryContainer;
+    final fromWorker = line.fromWorker;
+    final Color background =
+        fromWorker ? Colors.white : theme.colorScheme.primaryContainer;
+    final Color foreground =
+        fromWorker ? const Color(0xFF111111) : theme.colorScheme.onPrimaryContainer;
+    final BoxBorder border = Border.all(
+      color: fromWorker ? const Color(0xFFB0B8BF) : Colors.transparent,
+    );
     return Align(
-      alignment: line.fromWorker ? Alignment.centerLeft : Alignment.centerRight,
+      alignment: fromWorker ? Alignment.centerLeft : Alignment.centerRight,
       child: Container(
-        margin: const EdgeInsets.symmetric(vertical: 2),
-        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
-        constraints: const BoxConstraints(maxWidth: 280),
+        margin: const EdgeInsets.symmetric(vertical: 3),
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+        constraints: const BoxConstraints(maxWidth: 300),
         decoration: BoxDecoration(
-          color: color,
+          color: background,
+          border: border,
           borderRadius: BorderRadius.circular(12),
         ),
-        child: Text(line.text, style: const TextStyle(fontSize: 12)),
+        child: Text(
+          line.text,
+          style: TextStyle(fontSize: 14, height: 1.35, color: foreground),
+        ),
       ),
     );
   }
@@ -459,12 +615,12 @@ class _EventTile extends StatelessWidget {
       leading: Icon(_iconFor(event.state), color: _colorFor(event.state)),
       title: Text(
         '${event.taskName ?? '(no task)'} · ${event.source}',
-        style: const TextStyle(fontSize: 13),
+        style: const TextStyle(fontSize: 14, fontWeight: FontWeight.w600),
       ),
       subtitle: Text(
         '[$time] ${event.message ?? event.state}'
         '${event.result == null ? '' : '\nresult: $event.result'}',
-        style: const TextStyle(fontSize: 12),
+        style: const TextStyle(fontSize: 13, height: 1.3),
       ),
       isThreeLine: event.result != null,
       dense: true,
@@ -490,16 +646,16 @@ class _EventTile extends StatelessWidget {
   Color _colorFor(String state) {
     switch (state) {
       case 'executed':
-        return Colors.green;
+        return _okGreen;
       case 'relayed':
-        return Colors.blue;
+        return _infoBlue;
       case 'missed':
       case 'error':
-        return Colors.red;
+        return _alertRed;
       case 'warning':
-        return Colors.orange;
+        return _warnOrange;
       default:
-        return Colors.blueGrey;
+        return _mutedGrey;
     }
   }
 }

--- a/example/lib/web/web_demo_page.dart
+++ b/example/lib/web/web_demo_page.dart
@@ -8,19 +8,13 @@ import 'dart:js_interop_unsafe';
 import 'package:flutter/material.dart';
 import 'package:workmanager_web/workmanager_web.dart';
 
+import 'app_theme.dart';
 import 'background_tasks.dart';
 import 'install_glue.dart';
 
 const String _oneOffTask = 'dev.fluttercommunity.workmanagerExample.webOneOff';
 const String _periodicTask =
     'dev.fluttercommunity.workmanagerExample.webPeriodic';
-
-/// High-contrast status colors, readable on white.
-const Color _okGreen = Color(0xFF1E8E3E);
-const Color _alertRed = Color(0xFFC5221F);
-const Color _warnOrange = Color(0xFFB06000);
-const Color _infoBlue = Color(0xFF174EA6);
-const Color _mutedGrey = Color(0xFF5B6670);
 
 /// Web-only demo: registers tasks through [WorkmanagerWeb], shows a two-way
 /// "worker chat" (page <-> background worker via postMessage) and a task log
@@ -30,70 +24,6 @@ const Color _mutedGrey = Color(0xFF5B6670);
 /// watch a city, and the worker streams simulated temperatures, alerting when
 /// the temperature drops below a threshold. Simulated, so the demo needs no
 /// network and no API keys.
-class WebDemoApp extends StatelessWidget {
-  const WebDemoApp({super.key});
-
-  static final ThemeData _theme = ThemeData(
-    useMaterial3: true,
-    colorScheme: ColorScheme.fromSeed(
-      seedColor: const Color(0xFF0B57D0),
-    ).copyWith(
-      primary: const Color(0xFF0B57D0),
-      onPrimary: Colors.white,
-      primaryContainer: const Color(0xFFD3E3FD),
-      onPrimaryContainer: const Color(0xFF001B3F),
-      surface: Colors.white,
-      onSurface: const Color(0xFF111111),
-      onSurfaceVariant: const Color(0xFF1F1F1F),
-      outline: _mutedGrey,
-      outlineVariant: const Color(0xFFB0B8BF),
-      surfaceContainerHighest: const Color(0xFFE1E5E8),
-    ),
-    textTheme: const TextTheme(
-      titleLarge: TextStyle(
-        fontSize: 20,
-        fontWeight: FontWeight.w600,
-        color: Color(0xFF111111),
-      ),
-      titleSmall: TextStyle(
-        fontSize: 15,
-        fontWeight: FontWeight.w700,
-        color: Color(0xFF111111),
-      ),
-      bodyLarge: TextStyle(fontSize: 16, color: Color(0xFF111111)),
-      bodyMedium: TextStyle(fontSize: 15, color: Color(0xFF111111)),
-      bodySmall: TextStyle(fontSize: 14, color: Color(0xFF1F1F1F)),
-      labelLarge: TextStyle(fontSize: 14, color: Color(0xFF111111)),
-    ),
-    appBarTheme: const AppBarTheme(
-      backgroundColor: Color(0xFF0B57D0),
-      foregroundColor: Colors.white,
-      titleTextStyle: TextStyle(
-        fontSize: 20,
-        fontWeight: FontWeight.w600,
-        color: Colors.white,
-      ),
-    ),
-    tabBarTheme: const TabBarThemeData(
-      labelColor: Colors.white,
-      unselectedLabelColor: Color(0xFFD3E3FD),
-      indicatorColor: Colors.white,
-      labelStyle: TextStyle(fontSize: 14, fontWeight: FontWeight.w600),
-      unselectedLabelStyle: TextStyle(fontSize: 14),
-    ),
-    dividerTheme: const DividerThemeData(color: Color(0xFFB0B8BF)),
-  );
-
-  @override
-  Widget build(BuildContext context) {
-    return MaterialApp(
-      title: 'Workmanager Web Demo',
-      theme: _theme,
-      home: const WebDemoPage(),
-    );
-  }
-}
-
 class WebDemoPage extends StatefulWidget {
   const WebDemoPage({super.key});
 
@@ -362,7 +292,7 @@ class _WebDemoPageState extends State<WebDemoPage> {
           Icon(
             ready ? Icons.check_circle : Icons.hourglass_top,
             size: 18,
-            color: ready ? _okGreen : _mutedGrey,
+            color: ready ? AppTheme.okGreen : AppTheme.mutedGrey,
           ),
           const SizedBox(width: 8),
           Expanded(
@@ -391,8 +321,8 @@ class _WebDemoPageState extends State<WebDemoPage> {
           Container(
             padding: const EdgeInsets.all(12),
             decoration: BoxDecoration(
-              color: const Color(0xFFF1F4F8),
-              border: Border.all(color: const Color(0xFFB0B8BF)),
+              color: AppTheme.cardFill,
+              border: Border.all(color: AppTheme.borderGrey),
               borderRadius: BorderRadius.circular(10),
             ),
             child: Text(
@@ -418,7 +348,7 @@ class _WebDemoPageState extends State<WebDemoPage> {
           Expanded(
             child: Container(
               decoration: BoxDecoration(
-                border: Border.all(color: const Color(0xFFB0B8BF)),
+                border: Border.all(color: AppTheme.borderGrey),
                 borderRadius: BorderRadius.circular(10),
               ),
               child: _chat.isEmpty
@@ -589,8 +519,8 @@ class _WebDemoPageState extends State<WebDemoPage> {
         Container(
           padding: const EdgeInsets.all(12),
           decoration: BoxDecoration(
-            color: const Color(0xFFF1F4F8),
-            border: Border.all(color: const Color(0xFFB0B8BF)),
+            color: AppTheme.cardFill,
+            border: Border.all(color: AppTheme.borderGrey),
             borderRadius: BorderRadius.circular(10),
           ),
           child: Text(
@@ -732,7 +662,7 @@ class _InstalledStatus extends StatelessWidget {
     return Row(
       mainAxisSize: MainAxisSize.min,
       children: <Widget>[
-        const Icon(Icons.check_circle, size: 18, color: _okGreen),
+        const Icon(Icons.check_circle, size: 18, color: AppTheme.okGreen),
         const SizedBox(width: 6),
         Text('App installed', style: theme.textTheme.bodyMedium),
       ],
@@ -749,7 +679,7 @@ class _NotificationStatus extends StatelessWidget {
     return Row(
       mainAxisSize: MainAxisSize.min,
       children: <Widget>[
-        const Icon(Icons.notifications_active, size: 18, color: _okGreen),
+        const Icon(Icons.notifications_active, size: 18, color: AppTheme.okGreen),
         const SizedBox(width: 6),
         Text('Notifications on', style: theme.textTheme.bodyMedium),
       ],
@@ -777,7 +707,7 @@ class _GuideStep extends StatelessWidget {
             height: 26,
             alignment: Alignment.center,
             decoration: const BoxDecoration(
-              color: Color(0xFF0B57D0),
+              color: AppTheme.primaryBlue,
               shape: BoxShape.circle,
             ),
             child: Text(
@@ -825,9 +755,9 @@ class _ChatBubble extends StatelessWidget {
     final Color background =
         fromWorker ? Colors.white : theme.colorScheme.primaryContainer;
     final Color foreground =
-        fromWorker ? const Color(0xFF111111) : theme.colorScheme.onPrimaryContainer;
+        fromWorker ? AppTheme.textPrimary : theme.colorScheme.onPrimaryContainer;
     final BoxBorder border = Border.all(
-      color: fromWorker ? const Color(0xFFB0B8BF) : Colors.transparent,
+      color: fromWorker ? AppTheme.borderGrey : Colors.transparent,
     );
     return Align(
       alignment: fromWorker ? Alignment.centerLeft : Alignment.centerRight,
@@ -894,16 +824,16 @@ class _EventTile extends StatelessWidget {
   Color _colorFor(String state) {
     switch (state) {
       case 'executed':
-        return _okGreen;
+        return AppTheme.okGreen;
       case 'relayed':
-        return _infoBlue;
+        return AppTheme.infoBlue;
       case 'missed':
       case 'error':
-        return _alertRed;
+        return AppTheme.alertRed;
       case 'warning':
-        return _warnOrange;
+        return AppTheme.warnOrange;
       default:
-        return _mutedGrey;
+        return AppTheme.mutedGrey;
     }
   }
 }

--- a/example/lib/web/web_demo_page.dart
+++ b/example/lib/web/web_demo_page.dart
@@ -12,10 +12,9 @@ const String _oneOffTask = 'dev.fluttercommunity.workmanagerExample.webOneOff';
 const String _periodicTask =
     'dev.fluttercommunity.workmanagerExample.webPeriodic';
 
-/// Web-only demo: registers tasks through [WorkmanagerWeb], shows a live
-/// background-execution log and a two-way "worker chat" (page <-> background
-/// worker via postMessage), and offers a PWA install button so Periodic
-/// Background Sync can be tested.
+/// Web-only demo: registers tasks through [WorkmanagerWeb], shows a two-way
+/// "worker chat" (page <-> background worker via postMessage) and a task log
+/// with background-execution events (incl. Service Worker replay).
 class WebDemoApp extends StatelessWidget {
   const WebDemoApp({super.key});
 
@@ -40,6 +39,7 @@ class _WebDemoPageState extends State<WebDemoPage> {
   final List<_ChatLine> _chat = <_ChatLine>[];
   final TextEditingController _messageController = TextEditingController();
   bool _initializing = true;
+  bool _periodicRegistered = false;
 
   @override
   void initState() {
@@ -61,8 +61,20 @@ class _WebDemoPageState extends State<WebDemoPage> {
       webCallbackDispatcher,
       dispatcherUrl: WorkmanagerWeb.defaultDispatcherUrl,
     );
+    // Register the demo task automatically so the demo works with zero
+    // setup; use DevTools -> Application -> Periodic Background Sync to
+    // trigger it while the page is closed.
+    await WorkmanagerWeb().registerPeriodicTask(
+      _periodicTask,
+      _periodicTask,
+      inputData: <String, dynamic>{'ticker': 'eth', 'threshold': 2400},
+      frequency: const Duration(minutes: 15),
+    );
     if (mounted) {
-      setState(() => _initializing = false);
+      setState(() {
+        _initializing = false;
+        _periodicRegistered = true;
+      });
     }
   }
 
@@ -100,165 +112,139 @@ class _WebDemoPageState extends State<WebDemoPage> {
     _sendToWorker(<String, Object?>{'op': 'text', 'text': trimmed});
   }
 
-  Future<void> _registerOneOff() async {
-    await WorkmanagerWeb().registerOneOffTask(
-      _oneOffTask,
-      _oneOffTask,
-      inputData: <String, dynamic>{
-        'via': 'oneOff',
-        'ticker': 'btc',
-        'threshold': 58000,
-      },
-      initialDelay: const Duration(seconds: 5),
-    );
-  }
-
-  Future<void> _registerPeriodic() async {
-    await WorkmanagerWeb().registerPeriodicTask(
-      _periodicTask,
-      _periodicTask,
-      inputData: <String, dynamic>{
-        'via': 'periodic',
-        'ticker': 'eth',
-        'threshold': 2400,
-      },
-      frequency: const Duration(minutes: 15),
-    );
-  }
-
-  Future<void> _triggerNow() async {
+  Future<void> _runCheckNow() async {
     await WorkmanagerWeb().triggerTask(
       _oneOffTask,
-      inputData: <String, dynamic>{
-        'via': 'manual trigger',
-        'ticker': 'btc',
-        'threshold': 60000,
-      },
+      inputData: <String, dynamic>{'ticker': 'btc', 'threshold': 60000},
     );
   }
 
   Future<void> _cancelAll() async {
     await WorkmanagerWeb().cancelAll();
+    if (mounted) {
+      setState(() => _periodicRegistered = false);
+    }
   }
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
-        title: const Text('Workmanager Web (experimental)'),
-        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-      ),
-      body: Column(
-        children: <Widget>[
-          Padding(
-            padding: const EdgeInsets.all(12),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.stretch,
-              children: <Widget>[
-                Text(
-                  _initializing
-                      ? 'Initializing…'
-                      : 'Tasks run in a Web Worker (page open) or the Service '
-                          'Worker (page closed, via Periodic Sync / Push) and '
-                          'results are replayed from IndexedDB on load. The '
-                          'chat below talks to the worker over postMessage. '
-                          'Install the PWA for real background sync.',
-                  style: Theme.of(context).textTheme.bodySmall,
-                ),
-                const SizedBox(height: 8),
-                Wrap(
-                  spacing: 8,
-                  runSpacing: 8,
-                  children: <Widget>[
-                    FilledButton(
-                      onPressed: _initializing ? null : _registerOneOff,
-                      child: const Text('One-off (5 s)'),
-                    ),
-                    FilledButton(
-                      onPressed: _initializing ? null : _registerPeriodic,
-                      child: const Text('Periodic (15 min)'),
-                    ),
-                    FilledButton.tonal(
-                      onPressed: _initializing ? null : _triggerNow,
-                      child: const Text('Run now'),
-                    ),
-                    OutlinedButton(
-                      onPressed: _initializing ? null : _cancelAll,
-                      child: const Text('Cancel all'),
-                    ),
-                    if (InstallGlue.canPrompt)
-                      FilledButton.icon(
-                        onPressed: InstallGlue.promptInstall,
-                        icon: const Icon(Icons.download),
-                        label: const Text('Install PWA'),
-                      ),
-                  ],
+    return DefaultTabController(
+      length: 2,
+      child: Scaffold(
+        appBar: AppBar(
+          title: const Text('Workmanager Web Demo'),
+          backgroundColor: Theme.of(context).colorScheme.inversePrimary,
+          bottom: const TabBar(
+            tabs: <Widget>[
+              Tab(icon: Icon(Icons.chat_bubble_outline), text: 'Worker chat'),
+              Tab(icon: Icon(Icons.receipt_long_outlined), text: 'Task log'),
+            ],
+          ),
+          actions: <Widget>[
+            PopupMenuButton<String>(
+              enabled: !_initializing,
+              onSelected: (String value) {
+                if (value == 'cancel') {
+                  _cancelAll();
+                }
+              },
+              itemBuilder: (BuildContext context) => <PopupMenuEntry<String>>[
+                const PopupMenuItem<String>(
+                  value: 'cancel',
+                  child: Text('Cancel all tasks'),
                 ),
               ],
             ),
+          ],
+        ),
+        body: Column(
+          children: <Widget>[
+            _buildStatusStrip(context),
+            const Divider(height: 1),
+            Expanded(
+              child: TabBarView(
+                children: <Widget>[
+                  _buildChatTab(context),
+                  _buildTaskLogTab(context),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildStatusStrip(BuildContext context) {
+    final theme = Theme.of(context);
+    final ready = !_initializing && _periodicRegistered;
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+      child: Row(
+        children: <Widget>[
+          Icon(
+            ready ? Icons.check_circle : Icons.hourglass_top,
+            size: 16,
+            color: ready ? Colors.green : theme.colorScheme.outline,
           ),
-          const Divider(height: 1),
-          _buildChatPanel(context),
-          const Divider(height: 1),
+          const SizedBox(width: 6),
           Expanded(
-            child: _events.isEmpty
-                ? const Center(
-                    child: Text(
-                      'No background events yet.\n'
-                      'Events executed by the Web Worker, the Service Worker '
-                      '(page closed) and replayed on load appear here.',
-                      textAlign: TextAlign.center,
-                    ),
-                  )
-                : ListView.builder(
-                    itemCount: _events.length,
-                    itemBuilder: (BuildContext context, int index) {
-                      return _EventTile(event: _events[index]);
-                    },
-                  ),
+            child: Text(
+              _initializing
+                  ? 'Starting worker…'
+                  : _periodicRegistered
+                      ? 'Worker online · price check scheduled every 15 min '
+                          '(runs in the background via Service Worker)'
+                      : 'Worker online · no tasks scheduled',
+              style: theme.textTheme.bodySmall,
+              maxLines: 2,
+              overflow: TextOverflow.ellipsis,
+            ),
           ),
         ],
       ),
     );
   }
 
-  Widget _buildChatPanel(BuildContext context) {
+  Widget _buildChatTab(BuildContext context) {
     final theme = Theme.of(context);
     return Padding(
-      padding: const EdgeInsets.fromLTRB(12, 8, 12, 8),
+      padding: const EdgeInsets.all(12),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: <Widget>[
           Text(
-            'Worker chat — page ↔ background worker (postMessage)',
-            style: theme.textTheme.titleSmall,
+            'Talk to the worker — it replies from a separate thread '
+            '(postMessage). Try a watch, or type anything.',
+            style: theme.textTheme.bodySmall,
           ),
-          const SizedBox(height: 6),
-          Container(
-            height: 170,
-            decoration: BoxDecoration(
-              border: Border.all(color: theme.colorScheme.outlineVariant),
-              borderRadius: BorderRadius.circular(8),
-            ),
-            child: _chat.isEmpty
-                ? const Center(
-                    child: Text(
-                      'Send a message or tap a suggestion below.\n'
-                      'The worker replies from a separate thread.',
-                      textAlign: TextAlign.center,
-                      style: TextStyle(fontSize: 12),
+          const SizedBox(height: 8),
+          Expanded(
+            child: Container(
+              decoration: BoxDecoration(
+                border: Border.all(color: theme.colorScheme.outlineVariant),
+                borderRadius: BorderRadius.circular(8),
+              ),
+              child: _chat.isEmpty
+                  ? const Center(
+                      child: Text(
+                        'Messages appear here.\n'
+                        'Tap "Watch BTC" below to see live replies.',
+                        textAlign: TextAlign.center,
+                        style: TextStyle(fontSize: 12),
+                      ),
+                    )
+                  : ListView.builder(
+                      reverse: true,
+                      padding: const EdgeInsets.all(6),
+                      itemCount: _chat.length,
+                      itemBuilder: (BuildContext context, int index) {
+                        return _ChatBubble(line: _chat[index]);
+                      },
                     ),
-                  )
-                : ListView.builder(
-                    reverse: true,
-                    padding: const EdgeInsets.all(6),
-                    itemCount: _chat.length,
-                    itemBuilder: (BuildContext context, int index) {
-                      return _ChatBubble(line: _chat[index]);
-                    },
-                  ),
+            ),
           ),
-          const SizedBox(height: 6),
+          const SizedBox(height: 8),
           Row(
             children: <Widget>[
               Expanded(
@@ -267,7 +253,7 @@ class _WebDemoPageState extends State<WebDemoPage> {
                   onSubmitted: _sendFreeText,
                   decoration: const InputDecoration(
                     isDense: true,
-                    hintText: 'Type a message for the worker…',
+                    hintText: 'Message the worker…',
                     border: OutlineInputBorder(),
                   ),
                 ),
@@ -282,13 +268,14 @@ class _WebDemoPageState extends State<WebDemoPage> {
               ),
             ],
           ),
-          const SizedBox(height: 6),
+          const SizedBox(height: 8),
           Wrap(
             spacing: 6,
             runSpacing: 6,
             children: <Widget>[
               ActionChip(
-                label: const Text('Watch BTC (<\$58k)'),
+                avatar: const Icon(Icons.trending_up, size: 16),
+                label: const Text('Watch BTC'),
                 onPressed: _initializing
                     ? null
                     : () => _sendToWorker(<String, Object?>{
@@ -298,7 +285,8 @@ class _WebDemoPageState extends State<WebDemoPage> {
                         }),
               ),
               ActionChip(
-                label: const Text('Watch ETH (<\$2.5k)'),
+                avatar: const Icon(Icons.trending_up, size: 16),
+                label: const Text('Watch ETH'),
                 onPressed: _initializing
                     ? null
                     : () => _sendToWorker(<String, Object?>{
@@ -308,24 +296,67 @@ class _WebDemoPageState extends State<WebDemoPage> {
                         }),
               ),
               ActionChip(
-                label: const Text('Stop watch'),
+                avatar: const Icon(Icons.stop, size: 16),
+                label: const Text('Stop'),
                 onPressed: _initializing
                     ? null
                     : () => _sendToWorker(<String, Object?>{'op': 'stop'}),
-              ),
-              ActionChip(
-                label: const Text('Background check (task)'),
-                onPressed: _initializing
-                    ? null
-                    : () => _sendToWorker(<String, Object?>{
-                          'op': 'check',
-                          'ticker': 'ada',
-                        }),
               ),
             ],
           ),
         ],
       ),
+    );
+  }
+
+  Widget _buildTaskLogTab(BuildContext context) {
+    final theme = Theme.of(context);
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: <Widget>[
+        Padding(
+          padding: const EdgeInsets.all(12),
+          child: Wrap(
+            spacing: 8,
+            runSpacing: 8,
+            children: <Widget>[
+              FilledButton.tonalIcon(
+                onPressed: _initializing ? null : _runCheckNow,
+                icon: const Icon(Icons.play_arrow),
+                label: const Text('Run check now'),
+              ),
+              if (InstallGlue.canPrompt)
+                FilledButton.icon(
+                  onPressed: InstallGlue.promptInstall,
+                  icon: const Icon(Icons.download),
+                  label: const Text('Install app'),
+                ),
+            ],
+          ),
+        ),
+        const Divider(height: 1),
+        Expanded(
+          child: _events.isEmpty
+              ? Padding(
+                  padding: const EdgeInsets.all(24),
+                  child: Text(
+                    'No background events yet.\n\n'
+                    'Events executed by the Web Worker (page open) or the '
+                    'Service Worker (page closed, via Periodic Background '
+                    'Sync / Push) appear here, replayed from IndexedDB on '
+                    'load.',
+                    textAlign: TextAlign.center,
+                    style: theme.textTheme.bodySmall,
+                  ),
+                )
+              : ListView.builder(
+                  itemCount: _events.length,
+                  itemBuilder: (BuildContext context, int index) {
+                    return _EventTile(event: _events[index]);
+                  },
+                ),
+        ),
+      ],
     );
   }
 
@@ -340,8 +371,6 @@ class _WebDemoPageState extends State<WebDemoPage> {
         return '📨 stop';
       case 'text':
         return '📨 ${message['text']}';
-      case 'check':
-        return '📨 background check ${message['ticker']}';
       default:
         return '📨 $message';
     }

--- a/example/lib/web/web_demo_page.dart
+++ b/example/lib/web/web_demo_page.dart
@@ -467,6 +467,15 @@ class _WebDemoPageState extends State<WebDemoPage> {
             ],
           ),
         ),
+        if (!InstallGlue.canPrompt)
+          Padding(
+            padding: const EdgeInsets.fromLTRB(12, 0, 12, 4),
+            child: Text(
+              'Install button not shown by Chrome? Use the install icon (⊕) '
+              'in the address bar instead (needs localhost or HTTPS).',
+              style: theme.textTheme.bodySmall,
+            ),
+          ),
         Padding(
           padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
           child: Text(
@@ -543,9 +552,11 @@ class _WebDemoPageState extends State<WebDemoPage> {
         ),
         const _GuideStep(
           number: '3',
-          title: 'Install the app',
-          body: 'Tap "Install app". Installed apps can run background tasks '
-              'without an open tab.',
+          title: 'Install the app (as a PWA)',
+          body: 'Installing adds the demo to your device like a native app '
+              '— that is what allows tasks to run with no tab open. Tap '
+              '"Install app" on the Task log tab, or use the install icon '
+              '(⊕) in Chrome\'s address bar.',
         ),
         const _GuideStep(
           number: '4',

--- a/example/lib/web/web_demo_page.dart
+++ b/example/lib/web/web_demo_page.dart
@@ -108,11 +108,18 @@ class _WebDemoPageState extends State<WebDemoPage> {
   bool _initializing = true;
   bool _periodicRegistered = false;
   bool _notificationsGranted = false;
+  bool _appInstalled = false;
 
   @override
   void initState() {
     super.initState();
     InstallGlue.listen();
+    _appInstalled = InstallGlue.installed;
+    InstallGlue.onInstalled = () {
+      if (mounted) {
+        setState(() => _appInstalled = true);
+      }
+    };
     WorkmanagerWeb().backgroundEvents.listen(_onEvent);
     WorkmanagerWeb().workerMessages.listen(_onWorkerMessage);
     _initialize();
@@ -201,6 +208,41 @@ class _WebDemoPageState extends State<WebDemoPage> {
     if (mounted) {
       setState(() => _periodicRegistered = false);
     }
+  }
+
+  /// Installs the demo as a PWA. Shows the browser's install prompt when
+  /// available; otherwise explains how to install (address-bar icon).
+  Future<void> _installApp() async {
+    final installed = await InstallGlue.promptInstall();
+    if (installed) {
+      if (mounted) {
+        setState(() => _appInstalled = true);
+      }
+      return;
+    }
+    if (!mounted) {
+      return;
+    }
+    await showDialog<void>(
+      context: context,
+      builder: (BuildContext context) => AlertDialog(
+        title: const Text('How to install the demo'),
+        content: const Text(
+          'Chrome hasn\'t offered the install prompt yet. You can:\n\n'
+          '• Tap the install icon (⊕) in the address bar.\n'
+          '• Use the demo for a moment, then tap "Install the app" again.\n'
+          '• Installation requires localhost or HTTPS.\n\n'
+          'Installing adds the app to your device like a native app — '
+          'that is what lets tasks run with no tab open.',
+        ),
+        actions: <Widget>[
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(),
+            child: const Text('Got it'),
+          ),
+        ],
+      ),
+    );
   }
 
   /// Requests the Web Notifications permission (must be called from a user
@@ -458,24 +500,17 @@ class _WebDemoPageState extends State<WebDemoPage> {
                   icon: const Icon(Icons.notifications_active_outlined),
                   label: const Text('Allow notifications'),
                 ),
-              if (InstallGlue.canPrompt)
+              if (_appInstalled)
+                const _InstalledStatus()
+              else
                 FilledButton.icon(
-                  onPressed: InstallGlue.promptInstall,
+                  onPressed: _installApp,
                   icon: const Icon(Icons.download),
-                  label: const Text('Install app'),
+                  label: const Text('Install the app'),
                 ),
             ],
           ),
         ),
-        if (!InstallGlue.canPrompt)
-          Padding(
-            padding: const EdgeInsets.fromLTRB(12, 0, 12, 4),
-            child: Text(
-              'Install button not shown by Chrome? Use the install icon (⊕) '
-              'in the address bar instead (needs localhost or HTTPS).',
-              style: theme.textTheme.bodySmall,
-            ),
-          ),
         Padding(
           padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
           child: Text(
@@ -554,9 +589,19 @@ class _WebDemoPageState extends State<WebDemoPage> {
           number: '3',
           title: 'Install the app (as a PWA)',
           body: 'Installing adds the demo to your device like a native app '
-              '— that is what allows tasks to run with no tab open. Tap '
-              '"Install app" on the Task log tab, or use the install icon '
-              '(⊕) in Chrome\'s address bar.',
+              '— that is what allows tasks to run with no tab open. Use the '
+              'button below, or the install icon (⊕) in Chrome\'s address '
+              'bar.',
+        ),
+        Padding(
+          padding: const EdgeInsets.only(left: 36, bottom: 8),
+          child: _appInstalled
+              ? const _InstalledStatus()
+              : FilledButton.icon(
+                  onPressed: _installApp,
+                  icon: const Icon(Icons.download),
+                  label: const Text('Install the app'),
+                ),
         ),
         const _GuideStep(
           number: '4',
@@ -636,6 +681,23 @@ class _WebDemoPageState extends State<WebDemoPage> {
       return input;
     }
     return input[0].toUpperCase() + input.substring(1);
+  }
+}
+
+class _InstalledStatus extends StatelessWidget {
+  const _InstalledStatus();
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: <Widget>[
+        const Icon(Icons.check_circle, size: 18, color: _okGreen),
+        const SizedBox(width: 6),
+        Text('App installed', style: theme.textTheme.bodyMedium),
+      ],
+    );
   }
 }
 

--- a/example/lib/web/web_demo_page.dart
+++ b/example/lib/web/web_demo_page.dart
@@ -90,7 +90,8 @@ class _WebDemoPageState extends State<WebDemoPage> {
       return;
     }
     setState(() {
-      _chat.add(_ChatLine(text: _formatWorkerMessage(payload), fromWorker: true));
+      _chat.add(
+          _ChatLine(text: _formatWorkerMessage(payload), fromWorker: true));
     });
   }
 
@@ -98,7 +99,8 @@ class _WebDemoPageState extends State<WebDemoPage> {
   /// `handleWorkerMessage` in `background_tasks.dart`).
   void _sendToWorker(Map<String, Object?> message) {
     setState(() {
-      _chat.add(_ChatLine(text: _formatSentMessage(message), fromWorker: false));
+      _chat
+          .add(_ChatLine(text: _formatSentMessage(message), fromWorker: false));
     });
     WorkmanagerWeb().sendMessageToWorker(message);
   }

--- a/example/lib/web/web_demo_page.dart
+++ b/example/lib/web/web_demo_page.dart
@@ -13,7 +13,8 @@ const String _periodicTask =
     'dev.fluttercommunity.workmanagerExample.webPeriodic';
 
 /// Web-only demo: registers tasks through [WorkmanagerWeb], shows a live
-/// background-execution log and offers a PWA install button so Periodic
+/// background-execution log and a two-way "worker chat" (page <-> background
+/// worker via postMessage), and offers a PWA install button so Periodic
 /// Background Sync can be tested.
 class WebDemoApp extends StatelessWidget {
   const WebDemoApp({super.key});
@@ -36,6 +37,8 @@ class WebDemoPage extends StatefulWidget {
 
 class _WebDemoPageState extends State<WebDemoPage> {
   final List<WorkmanagerWebEvent> _events = <WorkmanagerWebEvent>[];
+  final List<_ChatLine> _chat = <_ChatLine>[];
+  final TextEditingController _messageController = TextEditingController();
   bool _initializing = true;
 
   @override
@@ -43,7 +46,14 @@ class _WebDemoPageState extends State<WebDemoPage> {
     super.initState();
     InstallGlue.listen();
     WorkmanagerWeb().backgroundEvents.listen(_onEvent);
+    WorkmanagerWeb().workerMessages.listen(_onWorkerMessage);
     _initialize();
+  }
+
+  @override
+  void dispose() {
+    _messageController.dispose();
+    super.dispose();
   }
 
   Future<void> _initialize() async {
@@ -63,11 +73,42 @@ class _WebDemoPageState extends State<WebDemoPage> {
     setState(() => _events.insert(0, event));
   }
 
+  void _onWorkerMessage(Object? payload) {
+    if (!mounted) {
+      return;
+    }
+    setState(() {
+      _chat.add(_ChatLine(text: _formatWorkerMessage(payload), fromWorker: true));
+    });
+  }
+
+  /// Sends a structured message to the background worker (see
+  /// `handleWorkerMessage` in `background_tasks.dart`).
+  void _sendToWorker(Map<String, Object?> message) {
+    setState(() {
+      _chat.add(_ChatLine(text: _formatSentMessage(message), fromWorker: false));
+    });
+    WorkmanagerWeb().sendMessageToWorker(message);
+  }
+
+  void _sendFreeText(String text) {
+    final trimmed = text.trim();
+    if (trimmed.isEmpty) {
+      return;
+    }
+    _messageController.clear();
+    _sendToWorker(<String, Object?>{'op': 'text', 'text': trimmed});
+  }
+
   Future<void> _registerOneOff() async {
     await WorkmanagerWeb().registerOneOffTask(
       _oneOffTask,
       _oneOffTask,
-      inputData: <String, dynamic>{'via': 'oneOff'},
+      inputData: <String, dynamic>{
+        'via': 'oneOff',
+        'ticker': 'btc',
+        'threshold': 58000,
+      },
       initialDelay: const Duration(seconds: 5),
     );
   }
@@ -76,7 +117,11 @@ class _WebDemoPageState extends State<WebDemoPage> {
     await WorkmanagerWeb().registerPeriodicTask(
       _periodicTask,
       _periodicTask,
-      inputData: <String, dynamic>{'via': 'periodic'},
+      inputData: <String, dynamic>{
+        'via': 'periodic',
+        'ticker': 'eth',
+        'threshold': 2400,
+      },
       frequency: const Duration(minutes: 15),
     );
   }
@@ -84,7 +129,11 @@ class _WebDemoPageState extends State<WebDemoPage> {
   Future<void> _triggerNow() async {
     await WorkmanagerWeb().triggerTask(
       _oneOffTask,
-      inputData: <String, dynamic>{'via': 'manual trigger'},
+      inputData: <String, dynamic>{
+        'via': 'manual trigger',
+        'ticker': 'btc',
+        'threshold': 60000,
+      },
     );
   }
 
@@ -109,9 +158,11 @@ class _WebDemoPageState extends State<WebDemoPage> {
                 Text(
                   _initializing
                       ? 'Initializing…'
-                      : 'Ready. Open DevTools → Application → Service Workers '
-                          'to trigger "periodicsync" / "Push" and watch this '
-                          'panel. Install the PWA for real background sync.',
+                      : 'Tasks run in a Web Worker (page open) or the Service '
+                          'Worker (page closed, via Periodic Sync / Push) and '
+                          'results are replayed from IndexedDB on load. The '
+                          'chat below talks to the worker over postMessage. '
+                          'Install the PWA for real background sync.',
                   style: Theme.of(context).textTheme.bodySmall,
                 ),
                 const SizedBox(height: 8),
@@ -147,6 +198,8 @@ class _WebDemoPageState extends State<WebDemoPage> {
             ),
           ),
           const Divider(height: 1),
+          _buildChatPanel(context),
+          const Divider(height: 1),
           Expanded(
             child: _events.isEmpty
                 ? const Center(
@@ -165,6 +218,197 @@ class _WebDemoPageState extends State<WebDemoPage> {
                   ),
           ),
         ],
+      ),
+    );
+  }
+
+  Widget _buildChatPanel(BuildContext context) {
+    final theme = Theme.of(context);
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(12, 8, 12, 8),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: <Widget>[
+          Text(
+            'Worker chat — page ↔ background worker (postMessage)',
+            style: theme.textTheme.titleSmall,
+          ),
+          const SizedBox(height: 6),
+          Container(
+            height: 170,
+            decoration: BoxDecoration(
+              border: Border.all(color: theme.colorScheme.outlineVariant),
+              borderRadius: BorderRadius.circular(8),
+            ),
+            child: _chat.isEmpty
+                ? const Center(
+                    child: Text(
+                      'Send a message or tap a suggestion below.\n'
+                      'The worker replies from a separate thread.',
+                      textAlign: TextAlign.center,
+                      style: TextStyle(fontSize: 12),
+                    ),
+                  )
+                : ListView.builder(
+                    reverse: true,
+                    padding: const EdgeInsets.all(6),
+                    itemCount: _chat.length,
+                    itemBuilder: (BuildContext context, int index) {
+                      return _ChatBubble(line: _chat[index]);
+                    },
+                  ),
+          ),
+          const SizedBox(height: 6),
+          Row(
+            children: <Widget>[
+              Expanded(
+                child: TextField(
+                  controller: _messageController,
+                  onSubmitted: _sendFreeText,
+                  decoration: const InputDecoration(
+                    isDense: true,
+                    hintText: 'Type a message for the worker…',
+                    border: OutlineInputBorder(),
+                  ),
+                ),
+              ),
+              const SizedBox(width: 6),
+              IconButton.filled(
+                onPressed: _initializing
+                    ? null
+                    : () => _sendFreeText(_messageController.text),
+                icon: const Icon(Icons.send),
+                tooltip: 'Send to worker',
+              ),
+            ],
+          ),
+          const SizedBox(height: 6),
+          Wrap(
+            spacing: 6,
+            runSpacing: 6,
+            children: <Widget>[
+              ActionChip(
+                label: const Text('Watch BTC (<\$58k)'),
+                onPressed: _initializing
+                    ? null
+                    : () => _sendToWorker(<String, Object?>{
+                          'op': 'watch',
+                          'ticker': 'btc',
+                          'threshold': 58000,
+                        }),
+              ),
+              ActionChip(
+                label: const Text('Watch ETH (<\$2.5k)'),
+                onPressed: _initializing
+                    ? null
+                    : () => _sendToWorker(<String, Object?>{
+                          'op': 'watch',
+                          'ticker': 'eth',
+                          'threshold': 2500,
+                        }),
+              ),
+              ActionChip(
+                label: const Text('Stop watch'),
+                onPressed: _initializing
+                    ? null
+                    : () => _sendToWorker(<String, Object?>{'op': 'stop'}),
+              ),
+              ActionChip(
+                label: const Text('Background check (task)'),
+                onPressed: _initializing
+                    ? null
+                    : () => _sendToWorker(<String, Object?>{
+                          'op': 'check',
+                          'ticker': 'ada',
+                        }),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  String _formatSentMessage(Map<String, Object?> message) {
+    final op = message['op'];
+    switch (op) {
+      case 'watch':
+        final threshold = (message['threshold'] as num?)?.toDouble();
+        return '📨 watch ${message['ticker']}'
+            '${threshold == null ? '' : ' (< \$${threshold.toStringAsFixed(0)})'}';
+      case 'stop':
+        return '📨 stop';
+      case 'text':
+        return '📨 ${message['text']}';
+      case 'check':
+        return '📨 background check ${message['ticker']}';
+      default:
+        return '📨 $message';
+    }
+  }
+
+  String _formatWorkerMessage(Object? payload) {
+    if (payload is! Map) {
+      return '${payload ?? '(empty)'}';
+    }
+    final kind = payload['kind'];
+    final ticker = payload['ticker'] as String?;
+    final price = (payload['price'] as num?)?.toDouble();
+    final priceText = price == null ? '' : '\$${price.toStringAsFixed(2)}';
+    switch (kind) {
+      case 'watching':
+        final threshold = (payload['threshold'] as num?)?.toDouble();
+        return '👀 watching $ticker${threshold == null ? '' : ' · alert < \$${threshold.toStringAsFixed(0)}'}';
+      case 'tick':
+        return '📈 $ticker $priceText';
+      case 'alert':
+        final threshold = (payload['threshold'] as num?)?.toDouble();
+        return '🚨 $ticker $priceText below '
+            '\$${threshold?.toStringAsFixed(0) ?? '?'} — stopping';
+      case 'stopped':
+        return '🛑 watch stopped';
+      case 'echo':
+        return '↩︎ ${payload['text']}';
+      case 'task-start':
+        return '▶ background check: $ticker…';
+      case 'task-done':
+        final below = payload['below'] == true;
+        return '✅ $ticker $priceText${below ? ' · BELOW threshold' : ' · ok'}';
+      default:
+        return '$payload';
+    }
+  }
+}
+
+class _ChatLine {
+  const _ChatLine({required this.text, required this.fromWorker});
+
+  final String text;
+  final bool fromWorker;
+}
+
+class _ChatBubble extends StatelessWidget {
+  const _ChatBubble({required this.line});
+
+  final _ChatLine line;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final color = line.fromWorker
+        ? theme.colorScheme.surfaceContainerHighest
+        : theme.colorScheme.primaryContainer;
+    return Align(
+      alignment: line.fromWorker ? Alignment.centerLeft : Alignment.centerRight,
+      child: Container(
+        margin: const EdgeInsets.symmetric(vertical: 2),
+        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+        constraints: const BoxConstraints(maxWidth: 280),
+        decoration: BoxDecoration(
+          color: color,
+          borderRadius: BorderRadius.circular(12),
+        ),
+        child: Text(line.text, style: const TextStyle(fontSize: 12)),
       ),
     );
   }

--- a/example/lib/web/web_demo_page.dart
+++ b/example/lib/web/web_demo_page.dart
@@ -74,6 +74,13 @@ class WebDemoApp extends StatelessWidget {
         color: Colors.white,
       ),
     ),
+    tabBarTheme: const TabBarThemeData(
+      labelColor: Colors.white,
+      unselectedLabelColor: Color(0xFFD3E3FD),
+      indicatorColor: Colors.white,
+      labelStyle: TextStyle(fontSize: 14, fontWeight: FontWeight.w600),
+      unselectedLabelStyle: TextStyle(fontSize: 14),
+    ),
     dividerTheme: const DividerThemeData(color: Color(0xFFB0B8BF)),
   );
 

--- a/example/lib/web/web_glue.dart
+++ b/example/lib/web/web_glue.dart
@@ -1,0 +1,5 @@
+// Copyright 2024 The Flutter Workmanager Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style license that can be
+// found in the LICENSE file.
+
+export 'web_glue_stub.dart' if (dart.library.js_interop) 'web_glue_web.dart';

--- a/example/lib/web/web_glue_stub.dart
+++ b/example/lib/web/web_glue_stub.dart
@@ -1,0 +1,13 @@
+// Copyright 2024 The Flutter Workmanager Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style license that can be
+// found in the LICENSE file.
+
+/// Native-safe stand-in for the browser bridges (keeps the example analyzable
+/// and compilable on native platforms). All calls are no-ops on non-web.
+void openUrl(String url) {}
+
+Future<bool> requestNotificationPermission() async => false;
+
+void showPageNotification(String title, String body) {}
+
+void showServiceWorkerNotification(String title, String body) {}

--- a/example/lib/web/web_glue_web.dart
+++ b/example/lib/web/web_glue_web.dart
@@ -1,0 +1,69 @@
+// Copyright 2024 The Flutter Workmanager Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style license that can be
+// found in the LICENSE file.
+
+import 'dart:js_interop';
+import 'dart:js_interop_unsafe';
+
+/// Browser-only implementations of the small JS bridges used by the web demo
+/// (landing page links + notifications). Kept behind a conditional export so
+/// the example still compiles on native platforms (see `web_glue.dart`).
+
+/// Opens [url] in a new browser tab.
+void openUrl(String url) {
+  final window = globalContext['window'] as JSObject?;
+  if (window != null) {
+    window.callMethod('open'.toJS, url.toJS);
+  }
+}
+
+/// Requests the Web Notifications permission (must be called from a user
+/// gesture in most browsers). Returns whether notifications are granted.
+Future<bool> requestNotificationPermission() async {
+  final notification = globalContext['Notification'];
+  if (notification == null) {
+    return false;
+  }
+  final notificationObj = notification as JSObject;
+  final permission = notificationObj['permission']?.dartify();
+  if (permission == 'granted') {
+    return true;
+  }
+  if (permission == 'denied') {
+    return false;
+  }
+  final result = await (notificationObj.callMethod('requestPermission'.toJS)
+          as JSPromise<JSAny?>)
+      .toDart;
+  return result?.dartify() == 'granted';
+}
+
+/// Shows a page-side browser notification (only valid once permission is
+/// granted).
+void showPageNotification(String title, String body) {
+  final notification = globalContext['Notification'];
+  if (notification == null) {
+    return;
+  }
+  (notification as JSFunction).callAsConstructor<JSObject>(
+    title.toJS,
+    <String, Object?>{'body': body}.jsify(),
+  );
+}
+
+/// Shows a browser notification from inside a Service Worker (i.e. while the
+/// page is closed) via `registration.showNotification`. No-op when not in a
+/// Service Worker context.
+void showServiceWorkerNotification(String title, String body) {
+  final self = globalContext;
+  if (!self.has('registration')) {
+    return;
+  }
+  final registration = self['registration'] as JSObject;
+  final promise = registration.callMethod(
+    'showNotification'.toJS,
+    title.toJS,
+    <String, Object?>{'body': body, 'tag': 'workmanager-demo'}.jsify(),
+  ) as JSPromise<JSAny?>;
+  promise.toDart.catchError((Object _) => null);
+}

--- a/example/web/background.dart.js
+++ b/example/web/background.dart.js
@@ -22,7 +22,7 @@ a[c]=function(){if(a[b]===s){a[b]=d()}a[c]=function(){return this[b]}
 return a[b]}}function lazyFinal(a,b,c,d){var s=a
 a[b]=s
 a[c]=function(){if(a[b]===s){var r=d()
-if(a[b]!==s){A.iu(b)}a[b]=r}var q=a[b]
+if(a[b]!==s){A.iy(b)}a[b]=r}var q=a[b]
 a[c]=function(){return q}
 return q}}function makeConstList(a,b){if(b!=null)A.K(a,b)
 a.$flags=7
@@ -30,10 +30,10 @@ return a}function convertToFastObject(a){function t(){}t.prototype=a
 new t()
 return a}function convertAllToFastObject(a){for(var s=0;s<a.length;++s){convertToFastObject(a[s])}}var y=0
 function instanceTearOffGetter(a,b){var s=null
-return a?function(c){if(s===null)s=A.e5(b)
-return new s(c,this)}:function(){if(s===null)s=A.e5(b)
+return a?function(c){if(s===null)s=A.e7(b)
+return new s(c,this)}:function(){if(s===null)s=A.e7(b)
 return new s(this,null)}}function staticTearOffGetter(a){var s=null
-return function(){if(s===null)s=A.e5(a).prototype
+return function(){if(s===null)s=A.e7(a).prototype
 return s}}var x=0
 function tearOffParameters(a,b,c,d,e,f,g,h,i,j){if(typeof h=="number"){h+=x}return{co:a,iS:b,iI:c,rC:d,dV:e,cs:f,fs:g,fT:h,aI:i||0,nDA:j}}function installStaticTearOff(a,b,c,d,e,f,g,h){var s=tearOffParameters(a,true,false,c,d,e,f,g,h,false)
 var r=staticTearOffGetter(s)
@@ -52,124 +52,124 @@ return a}var hunkHelpers=function(){var s=function(a,b,c,d,e){return function(f,
 return{inherit:inherit,inheritMany:inheritMany,mixin:mixinEasy,mixinHard:mixinHard,installStaticTearOff:installStaticTearOff,installInstanceTearOff:installInstanceTearOff,_instance_0u:s(0,0,null,["$0"],0),_instance_1u:s(0,1,null,["$1"],0),_instance_2u:s(0,2,null,["$2"],0),_instance_0i:s(1,0,null,["$0"],0),_instance_1i:s(1,1,null,["$1"],0),_instance_2i:s(1,2,null,["$2"],0),_static_0:r(0,null,["$0"],0),_static_1:r(1,null,["$1"],0),_static_2:r(2,null,["$2"],0),makeConstList:makeConstList,lazy:lazy,lazyFinal:lazyFinal,updateHolder:updateHolder,convertToFastObject:convertToFastObject,updateTypes:updateTypes,setOrUpdateInterceptorsByTag:setOrUpdateInterceptorsByTag,setOrUpdateLeafTags:setOrUpdateLeafTags}}()
 function initializeDeferredHunk(a){x=v.types.length
 a(hunkHelpers,v,w,$)}var J={
-eb(a,b,c,d){return{i:a,p:b,e:c,x:d}},
-e7(a){var s,r,q,p,o,n=a[v.dispatchPropertyName]
-if(n==null)if($.e9==null){A.il()
+ee(a,b,c,d){return{i:a,p:b,e:c,x:d}},
+ea(a){var s,r,q,p,o,n=a[v.dispatchPropertyName]
+if(n==null)if($.ec==null){A.iq()
 n=a[v.dispatchPropertyName]}if(n!=null){s=n.p
 if(!1===s)return n.i
 if(!0===s)return a
 r=Object.getPrototypeOf(a)
 if(s===r)return n.i
-if(n.e===r)throw A.e(A.eA("Return interceptor for "+A.m(s(a,n))))}q=a.constructor
+if(n.e===r)throw A.e(A.eD("Return interceptor for "+A.n(s(a,n))))}q=a.constructor
 if(q==null)p=null
-else{o=$.d5
-if(o==null)o=$.d5=v.getIsolateTag("_$dart_js")
+else{o=$.d6
+if(o==null)o=$.d6=v.getIsolateTag("_$dart_js")
 p=q[o]}if(p!=null)return p
-p=A.iq(a)
+p=A.iu(a)
 if(p!=null)return p
-if(typeof a=="function")return B.v
+if(typeof a=="function")return B.w
 s=Object.getPrototypeOf(a)
-if(s==null)return B.j
-if(s===Object.prototype)return B.j
-if(typeof q=="function"){o=$.d5
-if(o==null)o=$.d5=v.getIsolateTag("_$dart_js")
+if(s==null)return B.k
+if(s===Object.prototype)return B.k
+if(typeof q=="function"){o=$.d6
+if(o==null)o=$.d6=v.getIsolateTag("_$dart_js")
 Object.defineProperty(q,o,{value:B.f,enumerable:false,writable:true,configurable:true})
 return B.f}return B.f},
-fD(a,b){if(a<0||a>4294967295)throw A.e(A.ev(a,0,4294967295,"length",null))
-return J.fF(new Array(a),b)},
-fE(a,b){if(a<0)throw A.e(A.ak("Length must be a non-negative integer: "+a,null))
+fF(a,b){if(a<0||a>4294967295)throw A.e(A.c3(a,0,4294967295,"length",null))
+return J.fH(new Array(a),b)},
+fG(a,b){if(a<0)throw A.e(A.al("Length must be a non-negative integer: "+a,null))
 return A.K(new Array(a),b.h("x<0>"))},
-fF(a,b){var s=A.K(a,b.h("x<0>"))
+fH(a,b){var s=A.K(a,b.h("x<0>"))
 s.$flags=1
 return s},
-af(a){if(typeof a=="number"){if(Math.floor(a)==a)return J.aP.prototype
-return J.bL.prototype}if(typeof a=="string")return J.an.prototype
-if(a==null)return J.aQ.prototype
-if(typeof a=="boolean")return J.bK.prototype
+ag(a){if(typeof a=="number"){if(Math.floor(a)==a)return J.aQ.prototype
+return J.bO.prototype}if(typeof a=="string")return J.ao.prototype
+if(a==null)return J.aR.prototype
+if(typeof a=="boolean")return J.bN.prototype
 if(Array.isArray(a))return J.x.prototype
 if(typeof a!="object"){if(typeof a=="function")return J.N.prototype
-if(typeof a=="symbol")return J.aT.prototype
-if(typeof a=="bigint")return J.aR.prototype
-return a}if(a instanceof A.d)return a
-return J.e7(a)},
-f6(a){if(typeof a=="string")return J.an.prototype
+if(typeof a=="symbol")return J.aW.prototype
+if(typeof a=="bigint")return J.aU.prototype
+return a}if(a instanceof A.c)return a
+return J.ea(a)},
+e9(a){if(typeof a=="string")return J.ao.prototype
 if(a==null)return a
 if(Array.isArray(a))return J.x.prototype
 if(typeof a!="object"){if(typeof a=="function")return J.N.prototype
-if(typeof a=="symbol")return J.aT.prototype
-if(typeof a=="bigint")return J.aR.prototype
-return a}if(a instanceof A.d)return a
-return J.e7(a)},
-cn(a){if(a==null)return a
+if(typeof a=="symbol")return J.aW.prototype
+if(typeof a=="bigint")return J.aU.prototype
+return a}if(a instanceof A.c)return a
+return J.ea(a)},
+dx(a){if(a==null)return a
 if(Array.isArray(a))return J.x.prototype
 if(typeof a!="object"){if(typeof a=="function")return J.N.prototype
-if(typeof a=="symbol")return J.aT.prototype
-if(typeof a=="bigint")return J.aR.prototype
-return a}if(a instanceof A.d)return a
-return J.e7(a)},
+if(typeof a=="symbol")return J.aW.prototype
+if(typeof a=="bigint")return J.aU.prototype
+return a}if(a instanceof A.c)return a
+return J.ea(a)},
 P(a,b){if(a==null)return b==null
 if(typeof a!="object")return b!=null&&a===b
-return J.af(a).C(a,b)},
-fo(a,b){return J.cn(a).K(a,b)},
-W(a){return J.af(a).gq(a)},
-dH(a){return J.cn(a).gp(a)},
-dI(a){return J.f6(a).gl(a)},
-fp(a){return J.af(a).gt(a)},
-eg(a,b,c){return J.cn(a).L(a,b,c)},
-aH(a){return J.af(a).i(a)},
-bI:function bI(){},
-bK:function bK(){},
-aQ:function aQ(){},
-aS:function aS(){},
-Y:function Y(){},
-c_:function c_(){},
-b6:function b6(){},
-N:function N(){},
+return J.ag(a).C(a,b)},
+fq(a,b){return J.dx(a).L(a,b)},
+X(a){return J.ag(a).gq(a)},
+dJ(a){return J.dx(a).gp(a)},
+dK(a){return J.e9(a).gl(a)},
+fr(a){return J.ag(a).gt(a)},
+ek(a,b,c){return J.dx(a).M(a,b,c)},
+aI(a){return J.ag(a).i(a)},
+bL:function bL(){},
+bN:function bN(){},
 aR:function aR(){},
-aT:function aT(){},
+aV:function aV(){},
+Z:function Z(){},
+c0:function c0(){},
+b9:function b9(){},
+N:function N(){},
+aU:function aU(){},
+aW:function aW(){},
 x:function x(a){this.$ti=a},
-bJ:function bJ(){},
-cx:function cx(a){this.$ti=a},
-aI:function aI(a,b,c){var _=this
+bM:function bM(){},
+cy:function cy(a){this.$ti=a},
+aJ:function aJ(a,b,c){var _=this
 _.a=a
 _.b=b
 _.c=0
 _.d=null
 _.$ti=c},
-bM:function bM(){},
-aP:function aP(){},
-bL:function bL(){},
-an:function an(){}},A={dM:function dM(){},
-fs(a,b,c){if(t.O.b(a))return new A.ba(a,b.h("@<0>").k(c).h("ba<1,2>"))
-return new A.a3(a,b.h("@<0>").k(c).h("a3<1,2>"))},
-a_(a,b){a=a+b&536870911
+aS:function aS(){},
+aQ:function aQ(){},
+bO:function bO(){},
+ao:function ao(){}},A={dO:function dO(){},
+fu(a,b,c){if(t.O.b(a))return new A.bd(a,b.h("@<0>").k(c).h("bd<1,2>"))
+return new A.a4(a,b.h("@<0>").k(c).h("a4<1,2>"))},
+a0(a,b){a=a+b&536870911
 a=a+((a&524287)<<10)&536870911
 return a^a>>>6},
-dU(a){a=a+((a&67108863)<<3)&536870911
+dW(a){a=a+((a&67108863)<<3)&536870911
 a^=a>>>11
 return a+((a&16383)<<15)&536870911},
-dr(a,b,c){return a},
-ea(a){var s,r
+ds(a,b,c){return a},
+ed(a){var s,r
 for(s=$.G.length,r=0;r<s;++r)if(a===$.G[r])return!0
 return!1},
-dQ(a,b,c,d){if(t.O.b(a))return new A.aN(a,b,c.h("@<0>").k(d).h("aN<1,2>"))
-return new A.a7(a,b,c.h("@<0>").k(d).h("a7<1,2>"))},
-ar:function ar(){},
-aJ:function aJ(a,b){this.a=a
-this.$ti=b},
-a3:function a3(a,b){this.a=a
-this.$ti=b},
-ba:function ba(a,b){this.a=a
+dS(a,b,c,d){if(t.O.b(a))return new A.aO(a,b,c.h("@<0>").k(d).h("aO<1,2>"))
+return new A.a8(a,b,c.h("@<0>").k(d).h("a8<1,2>"))},
+as:function as(){},
+aK:function aK(a,b){this.a=a
 this.$ti=b},
 a4:function a4(a,b){this.a=a
 this.$ti=b},
-cq:function cq(a,b){this.a=a
+bd:function bd(a,b){this.a=a
+this.$ti=b},
+a5:function a5(a,b){this.a=a
+this.$ti=b},
+cr:function cr(a,b){this.a=a
 this.b=b},
-cp:function cp(a){this.a=a},
-bP:function bP(a){this.a=a},
-aK:function aK(a){this.a=a},
-cD:function cD(){},
-c:function c(){},
+cq:function cq(a){this.a=a},
+bQ:function bQ(a){this.a=a},
+aL:function aL(a){this.a=a},
+cE:function cE(){},
+d:function d(){},
 O:function O(){},
 R:function R(a,b,c){var _=this
 _.a=a
@@ -177,13 +177,13 @@ _.b=b
 _.c=0
 _.d=null
 _.$ti=c},
-a7:function a7(a,b,c){this.a=a
+a8:function a8(a,b,c){this.a=a
 this.b=b
 this.$ti=c},
-aN:function aN(a,b,c){this.a=a
+aO:function aO(a,b,c){this.a=a
 this.b=b
 this.$ti=c},
-aY:function aY(a,b,c){var _=this
+b0:function b0(a,b,c){var _=this
 _.a=null
 _.b=a
 _.c=b
@@ -192,82 +192,82 @@ S:function S(a,b,c){this.a=a
 this.b=b
 this.$ti=c},
 A:function A(){},
-b7:function b7(){},
-aq:function aq(){},
-fc(a){var s=v.mangledGlobalNames[a]
+ba:function ba(){},
+ar:function ar(){},
+fe(a){var s=v.mangledGlobalNames[a]
 if(s!=null)return s
 return"minified:"+a},
-iP(a,b){var s
+iT(a,b){var s
 if(b!=null){s=b.x
 if(s!=null)return s}return t.E.b(a)},
-m(a){var s
+n(a){var s
 if(typeof a=="string")return a
 if(typeof a=="number"){if(a!==0)return""+a}else if(!0===a)return"true"
 else if(!1===a)return"false"
 else if(a==null)return"null"
-s=J.aH(a)
+s=J.aI(a)
 return s},
-c0(a){var s,r=$.es
-if(r==null)r=$.es=Symbol("identityHashCode")
+c1(a){var s,r=$.ew
+if(r==null)r=$.ew=Symbol("identityHashCode")
 s=a[r]
 if(s==null){s=Math.random()*0x3fffffff|0
 a[r]=s}return s},
-c1(a){var s,r,q,p
-if(a instanceof A.d)return A.F(A.aE(a),null)
-s=J.af(a)
-if(s===B.t||s===B.w||t.cr.b(a)){r=B.h(a)
+c2(a){var s,r,q,p
+if(a instanceof A.c)return A.F(A.aE(a),null)
+s=J.ag(a)
+if(s===B.u||s===B.x||t.cr.b(a)){r=B.h(a)
 if(r!=="Object"&&r!=="")return r
 q=a.constructor
 if(typeof q=="function"){p=q.name
 if(typeof p=="string"&&p!=="Object"&&p!=="")return p}}return A.F(A.aE(a),null)},
-et(a){var s,r,q
-if(a==null||typeof a=="number"||A.dk(a))return J.aH(a)
+ex(a){var s,r,q
+if(a==null||typeof a=="number"||A.dk(a))return J.aI(a)
 if(typeof a=="string")return JSON.stringify(a)
-if(a instanceof A.X)return a.i(0)
-if(a instanceof A.V)return a.ag(!0)
-s=$.fn()
-for(r=0;r<1;++r){q=s[r].aV(a)
-if(q!=null)return q}return"Instance of '"+A.c1(a)+"'"},
+if(a instanceof A.Y)return a.i(0)
+if(a instanceof A.W)return a.ag(!0)
+s=$.fp()
+for(r=0;r<1;++r){q=s[r].aY(a)
+if(q!=null)return q}return"Instance of '"+A.c2(a)+"'"},
 E(a){if(a.date===void 0)a.date=new Date(a.a)
 return a.date},
-fQ(a){return a.c?A.E(a).getUTCFullYear()+0:A.E(a).getFullYear()+0},
-fO(a){return a.c?A.E(a).getUTCMonth()+1:A.E(a).getMonth()+1},
-fK(a){return a.c?A.E(a).getUTCDate()+0:A.E(a).getDate()+0},
-fL(a){return a.c?A.E(a).getUTCHours()+0:A.E(a).getHours()+0},
-fN(a){return a.c?A.E(a).getUTCMinutes()+0:A.E(a).getMinutes()+0},
-fP(a){return a.c?A.E(a).getUTCSeconds()+0:A.E(a).getSeconds()+0},
-fM(a){return a.c?A.E(a).getUTCMilliseconds()+0:A.E(a).getMilliseconds()+0},
-fJ(a){var s=a.$thrownJsError
+fS(a){return a.c?A.E(a).getUTCFullYear()+0:A.E(a).getFullYear()+0},
+fQ(a){return a.c?A.E(a).getUTCMonth()+1:A.E(a).getMonth()+1},
+fM(a){return a.c?A.E(a).getUTCDate()+0:A.E(a).getDate()+0},
+fN(a){return a.c?A.E(a).getUTCHours()+0:A.E(a).getHours()+0},
+fP(a){return a.c?A.E(a).getUTCMinutes()+0:A.E(a).getMinutes()+0},
+fR(a){return a.c?A.E(a).getUTCSeconds()+0:A.E(a).getSeconds()+0},
+fO(a){return a.c?A.E(a).getUTCMilliseconds()+0:A.E(a).getMilliseconds()+0},
+fL(a){var s=a.$thrownJsError
 if(s==null)return null
-return A.ag(s)},
-eu(a,b){var s
+return A.ah(s)},
+ey(a,b){var s
 if(a.$thrownJsError==null){s=new Error()
 A.w(a,s)
 a.$thrownJsError=s
 s.stack=b.i(0)}},
-y(a,b){if(a==null)J.dI(a)
-throw A.e(A.dt(a,b))},
-dt(a,b){var s,r="index"
-if(!A.e2(b))return new A.Q(!0,b,r,null)
-s=J.dI(a)
-if(b<0||b>=s)return A.fB(b,s,a,r)
-return new A.b3(null,null,!0,b,r,"Value not in range")},
+y(a,b){if(a==null)J.dK(a)
+throw A.e(A.du(a,b))},
+du(a,b){var s,r="index"
+if(!A.e4(b))return new A.Q(!0,b,r,null)
+s=J.dK(a)
+if(b<0||b>=s)return A.fD(b,s,a,r)
+return new A.b6(null,null,!0,b,r,"Value not in range")},
 e(a){return A.w(a,new Error())},
 w(a,b){var s
 if(a==null)a=new A.T()
 b.dartException=a
-s=A.iv
+s=A.iz
 if("defineProperty" in Object){Object.defineProperty(b,"message",{get:s})
 b.name=""}else b.toString=s
 return b},
-iv(){return J.aH(this.dartException)},
-co(a,b){throw A.w(a,b==null?new Error():b)},
-ec(a,b,c){var s
+iz(){return J.aI(this.dartException)},
+cp(a,b){throw A.w(a,b==null?new Error():b)},
+eg(a,b,c){var s
 if(b==null)b=0
 if(c==null)c=0
 s=Error()
-A.co(A.hw(a,b,c),s)},
-hw(a,b,c){var s,r,q,p,o,n,m,l,k
+A.cp(A.hA(a,b,c),s)},
+hA(a,b,c){var s,r,q,p,o,n,m,l,k
 if(typeof b=="string")s=b
 else{r="[]=;add;removeWhere;retainWhere;removeRange;setRange;setInt8;setInt16;setInt32;setUint8;setUint16;setUint32;setFloat32;setFloat64".split(";")
 q=r.length
@@ -280,10 +280,10 @@ l="a "
 if((m&4)!==0)k="constant "
 else if((m&2)!==0){k="unmodifiable "
 l="an "}else k=(m&1)!==0?"fixed-length ":""
-return new A.b8("'"+s+"': Cannot "+o+" "+l+k+n)},
-fb(a){throw A.e(A.am(a))},
+return new A.bb("'"+s+"': Cannot "+o+" "+l+k+n)},
+fd(a){throw A.e(A.an(a))},
 U(a){var s,r,q,p,o,n
-a=A.it(a.replace(String({}),"$receiver$"))
+a=A.ix(a.replace(String({}),"$receiver$"))
 s=a.match(/\\\$[a-zA-Z]+\\\$/g)
 if(s==null)s=A.K([],t.s)
 r=s.indexOf("\\$arguments\\$")
@@ -291,73 +291,73 @@ q=s.indexOf("\\$argumentsExpr\\$")
 p=s.indexOf("\\$expr\\$")
 o=s.indexOf("\\$method\\$")
 n=s.indexOf("\\$receiver\\$")
-return new A.cE(a.replace(new RegExp("\\\\\\$arguments\\\\\\$","g"),"((?:x|[^x])*)").replace(new RegExp("\\\\\\$argumentsExpr\\\\\\$","g"),"((?:x|[^x])*)").replace(new RegExp("\\\\\\$expr\\\\\\$","g"),"((?:x|[^x])*)").replace(new RegExp("\\\\\\$method\\\\\\$","g"),"((?:x|[^x])*)").replace(new RegExp("\\\\\\$receiver\\\\\\$","g"),"((?:x|[^x])*)"),r,q,p,o,n)},
-cF(a){return function($expr$){var $argumentsExpr$="$arguments$"
+return new A.cF(a.replace(new RegExp("\\\\\\$arguments\\\\\\$","g"),"((?:x|[^x])*)").replace(new RegExp("\\\\\\$argumentsExpr\\\\\\$","g"),"((?:x|[^x])*)").replace(new RegExp("\\\\\\$expr\\\\\\$","g"),"((?:x|[^x])*)").replace(new RegExp("\\\\\\$method\\\\\\$","g"),"((?:x|[^x])*)").replace(new RegExp("\\\\\\$receiver\\\\\\$","g"),"((?:x|[^x])*)"),r,q,p,o,n)},
+cG(a){return function($expr$){var $argumentsExpr$="$arguments$"
 try{$expr$.$method$($argumentsExpr$)}catch(s){return s.message}}(a)},
-ez(a){return function($expr$){try{$expr$.$method$}catch(s){return s.message}}(a)},
-dN(a,b){var s=b==null,r=s?null:b.method
-return new A.bO(a,r,s?null:b.receiver)},
-aj(a){var s
-if(a==null)return new A.cC(a)
-if(a instanceof A.aO){s=a.a
-return A.a2(a,s==null?A.ay(s):s)}if(typeof a!=="object")return a
-if("dartException" in a)return A.a2(a,a.dartException)
-return A.i3(a)},
-a2(a,b){if(t.C.b(b))if(b.$thrownJsError==null)b.$thrownJsError=a
+eC(a){return function($expr$){try{$expr$.$method$}catch(s){return s.message}}(a)},
+dP(a,b){var s=b==null,r=s?null:b.method
+return new A.bP(a,r,s?null:b.receiver)},
+ak(a){var s
+if(a==null)return new A.cD(a)
+if(a instanceof A.aP){s=a.a
+return A.a3(a,s==null?A.aa(s):s)}if(typeof a!=="object")return a
+if("dartException" in a)return A.a3(a,a.dartException)
+return A.i7(a)},
+a3(a,b){if(t.C.b(b))if(b.$thrownJsError==null)b.$thrownJsError=a
 return b},
-i3(a){var s,r,q,p,o,n,m,l,k,j,i,h,g
+i7(a){var s,r,q,p,o,n,m,l,k,j,i,h,g
 if(!("message" in a))return a
 s=a.message
 if("number" in a&&typeof a.number=="number"){r=a.number
 q=r&65535
-if((B.c.aE(r,16)&8191)===10)switch(q){case 438:return A.a2(a,A.dN(A.m(s)+" (Error "+q+")",null))
-case 445:case 5007:A.m(s)
-return A.a2(a,new A.b2())}}if(a instanceof TypeError){p=$.fd()
-o=$.fe()
-n=$.ff()
-m=$.fg()
-l=$.fj()
-k=$.fk()
-j=$.fi()
-$.fh()
-i=$.fm()
-h=$.fl()
+if((B.c.aG(r,16)&8191)===10)switch(q){case 438:return A.a3(a,A.dP(A.n(s)+" (Error "+q+")",null))
+case 445:case 5007:A.n(s)
+return A.a3(a,new A.b5())}}if(a instanceof TypeError){p=$.ff()
+o=$.fg()
+n=$.fh()
+m=$.fi()
+l=$.fl()
+k=$.fm()
+j=$.fk()
+$.fj()
+i=$.fo()
+h=$.fn()
 g=p.A(s)
-if(g!=null)return A.a2(a,A.dN(A.az(s),g))
+if(g!=null)return A.a3(a,A.dP(A.az(s),g))
 else{g=o.A(s)
 if(g!=null){g.method="call"
-return A.a2(a,A.dN(A.az(s),g))}else if(n.A(s)!=null||m.A(s)!=null||l.A(s)!=null||k.A(s)!=null||j.A(s)!=null||m.A(s)!=null||i.A(s)!=null||h.A(s)!=null){A.az(s)
-return A.a2(a,new A.b2())}}return A.a2(a,new A.c9(typeof s=="string"?s:""))}if(a instanceof RangeError){if(typeof s=="string"&&s.indexOf("call stack")!==-1)return new A.b5()
+return A.a3(a,A.dP(A.az(s),g))}else if(n.A(s)!=null||m.A(s)!=null||l.A(s)!=null||k.A(s)!=null||j.A(s)!=null||m.A(s)!=null||i.A(s)!=null||h.A(s)!=null){A.az(s)
+return A.a3(a,new A.b5())}}return A.a3(a,new A.cb(typeof s=="string"?s:""))}if(a instanceof RangeError){if(typeof s=="string"&&s.indexOf("call stack")!==-1)return new A.b8()
 s=function(b){try{return String(b)}catch(f){}return null}(a)
-return A.a2(a,new A.Q(!1,null,null,typeof s=="string"?s.replace(/^RangeError:\s*/,""):s))}if(typeof InternalError=="function"&&a instanceof InternalError)if(typeof s=="string"&&s==="too much recursion")return new A.b5()
+return A.a3(a,new A.Q(!1,null,null,typeof s=="string"?s.replace(/^RangeError:\s*/,""):s))}if(typeof InternalError=="function"&&a instanceof InternalError)if(typeof s=="string"&&s==="too much recursion")return new A.b8()
 return a},
-ag(a){var s
-if(a instanceof A.aO)return a.b
-if(a==null)return new A.bm(a)
+ah(a){var s
+if(a instanceof A.aP)return a.b
+if(a==null)return new A.bp(a)
 s=a.$cachedTrace
 if(s!=null)return s
-s=new A.bm(a)
+s=new A.bp(a)
 if(typeof a==="object")a.$cachedTrace=s
 return s},
-dD(a){if(a==null)return J.W(a)
-if(typeof a=="object")return A.c0(a)
-return J.W(a)},
-id(a,b){var s,r,q,p=a.length
+dF(a){if(a==null)return J.X(a)
+if(typeof a=="object")return A.c1(a)
+return J.X(a)},
+ii(a,b){var s,r,q,p=a.length
 for(s=0;s<p;s=q){r=s+1
 q=r+1
 b.v(0,a[s],a[r])}return b},
-hH(a,b,c,d,e,f){t.Z.a(a)
-switch(A.a1(b)){case 0:return a.$0()
+hL(a,b,c,d,e,f){t.Z.a(a)
+switch(A.a2(b)){case 0:return a.$0()
 case 1:return a.$1(c)
 case 2:return a.$2(c,d)
 case 3:return a.$3(c,d,e)
-case 4:return a.$4(c,d,e,f)}throw A.e(new A.cV("Unsupported number of arguments for wrapped closure"))},
+case 4:return a.$4(c,d,e,f)}throw A.e(new A.cW("Unsupported number of arguments for wrapped closure"))},
 aD(a,b){var s=a.$identity
 if(!!s)return s
-s=A.ia(a,b)
+s=A.ie(a,b)
 a.$identity=s
 return s},
-ia(a,b){var s
+ie(a,b){var s
 switch(b){case 0:s=a.$0
 break
 case 1:s=a.$1
@@ -369,10 +369,10 @@ break
 case 4:s=a.$4
 break
 default:s=null}if(s!=null)return s.bind(a)
-return function(c,d,e){return function(f,g,h,i){return e(c,d,f,g,h,i)}}(a,b,A.hH)},
-fx(a2){var s,r,q,p,o,n,m,l,k,j,i=a2.co,h=a2.iS,g=a2.iI,f=a2.nDA,e=a2.aI,d=a2.fs,c=a2.cs,b=d[0],a=c[0],a0=i[b],a1=a2.fT
+return function(c,d,e){return function(f,g,h,i){return e(c,d,f,g,h,i)}}(a,b,A.hL)},
+fz(a2){var s,r,q,p,o,n,m,l,k,j,i=a2.co,h=a2.iS,g=a2.iI,f=a2.nDA,e=a2.aI,d=a2.fs,c=a2.cs,b=d[0],a=c[0],a0=i[b],a1=a2.fT
 a1.toString
-s=h?Object.create(new A.c4().constructor.prototype):Object.create(new A.al(null,null).constructor.prototype)
+s=h?Object.create(new A.c6().constructor.prototype):Object.create(new A.am(null,null).constructor.prototype)
 s.$initialize=s.constructor
 r=h?function static_tear_off(){this.$initialize()}:function tear_off(a3,a4){this.$initialize(a3,a4)}
 s.constructor=r
@@ -380,24 +380,24 @@ r.prototype=s
 s.$_name=b
 s.$_target=a0
 q=!h
-if(q)p=A.em(b,a0,g,f)
+if(q)p=A.eq(b,a0,g,f)
 else{s.$static_name=b
-p=a0}s.$S=A.ft(a1,h,g)
+p=a0}s.$S=A.fv(a1,h,g)
 s[a]=p
 for(o=p,n=1;n<d.length;++n){m=d[n]
 if(typeof m=="string"){l=i[m]
 k=m
 m=l}else k=""
 j=c[n]
-if(j!=null){if(q)m=A.em(k,m,g,f)
+if(j!=null){if(q)m=A.eq(k,m,g,f)
 s[j]=m}if(n===e)o=m}s.$C=o
 s.$R=a2.rC
 s.$D=a2.dV
 return r},
-ft(a,b,c){if(typeof a=="number")return a
+fv(a,b,c){if(typeof a=="number")return a
 if(typeof a=="string"){if(b)throw A.e("Cannot compute signature for static tearoff.")
-return function(d,e){return function(){return e(this,d)}}(a,A.fq)}throw A.e("Error in functionType of tearoff")},
-fu(a,b,c,d){var s=A.el
+return function(d,e){return function(){return e(this,d)}}(a,A.fs)}throw A.e("Error in functionType of tearoff")},
+fw(a,b,c,d){var s=A.ep
 switch(b?-1:a){case 0:return function(e,f){return function(){return f(this)[e]()}}(c,s)
 case 1:return function(e,f){return function(g){return f(this)[e](g)}}(c,s)
 case 2:return function(e,f){return function(g,h){return f(this)[e](g,h)}}(c,s)
@@ -405,10 +405,10 @@ case 3:return function(e,f){return function(g,h,i){return f(this)[e](g,h,i)}}(c,
 case 4:return function(e,f){return function(g,h,i,j){return f(this)[e](g,h,i,j)}}(c,s)
 case 5:return function(e,f){return function(g,h,i,j,k){return f(this)[e](g,h,i,j,k)}}(c,s)
 default:return function(e,f){return function(){return e.apply(f(this),arguments)}}(d,s)}},
-em(a,b,c,d){if(c)return A.fw(a,b,d)
-return A.fu(b.length,d,a,b)},
-fv(a,b,c,d){var s=A.el,r=A.fr
-switch(b?-1:a){case 0:throw A.e(new A.c2("Intercepted function with no arguments."))
+eq(a,b,c,d){if(c)return A.fy(a,b,d)
+return A.fw(b.length,d,a,b)},
+fx(a,b,c,d){var s=A.ep,r=A.ft
+switch(b?-1:a){case 0:throw A.e(new A.c4("Intercepted function with no arguments."))
 case 1:return function(e,f,g){return function(){return f(this)[e](g(this))}}(c,r,s)
 case 2:return function(e,f,g){return function(h){return f(this)[e](g(this),h)}}(c,r,s)
 case 3:return function(e,f,g){return function(h,i){return f(this)[e](g(this),h,i)}}(c,r,s)
@@ -418,68 +418,68 @@ case 6:return function(e,f,g){return function(h,i,j,k,l){return f(this)[e](g(thi
 default:return function(e,f,g){return function(){var q=[g(this)]
 Array.prototype.push.apply(q,arguments)
 return e.apply(f(this),q)}}(d,r,s)}},
-fw(a,b,c){var s,r
-if($.ej==null)$.ej=A.ei("interceptor")
-if($.ek==null)$.ek=A.ei("receiver")
+fy(a,b,c){var s,r
+if($.en==null)$.en=A.em("interceptor")
+if($.eo==null)$.eo=A.em("receiver")
 s=b.length
-r=A.fv(s,c,a,b)
+r=A.fx(s,c,a,b)
 return r},
-e5(a){return A.fx(a)},
-fq(a,b){return A.bt(v.typeUniverse,A.aE(a.a),b)},
-el(a){return a.a},
-fr(a){return a.b},
-ei(a){var s,r,q,p=new A.al("receiver","interceptor"),o=Object.getOwnPropertyNames(p)
+e7(a){return A.fz(a)},
+fs(a,b){return A.bw(v.typeUniverse,A.aE(a.a),b)},
+ep(a){return a.a},
+ft(a){return a.b},
+em(a){var s,r,q,p=new A.am("receiver","interceptor"),o=Object.getOwnPropertyNames(p)
 o.$flags=1
 s=o
 for(o=s.length,r=0;r<o;++r){q=s[r]
-if(p[q]===a)return q}throw A.e(A.ak("Field name "+a+" not found.",null))},
-ie(a){return v.getIsolateTag(a)},
-iq(a){var s,r,q,p,o,n=A.az($.f7.$1(a)),m=$.du[n]
+if(p[q]===a)return q}throw A.e(A.al("Field name "+a+" not found.",null))},
+ij(a){return v.getIsolateTag(a)},
+iu(a){var s,r,q,p,o,n=A.az($.fa.$1(a)),m=$.dv[n]
 if(m!=null){Object.defineProperty(a,v.dispatchPropertyName,{value:m,enumerable:false,writable:true,configurable:true})
-return m.i}s=$.dA[n]
+return m.i}s=$.dC[n]
 if(s!=null)return s
 r=v.interceptorsByTag[n]
-if(r==null){q=A.cl($.f3.$2(a,n))
-if(q!=null){m=$.du[q]
+if(r==null){q=A.cn($.f7.$2(a,n))
+if(q!=null){m=$.dv[q]
 if(m!=null){Object.defineProperty(a,v.dispatchPropertyName,{value:m,enumerable:false,writable:true,configurable:true})
-return m.i}s=$.dA[q]
+return m.i}s=$.dC[q]
 if(s!=null)return s
 r=v.interceptorsByTag[q]
 n=q}}if(r==null)return null
 s=r.prototype
 p=n[0]
-if(p==="!"){m=A.dC(s)
-$.du[n]=m
+if(p==="!"){m=A.dE(s)
+$.dv[n]=m
 Object.defineProperty(a,v.dispatchPropertyName,{value:m,enumerable:false,writable:true,configurable:true})
-return m.i}if(p==="~"){$.dA[n]=s
-return s}if(p==="-"){o=A.dC(s)
+return m.i}if(p==="~"){$.dC[n]=s
+return s}if(p==="-"){o=A.dE(s)
 Object.defineProperty(Object.getPrototypeOf(a),v.dispatchPropertyName,{value:o,enumerable:false,writable:true,configurable:true})
-return o.i}if(p==="+")return A.f8(a,s)
-if(p==="*")throw A.e(A.eA(n))
-if(v.leafTags[n]===true){o=A.dC(s)
+return o.i}if(p==="+")return A.fb(a,s)
+if(p==="*")throw A.e(A.eD(n))
+if(v.leafTags[n]===true){o=A.dE(s)
 Object.defineProperty(Object.getPrototypeOf(a),v.dispatchPropertyName,{value:o,enumerable:false,writable:true,configurable:true})
-return o.i}else return A.f8(a,s)},
-f8(a,b){var s=Object.getPrototypeOf(a)
-Object.defineProperty(s,v.dispatchPropertyName,{value:J.eb(b,s,null,null),enumerable:false,writable:true,configurable:true})
+return o.i}else return A.fb(a,s)},
+fb(a,b){var s=Object.getPrototypeOf(a)
+Object.defineProperty(s,v.dispatchPropertyName,{value:J.ee(b,s,null,null),enumerable:false,writable:true,configurable:true})
 return b},
-dC(a){return J.eb(a,!1,null,!!a.$iB)},
-is(a,b,c){var s=b.prototype
-if(v.leafTags[a]===true)return A.dC(s)
-else return J.eb(s,c,null,null)},
-il(){if(!0===$.e9)return
-$.e9=!0
-A.im()},
-im(){var s,r,q,p,o,n,m,l
-$.du=Object.create(null)
-$.dA=Object.create(null)
-A.ik()
+dE(a){return J.ee(a,!1,null,!!a.$iC)},
+iw(a,b,c){var s=b.prototype
+if(v.leafTags[a]===true)return A.dE(s)
+else return J.ee(s,c,null,null)},
+iq(){if(!0===$.ec)return
+$.ec=!0
+A.ir()},
+ir(){var s,r,q,p,o,n,m,l
+$.dv=Object.create(null)
+$.dC=Object.create(null)
+A.ip()
 s=v.interceptorsByTag
 r=Object.getOwnPropertyNames(s)
 if(typeof window!="undefined"){window
 q=function(){}
 for(p=0;p<r.length;++p){o=r[p]
-n=$.fa.$1(o)
-if(n!=null){m=A.is(o,s[o],n)
+n=$.fc.$1(o)
+if(n!=null){m=A.iw(o,s[o],n)
 if(m!=null){Object.defineProperty(n,v.dispatchPropertyName,{value:m,enumerable:false,writable:true,configurable:true})
 q.prototype=n}}}}for(p=0;p<r.length;++p){o=r[p]
 if(/^[A-Za-z_]/.test(o)){l=s[o]
@@ -488,355 +488,355 @@ s["~"+o]=l
 s["-"+o]=l
 s["+"+o]=l
 s["*"+o]=l}}},
-ik(){var s,r,q,p,o,n,m=B.k()
-m=A.aC(B.l,A.aC(B.m,A.aC(B.i,A.aC(B.i,A.aC(B.n,A.aC(B.o,A.aC(B.p(B.h),m)))))))
+ip(){var s,r,q,p,o,n,m=B.l()
+m=A.aC(B.m,A.aC(B.n,A.aC(B.i,A.aC(B.i,A.aC(B.o,A.aC(B.p,A.aC(B.q(B.h),m)))))))
 if(typeof dartNativeDispatchHooksTransformer!="undefined"){s=dartNativeDispatchHooksTransformer
 if(typeof s=="function")s=[s]
 if(Array.isArray(s))for(r=0;r<s.length;++r){q=s[r]
 if(typeof q=="function")m=q(m)||m}}p=m.getTag
 o=m.getUnknownTag
 n=m.prototypeForTag
-$.f7=new A.dx(p)
-$.f3=new A.dy(o)
-$.fa=new A.dz(n)},
+$.fa=new A.dz(p)
+$.f7=new A.dA(o)
+$.fc=new A.dB(n)},
 aC(a,b){return a(b)||b},
-ib(a,b){var s=b.length,r=v.rttc[""+s+";"+a]
+ig(a,b){var s=b.length,r=v.rttc[""+s+";"+a]
 if(r==null)return null
 if(s===0)return r
 if(s===r.length)return r.apply(null,b)
 return r(b)},
-it(a){if(/[[\]{}()*+?.\\^$|]/.test(a))return a.replace(/[[\]{}()*+?.\\^$|]/g,"\\$&")
+ix(a){if(/[[\]{}()*+?.\\^$|]/.test(a))return a.replace(/[[\]{}()*+?.\\^$|]/g,"\\$&")
 return a},
-bk:function bk(a,b){this.a=a
+bn:function bn(a,b){this.a=a
 this.b=b},
-bl:function bl(a,b,c){this.a=a
+bo:function bo(a,b,c){this.a=a
 this.b=b
 this.c=c},
-aL:function aL(){},
-aM:function aM(a,b,c){this.a=a
+aM:function aM(){},
+aN:function aN(a,b,c){this.a=a
 this.b=b
 this.$ti=c},
-be:function be(a,b){this.a=a
+bh:function bh(a,b){this.a=a
 this.$ti=b},
-bf:function bf(a,b,c){var _=this
+bi:function bi(a,b,c){var _=this
 _.a=a
 _.b=b
 _.c=0
 _.d=null
 _.$ti=c},
-b4:function b4(){},
-cE:function cE(a,b,c,d,e,f){var _=this
+b7:function b7(){},
+cF:function cF(a,b,c,d,e,f){var _=this
 _.a=a
 _.b=b
 _.c=c
 _.d=d
 _.e=e
 _.f=f},
-b2:function b2(){},
-bO:function bO(a,b,c){this.a=a
+b5:function b5(){},
+bP:function bP(a,b,c){this.a=a
 this.b=b
 this.c=c},
-c9:function c9(a){this.a=a},
-cC:function cC(a){this.a=a},
-aO:function aO(a,b){this.a=a
+cb:function cb(a){this.a=a},
+cD:function cD(a){this.a=a},
+aP:function aP(a,b){this.a=a
 this.b=b},
-bm:function bm(a){this.a=a
+bp:function bp(a){this.a=a
 this.b=null},
-X:function X(){},
-bB:function bB(){},
-bC:function bC(){},
+Y:function Y(){},
+bE:function bE(){},
+bF:function bF(){},
+c8:function c8(){},
 c6:function c6(){},
-c4:function c4(){},
-al:function al(a,b){this.a=a
+am:function am(a,b){this.a=a
 this.b=b},
-c2:function c2(a){this.a=a},
-a6:function a6(a){var _=this
+c4:function c4(a){this.a=a},
+a7:function a7(a){var _=this
 _.a=0
 _.f=_.e=_.d=_.c=_.b=null
 _.r=0
 _.$ti=a},
-cy:function cy(a,b){this.a=a
+cz:function cz(a,b){this.a=a
 this.b=b
 this.c=null},
+b_:function b_(a,b){this.a=a
+this.$ti=b},
+aZ:function aZ(a,b,c,d){var _=this
+_.a=a
+_.b=b
+_.c=c
+_.d=null
+_.$ti=d},
 aX:function aX(a,b){this.a=a
 this.$ti=b},
-aW:function aW(a,b,c,d){var _=this
+aY:function aY(a,b,c,d){var _=this
 _.a=a
 _.b=b
 _.c=c
 _.d=null
 _.$ti=d},
-aU:function aU(a,b){this.a=a
-this.$ti=b},
-aV:function aV(a,b,c,d){var _=this
-_.a=a
-_.b=b
-_.c=c
-_.d=null
-_.$ti=d},
-dx:function dx(a){this.a=a},
-dy:function dy(a){this.a=a},
 dz:function dz(a){this.a=a},
-V:function V(){},
-au:function au(){},
+dA:function dA(a){this.a=a},
+dB:function dB(a){this.a=a},
+W:function W(){},
 av:function av(){},
-aa(a,b,c){if(a>>>0!==a||a>=c)throw A.e(A.dt(b,a))},
-ao:function ao(){},
-b0:function b0(){},
-bQ:function bQ(){},
+aw:function aw(){},
+ab(a,b,c){if(a>>>0!==a||a>=c)throw A.e(A.du(b,a))},
 ap:function ap(){},
-aZ:function aZ(){},
-b_:function b_(){},
+b3:function b3(){},
 bR:function bR(){},
+aq:function aq(){},
+b1:function b1(){},
+b2:function b2(){},
 bS:function bS(){},
 bT:function bT(){},
 bU:function bU(){},
 bV:function bV(){},
 bW:function bW(){},
 bX:function bX(){},
-b1:function b1(){},
 bY:function bY(){},
-bg:function bg(){},
-bh:function bh(){},
-bi:function bi(){},
+b4:function b4(){},
+bZ:function bZ(){},
 bj:function bj(){},
-dS(a,b){var s=b.c
-return s==null?b.c=A.br(a,"M",[b.x]):s},
-ew(a){var s=a.w
-if(s===6||s===7)return A.ew(a.x)
+bk:function bk(){},
+bl:function bl(){},
+bm:function bm(){},
+dU(a,b){var s=b.c
+return s==null?b.c=A.bu(a,"M",[b.x]):s},
+ez(a){var s=a.w
+if(s===6||s===7)return A.ez(a.x)
 return s===11||s===12},
-fR(a){return a.as},
-dv(a){return A.dc(v.typeUniverse,a,!1)},
-ac(a1,a2,a3,a4){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d,c,b,a,a0=a2.w
+fU(a){return a.as},
+dw(a){return A.dd(v.typeUniverse,a,!1)},
+ad(a1,a2,a3,a4){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d,c,b,a,a0=a2.w
 switch(a0){case 5:case 1:case 2:case 3:case 4:return a2
 case 6:s=a2.x
-r=A.ac(a1,s,a3,a4)
+r=A.ad(a1,s,a3,a4)
 if(r===s)return a2
-return A.eN(a1,r,!0)
+return A.eQ(a1,r,!0)
 case 7:s=a2.x
-r=A.ac(a1,s,a3,a4)
+r=A.ad(a1,s,a3,a4)
 if(r===s)return a2
-return A.eM(a1,r,!0)
+return A.eP(a1,r,!0)
 case 8:q=a2.y
 p=A.aB(a1,q,a3,a4)
 if(p===q)return a2
-return A.br(a1,a2.x,p)
+return A.bu(a1,a2.x,p)
 case 9:o=a2.x
-n=A.ac(a1,o,a3,a4)
+n=A.ad(a1,o,a3,a4)
 m=a2.y
 l=A.aB(a1,m,a3,a4)
 if(n===o&&l===m)return a2
-return A.dY(a1,n,l)
+return A.e_(a1,n,l)
 case 10:k=a2.x
 j=a2.y
 i=A.aB(a1,j,a3,a4)
 if(i===j)return a2
-return A.eO(a1,k,i)
+return A.eR(a1,k,i)
 case 11:h=a2.x
-g=A.ac(a1,h,a3,a4)
+g=A.ad(a1,h,a3,a4)
 f=a2.y
-e=A.i0(a1,f,a3,a4)
+e=A.i4(a1,f,a3,a4)
 if(g===h&&e===f)return a2
-return A.eL(a1,g,e)
+return A.eO(a1,g,e)
 case 12:d=a2.y
 a4+=d.length
 c=A.aB(a1,d,a3,a4)
 o=a2.x
-n=A.ac(a1,o,a3,a4)
+n=A.ad(a1,o,a3,a4)
 if(c===d&&n===o)return a2
-return A.dZ(a1,n,c,!0)
+return A.e0(a1,n,c,!0)
 case 13:b=a2.x
 if(b<a4)return a2
 a=a3[b-a4]
 if(a==null)return a2
 return a
-default:throw A.e(A.bA("Attempted to substitute unexpected RTI kind "+a0))}},
-aB(a,b,c,d){var s,r,q,p,o=b.length,n=A.dd(o)
+default:throw A.e(A.bD("Attempted to substitute unexpected RTI kind "+a0))}},
+aB(a,b,c,d){var s,r,q,p,o=b.length,n=A.de(o)
 for(s=!1,r=0;r<o;++r){q=b[r]
-p=A.ac(a,q,c,d)
+p=A.ad(a,q,c,d)
 if(p!==q)s=!0
 n[r]=p}return s?n:b},
-i1(a,b,c,d){var s,r,q,p,o,n,m=b.length,l=A.dd(m)
+i5(a,b,c,d){var s,r,q,p,o,n,m=b.length,l=A.de(m)
 for(s=!1,r=0;r<m;r+=3){q=b[r]
 p=b[r+1]
 o=b[r+2]
-n=A.ac(a,o,c,d)
+n=A.ad(a,o,c,d)
 if(n!==o)s=!0
 l.splice(r,3,q,p,n)}return s?l:b},
-i0(a,b,c,d){var s,r=b.a,q=A.aB(a,r,c,d),p=b.b,o=A.aB(a,p,c,d),n=b.c,m=A.i1(a,n,c,d)
+i4(a,b,c,d){var s,r=b.a,q=A.aB(a,r,c,d),p=b.b,o=A.aB(a,p,c,d),n=b.c,m=A.i5(a,n,c,d)
 if(q===r&&o===p&&m===n)return b
-s=new A.cg()
+s=new A.ci()
 s.a=q
 s.b=o
 s.c=m
 return s},
 K(a,b){a[v.arrayRti]=b
 return a},
-f5(a){var s=a.$S
-if(s!=null){if(typeof s=="number")return A.ih(s)
+f9(a){var s=a.$S
+if(s!=null){if(typeof s=="number")return A.il(s)
 return a.$S()}return null},
-io(a,b){var s
-if(A.ew(b))if(a instanceof A.X){s=A.f5(a)
+is(a,b){var s
+if(A.ez(b))if(a instanceof A.Y){s=A.f9(a)
 if(s!=null)return s}return A.aE(a)},
-aE(a){if(a instanceof A.d)return A.r(a)
-if(Array.isArray(a))return A.ax(a)
-return A.e0(J.af(a))},
-ax(a){var s=a[v.arrayRti],r=t.b
+aE(a){if(a instanceof A.c)return A.t(a)
+if(Array.isArray(a))return A.ay(a)
+return A.e2(J.ag(a))},
+ay(a){var s=a[v.arrayRti],r=t.b
 if(s==null)return r
 if(s.constructor!==r.constructor)return r
 return s},
-r(a){var s=a.$ti
-return s!=null?s:A.e0(a)},
-e0(a){var s=a.constructor,r=s.$ccache
+t(a){var s=a.$ti
+return s!=null?s:A.e2(a)},
+e2(a){var s=a.constructor,r=s.$ccache
 if(r!=null)return r
-return A.hE(a,s)},
-hE(a,b){var s=a instanceof A.X?Object.getPrototypeOf(Object.getPrototypeOf(a)).constructor:b,r=A.hj(v.typeUniverse,s.name)
+return A.hI(a,s)},
+hI(a,b){var s=a instanceof A.Y?Object.getPrototypeOf(Object.getPrototypeOf(a)).constructor:b,r=A.hm(v.typeUniverse,s.name)
 b.$ccache=r
 return r},
-ih(a){var s,r=v.types,q=r[a]
-if(typeof q=="string"){s=A.dc(v.typeUniverse,q,!1)
+il(a){var s,r=v.types,q=r[a]
+if(typeof q=="string"){s=A.dd(v.typeUniverse,q,!1)
 r[a]=s
 return s}return q},
-ig(a){return A.ae(A.r(a))},
-e4(a){var s
-if(a instanceof A.V)return A.ic(a.$r,a.U())
-s=a instanceof A.X?A.f5(a):null
+ik(a){return A.af(A.t(a))},
+e6(a){var s
+if(a instanceof A.W)return A.ih(a.$r,a.U())
+s=a instanceof A.Y?A.f9(a):null
 if(s!=null)return s
-if(t.w.b(a))return J.fp(a).a
-if(Array.isArray(a))return A.ax(a)
+if(t.w.b(a))return J.fr(a).a
+if(Array.isArray(a))return A.ay(a)
 return A.aE(a)},
-ae(a){var s=a.r
-return s==null?a.r=new A.db(a):s},
-ic(a,b){var s,r,q=b,p=q.length
+af(a){var s=a.r
+return s==null?a.r=new A.dc(a):s},
+ih(a,b){var s,r,q=b,p=q.length
 if(p===0)return t.r
 if(0>=p)return A.y(q,0)
-s=A.bt(v.typeUniverse,A.e4(q[0]),"@<0>")
+s=A.bw(v.typeUniverse,A.e6(q[0]),"@<0>")
 for(r=1;r<p;++r){if(!(r<q.length))return A.y(q,r)
-s=A.eP(v.typeUniverse,s,A.e4(q[r]))}return A.bt(v.typeUniverse,s,a)},
-L(a){return A.ae(A.dc(v.typeUniverse,a,!1))},
-hD(a){var s=this
-s.b=A.hZ(s)
+s=A.eS(v.typeUniverse,s,A.e6(q[r]))}return A.bw(v.typeUniverse,s,a)},
+L(a){return A.af(A.dd(v.typeUniverse,a,!1))},
+hH(a){var s=this
+s.b=A.i2(s)
 return s.b(a)},
-hZ(a){var s,r,q,p,o
-if(a===t.K)return A.hN
-if(A.ah(a))return A.hR
+i2(a){var s,r,q,p,o
+if(a===t.K)return A.hR
+if(A.ai(a))return A.hV
 s=a.w
-if(s===6)return A.hA
-if(s===1)return A.eW
-if(s===7)return A.hI
-r=A.hY(a)
+if(s===6)return A.hE
+if(s===1)return A.eZ
+if(s===7)return A.hM
+r=A.i1(a)
 if(r!=null)return r
 if(s===8){q=a.x
-if(a.y.every(A.ah)){a.f="$i"+q
-if(q==="i")return A.hL
-if(a===t.m)return A.hK
-return A.hQ}}else if(s===10){p=A.ib(a.x,a.y)
-o=p==null?A.eW:p
-return o==null?A.ay(o):o}return A.hy},
-hY(a){if(a.w===8){if(a===t.S)return A.e2
-if(a===t.i||a===t.o)return A.hM
-if(a===t.N)return A.hP
+if(a.y.every(A.ai)){a.f="$i"+q
+if(q==="i")return A.hP
+if(a===t.m)return A.hO
+return A.hU}}else if(s===10){p=A.ig(a.x,a.y)
+o=p==null?A.eZ:p
+return o==null?A.aa(o):o}return A.hC},
+i1(a){if(a.w===8){if(a===t.S)return A.e4
+if(a===t.i||a===t.o)return A.hQ
+if(a===t.N)return A.hT
 if(a===t.y)return A.dk}return null},
-hC(a){var s=this,r=A.hx
-if(A.ah(s))r=A.hs
-else if(s===t.K)r=A.ay
-else if(A.aF(s)){r=A.hz
-if(s===t.a3)r=A.hp
-else if(s===t.aD)r=A.cl
-else if(s===t.u)r=A.hm
-else if(s===t.ae)r=A.ck
-else if(s===t.I)r=A.ho
-else if(s===t.aQ)r=A.hq}else if(s===t.S)r=A.a1
+hG(a){var s=this,r=A.hB
+if(A.ai(s))r=A.hv
+else if(s===t.K)r=A.aa
+else if(A.aF(s)){r=A.hD
+if(s===t.a3)r=A.hs
+else if(s===t.aD)r=A.cn
+else if(s===t.u)r=A.hp
+else if(s===t.ae)r=A.cm
+else if(s===t.I)r=A.hr
+else if(s===t.aQ)r=A.ht}else if(s===t.S)r=A.a2
 else if(s===t.N)r=A.az
-else if(s===t.y)r=A.hl
-else if(s===t.o)r=A.hr
-else if(s===t.i)r=A.hn
-else if(s===t.m)r=A.de
+else if(s===t.y)r=A.ho
+else if(s===t.o)r=A.hu
+else if(s===t.i)r=A.hq
+else if(s===t.m)r=A.by
 s.a=r
 return s.a(a)},
-hy(a){var s=this
+hC(a){var s=this
 if(a==null)return A.aF(s)
-return A.ip(v.typeUniverse,A.io(a,s),s)},
-hA(a){if(a==null)return!0
+return A.it(v.typeUniverse,A.is(a,s),s)},
+hE(a){if(a==null)return!0
 return this.x.b(a)},
-hQ(a){var s,r=this
+hU(a){var s,r=this
 if(a==null)return A.aF(r)
 s=r.f
-if(a instanceof A.d)return!!a[s]
-return!!J.af(a)[s]},
-hL(a){var s,r=this
+if(a instanceof A.c)return!!a[s]
+return!!J.ag(a)[s]},
+hP(a){var s,r=this
 if(a==null)return A.aF(r)
 if(typeof a!="object")return!1
 if(Array.isArray(a))return!0
 s=r.f
-if(a instanceof A.d)return!!a[s]
-return!!J.af(a)[s]},
-hK(a){var s=this
+if(a instanceof A.c)return!!a[s]
+return!!J.ag(a)[s]},
+hO(a){var s=this
 if(a==null)return!1
-if(typeof a=="object"){if(a instanceof A.d)return!!a[s.f]
+if(typeof a=="object"){if(a instanceof A.c)return!!a[s.f]
 return!0}if(typeof a=="function")return!0
 return!1},
-eV(a){if(typeof a=="object"){if(a instanceof A.d)return t.m.b(a)
+eY(a){if(typeof a=="object"){if(a instanceof A.c)return t.m.b(a)
 return!0}if(typeof a=="function")return!0
 return!1},
-hx(a){var s=this
+hB(a){var s=this
 if(a==null){if(A.aF(s))return a}else if(s.b(a))return a
-throw A.w(A.eS(a,s),new Error())},
-hz(a){var s=this
+throw A.w(A.eV(a,s),new Error())},
+hD(a){var s=this
 if(a==null||s.b(a))return a
-throw A.w(A.eS(a,s),new Error())},
-eS(a,b){return new A.bp("TypeError: "+A.eD(a,A.F(b,null)))},
-eD(a,b){return A.cr(a)+": type '"+A.F(A.e4(a),null)+"' is not a subtype of type '"+b+"'"},
-I(a,b){return new A.bp("TypeError: "+A.eD(a,b))},
-hI(a){var s=this
-return s.x.b(a)||A.dS(v.typeUniverse,s).b(a)},
-hN(a){return a!=null},
-ay(a){if(a!=null)return a
+throw A.w(A.eV(a,s),new Error())},
+eV(a,b){return new A.bs("TypeError: "+A.eG(a,A.F(b,null)))},
+eG(a,b){return A.cs(a)+": type '"+A.F(A.e6(a),null)+"' is not a subtype of type '"+b+"'"},
+I(a,b){return new A.bs("TypeError: "+A.eG(a,b))},
+hM(a){var s=this
+return s.x.b(a)||A.dU(v.typeUniverse,s).b(a)},
+hR(a){return a!=null},
+aa(a){if(a!=null)return a
 throw A.w(A.I(a,"Object"),new Error())},
-hR(a){return!0},
-hs(a){return a},
-eW(a){return!1},
+hV(a){return!0},
+hv(a){return a},
+eZ(a){return!1},
 dk(a){return!0===a||!1===a},
-hl(a){if(!0===a)return!0
+ho(a){if(!0===a)return!0
 if(!1===a)return!1
 throw A.w(A.I(a,"bool"),new Error())},
-hm(a){if(!0===a)return!0
+hp(a){if(!0===a)return!0
 if(!1===a)return!1
 if(a==null)return a
 throw A.w(A.I(a,"bool?"),new Error())},
-hn(a){if(typeof a=="number")return a
+hq(a){if(typeof a=="number")return a
 throw A.w(A.I(a,"double"),new Error())},
-ho(a){if(typeof a=="number")return a
+hr(a){if(typeof a=="number")return a
 if(a==null)return a
 throw A.w(A.I(a,"double?"),new Error())},
-e2(a){return typeof a=="number"&&Math.floor(a)===a},
-a1(a){if(typeof a=="number"&&Math.floor(a)===a)return a
+e4(a){return typeof a=="number"&&Math.floor(a)===a},
+a2(a){if(typeof a=="number"&&Math.floor(a)===a)return a
 throw A.w(A.I(a,"int"),new Error())},
-hp(a){if(typeof a=="number"&&Math.floor(a)===a)return a
+hs(a){if(typeof a=="number"&&Math.floor(a)===a)return a
 if(a==null)return a
 throw A.w(A.I(a,"int?"),new Error())},
-hM(a){return typeof a=="number"},
-hr(a){if(typeof a=="number")return a
+hQ(a){return typeof a=="number"},
+hu(a){if(typeof a=="number")return a
 throw A.w(A.I(a,"num"),new Error())},
-ck(a){if(typeof a=="number")return a
+cm(a){if(typeof a=="number")return a
 if(a==null)return a
 throw A.w(A.I(a,"num?"),new Error())},
-hP(a){return typeof a=="string"},
+hT(a){return typeof a=="string"},
 az(a){if(typeof a=="string")return a
 throw A.w(A.I(a,"String"),new Error())},
-cl(a){if(typeof a=="string")return a
+cn(a){if(typeof a=="string")return a
 if(a==null)return a
 throw A.w(A.I(a,"String?"),new Error())},
-de(a){if(A.eV(a))return a
+by(a){if(A.eY(a))return a
 throw A.w(A.I(a,"JSObject"),new Error())},
-hq(a){if(a==null)return a
-if(A.eV(a))return a
+ht(a){if(a==null)return a
+if(A.eY(a))return a
 throw A.w(A.I(a,"JSObject?"),new Error())},
-f1(a,b){var s,r,q
+f5(a,b){var s,r,q
 for(s="",r="",q=0;q<a.length;++q,r=", ")s+=r+A.F(a[q],b)
 return s},
-hU(a,b){var s,r,q,p,o,n,m=a.x,l=a.y
-if(""===m)return"("+A.f1(l,b)+")"
+hZ(a,b){var s,r,q,p,o,n,m=a.x,l=a.y
+if(""===m)return"("+A.f5(l,b)+")"
 s=l.length
 r=m.split(",")
 q=r.length-s
@@ -844,7 +844,7 @@ for(p="(",o="",n=0;n<s;++n,o=", "){p+=o
 if(q===0)p+="{"
 p+=A.F(l[n],b)
 if(q>=0)p+=" "+r[q];++q}return p+"})"},
-eT(a3,a4,a5){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d,c,b,a,a0,a1=", ",a2=null
+eW(a3,a4,a5){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d,c,b,a,a0,a1=", ",a2=null
 if(a5!=null){s=a5.length
 if(a4==null)a4=A.K([],t.s)
 else a2=a4.length
@@ -884,111 +884,111 @@ if(l===6){s=a.x
 r=A.F(s,b)
 q=s.w
 return(q===11||q===12?"("+r+")":r)+"?"}if(l===7)return"FutureOr<"+A.F(a.x,b)+">"
-if(l===8){p=A.i2(a.x)
+if(l===8){p=A.i6(a.x)
 o=a.y
-return o.length>0?p+("<"+A.f1(o,b)+">"):p}if(l===10)return A.hU(a,b)
-if(l===11)return A.eT(a,b,null)
-if(l===12)return A.eT(a.x,b,a.y)
+return o.length>0?p+("<"+A.f5(o,b)+">"):p}if(l===10)return A.hZ(a,b)
+if(l===11)return A.eW(a,b,null)
+if(l===12)return A.eW(a.x,b,a.y)
 if(l===13){n=a.x
 m=b.length
 n=m-1-n
 if(!(n>=0&&n<m))return A.y(b,n)
 return b[n]}return"?"},
-i2(a){var s=v.mangledGlobalNames[a]
+i6(a){var s=v.mangledGlobalNames[a]
 if(s!=null)return s
 return"minified:"+a},
-hk(a,b){var s=a.tR[b]
+hn(a,b){var s=a.tR[b]
 while(typeof s=="string")s=a.tR[s]
 return s},
-hj(a,b){var s,r,q,p,o,n=a.eT,m=n[b]
-if(m==null)return A.dc(a,b,!1)
+hm(a,b){var s,r,q,p,o,n=a.eT,m=n[b]
+if(m==null)return A.dd(a,b,!1)
 else if(typeof m=="number"){s=m
-r=A.bs(a,5,"#")
-q=A.dd(s)
+r=A.bv(a,5,"#")
+q=A.de(s)
 for(p=0;p<s;++p)q[p]=r
-o=A.br(a,b,q)
+o=A.bu(a,b,q)
 n[b]=o
 return o}else return m},
-hi(a,b){return A.eQ(a.tR,b)},
-hh(a,b){return A.eQ(a.eT,b)},
-dc(a,b,c){var s,r=a.eC,q=r.get(b)
+hl(a,b){return A.eT(a.tR,b)},
+hk(a,b){return A.eT(a.eT,b)},
+dd(a,b,c){var s,r=a.eC,q=r.get(b)
 if(q!=null)return q
-s=A.eI(A.eG(a,null,b,!1))
+s=A.eL(A.eJ(a,null,b,!1))
 r.set(b,s)
 return s},
-bt(a,b,c){var s,r,q=b.z
+bw(a,b,c){var s,r,q=b.z
 if(q==null)q=b.z=new Map()
 s=q.get(c)
 if(s!=null)return s
-r=A.eI(A.eG(a,b,c,!0))
+r=A.eL(A.eJ(a,b,c,!0))
 q.set(c,r)
 return r},
-eP(a,b,c){var s,r,q,p=b.Q
+eS(a,b,c){var s,r,q,p=b.Q
 if(p==null)p=b.Q=new Map()
 s=c.as
 r=p.get(s)
 if(r!=null)return r
-q=A.dY(a,b,c.w===9?c.y:[c])
+q=A.e_(a,b,c.w===9?c.y:[c])
 p.set(s,q)
 return q},
-a0(a,b){b.a=A.hC
-b.b=A.hD
+a1(a,b){b.a=A.hG
+b.b=A.hH
 return b},
-bs(a,b,c){var s,r,q=a.eC.get(c)
+bv(a,b,c){var s,r,q=a.eC.get(c)
 if(q!=null)return q
 s=new A.J(null,null)
 s.w=b
 s.as=c
-r=A.a0(a,s)
+r=A.a1(a,s)
 a.eC.set(c,r)
 return r},
-eN(a,b,c){var s,r=b.as+"?",q=a.eC.get(r)
+eQ(a,b,c){var s,r=b.as+"?",q=a.eC.get(r)
 if(q!=null)return q
-s=A.hf(a,b,r,c)
+s=A.hi(a,b,r,c)
 a.eC.set(r,s)
 return s},
-hf(a,b,c,d){var s,r,q
+hi(a,b,c,d){var s,r,q
 if(d){s=b.w
 r=!0
-if(!A.ah(b))if(!(b===t.P||b===t.T))if(s!==6)r=s===7&&A.aF(b.x)
+if(!A.ai(b))if(!(b===t.P||b===t.T))if(s!==6)r=s===7&&A.aF(b.x)
 if(r)return b
 else if(s===1)return t.P}q=new A.J(null,null)
 q.w=6
 q.x=b
 q.as=c
-return A.a0(a,q)},
-eM(a,b,c){var s,r=b.as+"/",q=a.eC.get(r)
+return A.a1(a,q)},
+eP(a,b,c){var s,r=b.as+"/",q=a.eC.get(r)
 if(q!=null)return q
-s=A.hd(a,b,r,c)
+s=A.hg(a,b,r,c)
 a.eC.set(r,s)
 return s},
-hd(a,b,c,d){var s,r
+hg(a,b,c,d){var s,r
 if(d){s=b.w
-if(A.ah(b)||b===t.K)return b
-else if(s===1)return A.br(a,"M",[b])
+if(A.ai(b)||b===t.K)return b
+else if(s===1)return A.bu(a,"M",[b])
 else if(b===t.P||b===t.T)return t.bc}r=new A.J(null,null)
 r.w=7
 r.x=b
 r.as=c
-return A.a0(a,r)},
-hg(a,b){var s,r,q=""+b+"^",p=a.eC.get(q)
+return A.a1(a,r)},
+hj(a,b){var s,r,q=""+b+"^",p=a.eC.get(q)
 if(p!=null)return p
 s=new A.J(null,null)
 s.w=13
 s.x=b
 s.as=q
-r=A.a0(a,s)
+r=A.a1(a,s)
 a.eC.set(q,r)
 return r},
-bq(a){var s,r,q,p=a.length
+bt(a){var s,r,q,p=a.length
 for(s="",r="",q=0;q<p;++q,r=",")s+=r+a[q].as
 return s},
-hc(a){var s,r,q,p,o,n=a.length
+hf(a){var s,r,q,p,o,n=a.length
 for(s="",r="",q=0;q<n;q+=3,r=","){p=a[q]
 o=a[q+1]?"!":":"
 s+=r+p+o+a[q+2].as}return s},
-br(a,b,c){var s,r,q,p=b
-if(c.length>0)p+="<"+A.bq(c)+">"
+bu(a,b,c){var s,r,q,p=b
+if(c.length>0)p+="<"+A.bt(c)+">"
 s=a.eC.get(p)
 if(s!=null)return s
 r=new A.J(null,null)
@@ -997,13 +997,13 @@ r.x=b
 r.y=c
 if(c.length>0)r.c=c[0]
 r.as=p
-q=A.a0(a,r)
+q=A.a1(a,r)
 a.eC.set(p,q)
 return q},
-dY(a,b,c){var s,r,q,p,o,n
+e_(a,b,c){var s,r,q,p,o,n
 if(b.w===9){s=b.x
 r=b.y.concat(c)}else{r=c
-s=b}q=s.as+(";<"+A.bq(r)+">")
+s=b}q=s.as+(";<"+A.bt(r)+">")
 p=a.eC.get(q)
 if(p!=null)return p
 o=new A.J(null,null)
@@ -1011,23 +1011,23 @@ o.w=9
 o.x=s
 o.y=r
 o.as=q
-n=A.a0(a,o)
+n=A.a1(a,o)
 a.eC.set(q,n)
 return n},
-eO(a,b,c){var s,r,q="+"+(b+"("+A.bq(c)+")"),p=a.eC.get(q)
+eR(a,b,c){var s,r,q="+"+(b+"("+A.bt(c)+")"),p=a.eC.get(q)
 if(p!=null)return p
 s=new A.J(null,null)
 s.w=10
 s.x=b
 s.y=c
 s.as=q
-r=A.a0(a,s)
+r=A.a1(a,s)
 a.eC.set(q,r)
 return r},
-eL(a,b,c){var s,r,q,p,o,n=b.as,m=c.a,l=m.length,k=c.b,j=k.length,i=c.c,h=i.length,g="("+A.bq(m)
+eO(a,b,c){var s,r,q,p,o,n=b.as,m=c.a,l=m.length,k=c.b,j=k.length,i=c.c,h=i.length,g="("+A.bt(m)
 if(j>0){s=l>0?",":""
-g+=s+"["+A.bq(k)+"]"}if(h>0){s=l>0?",":""
-g+=s+"{"+A.hc(i)+"}"}r=n+(g+")")
+g+=s+"["+A.bt(k)+"]"}if(h>0){s=l>0?",":""
+g+=s+"{"+A.hf(i)+"}"}r=n+(g+")")
 q=a.eC.get(r)
 if(q!=null)return q
 p=new A.J(null,null)
@@ -1035,32 +1035,32 @@ p.w=11
 p.x=b
 p.y=c
 p.as=r
-o=A.a0(a,p)
+o=A.a1(a,p)
 a.eC.set(r,o)
 return o},
-dZ(a,b,c,d){var s,r=b.as+("<"+A.bq(c)+">"),q=a.eC.get(r)
+e0(a,b,c,d){var s,r=b.as+("<"+A.bt(c)+">"),q=a.eC.get(r)
 if(q!=null)return q
-s=A.he(a,b,c,r,d)
+s=A.hh(a,b,c,r,d)
 a.eC.set(r,s)
 return s},
-he(a,b,c,d,e){var s,r,q,p,o,n,m,l
+hh(a,b,c,d,e){var s,r,q,p,o,n,m,l
 if(e){s=c.length
-r=A.dd(s)
+r=A.de(s)
 for(q=0,p=0;p<s;++p){o=c[p]
-if(o.w===1){r[p]=o;++q}}if(q>0){n=A.ac(a,b,r,0)
+if(o.w===1){r[p]=o;++q}}if(q>0){n=A.ad(a,b,r,0)
 m=A.aB(a,c,r,0)
-return A.dZ(a,n,m,c!==m)}}l=new A.J(null,null)
+return A.e0(a,n,m,c!==m)}}l=new A.J(null,null)
 l.w=12
 l.x=b
 l.y=c
 l.as=d
-return A.a0(a,l)},
-eG(a,b,c,d){return{u:a,e:b,r:c,s:[],p:0,n:d}},
-eI(a){var s,r,q,p,o,n,m,l=a.r,k=a.s
+return A.a1(a,l)},
+eJ(a,b,c,d){return{u:a,e:b,r:c,s:[],p:0,n:d}},
+eL(a){var s,r,q,p,o,n,m,l=a.r,k=a.s
 for(s=l.length,r=0;r<s;){q=l.charCodeAt(r)
-if(q>=48&&q<=57)r=A.h5(r+1,q,l,k)
-else if((((q|32)>>>0)-97&65535)<26||q===95||q===36||q===124)r=A.eH(a,r,l,k,!1)
-else if(q===46)r=A.eH(a,r,l,k,!0)
+if(q>=48&&q<=57)r=A.h8(r+1,q,l,k)
+else if((((q|32)>>>0)-97&65535)<26||q===95||q===36||q===124)r=A.eK(a,r,l,k,!1)
+else if(q===46)r=A.eK(a,r,l,k,!0)
 else{++r
 switch(q){case 44:break
 case 58:k.push(!1)
@@ -1069,38 +1069,38 @@ case 33:k.push(!0)
 break
 case 59:k.push(A.a9(a.u,a.e,k.pop()))
 break
-case 94:k.push(A.hg(a.u,k.pop()))
+case 94:k.push(A.hj(a.u,k.pop()))
 break
-case 35:k.push(A.bs(a.u,5,"#"))
+case 35:k.push(A.bv(a.u,5,"#"))
 break
-case 64:k.push(A.bs(a.u,2,"@"))
+case 64:k.push(A.bv(a.u,2,"@"))
 break
-case 126:k.push(A.bs(a.u,3,"~"))
+case 126:k.push(A.bv(a.u,3,"~"))
 break
 case 60:k.push(a.p)
 a.p=k.length
 break
-case 62:A.h7(a,k)
+case 62:A.ha(a,k)
 break
-case 38:A.h6(a,k)
+case 38:A.h9(a,k)
 break
 case 63:p=a.u
-k.push(A.eN(p,A.a9(p,a.e,k.pop()),a.n))
+k.push(A.eQ(p,A.a9(p,a.e,k.pop()),a.n))
 break
 case 47:p=a.u
-k.push(A.eM(p,A.a9(p,a.e,k.pop()),a.n))
+k.push(A.eP(p,A.a9(p,a.e,k.pop()),a.n))
 break
 case 40:k.push(-3)
 k.push(a.p)
 a.p=k.length
 break
-case 41:A.h4(a,k)
+case 41:A.h7(a,k)
 break
 case 91:k.push(a.p)
 a.p=k.length
 break
 case 93:o=k.splice(a.p)
-A.eJ(a.u,a.e,o)
+A.eM(a.u,a.e,o)
 a.p=k.pop()
 k.push(o)
 k.push(-1)
@@ -1109,7 +1109,7 @@ case 123:k.push(a.p)
 a.p=k.length
 break
 case 125:o=k.splice(a.p)
-A.h9(a.u,a.e,o)
+A.hc(a.u,a.e,o)
 a.p=k.pop()
 k.push(o)
 k.push(-2)
@@ -1123,12 +1123,12 @@ r=n+1
 break
 default:throw"Bad character "+q}}}m=k.pop()
 return A.a9(a.u,a.e,m)},
-h5(a,b,c,d){var s,r,q=b-48
+h8(a,b,c,d){var s,r,q=b-48
 for(s=c.length;a<s;++a){r=c.charCodeAt(a)
 if(!(r>=48&&r<=57))break
 q=q*10+(r-48)}d.push(q)
 return a},
-eH(a,b,c,d,e){var s,r,q,p,o,n,m=b+1
+eK(a,b,c,d,e){var s,r,q,p,o,n,m=b+1
 for(s=c.length;m<s;++m){r=c.charCodeAt(m)
 if(r===46){if(e)break
 e=!0}else{if(!((((r|32)>>>0)-97&65535)<26||r===95||r===36||r===124))q=r>=48&&r<=57
@@ -1137,55 +1137,55 @@ if(!q)break}}p=c.substring(b,m)
 if(e){s=a.u
 o=a.e
 if(o.w===9)o=o.x
-n=A.hk(s,o.x)[p]
-if(n==null)A.co('No "'+p+'" in "'+A.fR(o)+'"')
-d.push(A.bt(s,o,n))}else d.push(p)
+n=A.hn(s,o.x)[p]
+if(n==null)A.cp('No "'+p+'" in "'+A.fU(o)+'"')
+d.push(A.bw(s,o,n))}else d.push(p)
 return m},
-h7(a,b){var s,r=a.u,q=A.eF(a,b),p=b.pop()
-if(typeof p=="string")b.push(A.br(r,p,q))
+ha(a,b){var s,r=a.u,q=A.eI(a,b),p=b.pop()
+if(typeof p=="string")b.push(A.bu(r,p,q))
 else{s=A.a9(r,a.e,p)
-switch(s.w){case 11:b.push(A.dZ(r,s,q,a.n))
+switch(s.w){case 11:b.push(A.e0(r,s,q,a.n))
 break
-default:b.push(A.dY(r,s,q))
+default:b.push(A.e_(r,s,q))
 break}}},
-h4(a,b){var s,r,q,p=a.u,o=b.pop(),n=null,m=null
+h7(a,b){var s,r,q,p=a.u,o=b.pop(),n=null,m=null
 if(typeof o=="number")switch(o){case-1:n=b.pop()
 break
 case-2:m=b.pop()
 break
 default:b.push(o)
 break}else b.push(o)
-s=A.eF(a,b)
+s=A.eI(a,b)
 o=b.pop()
 switch(o){case-3:o=b.pop()
 if(n==null)n=p.sEA
 if(m==null)m=p.sEA
 r=A.a9(p,a.e,o)
-q=new A.cg()
+q=new A.ci()
 q.a=s
 q.b=n
 q.c=m
-b.push(A.eL(p,r,q))
+b.push(A.eO(p,r,q))
 return
-case-4:b.push(A.eO(p,b.pop(),s))
+case-4:b.push(A.eR(p,b.pop(),s))
 return
-default:throw A.e(A.bA("Unexpected state under `()`: "+A.m(o)))}},
-h6(a,b){var s=b.pop()
-if(0===s){b.push(A.bs(a.u,1,"0&"))
-return}if(1===s){b.push(A.bs(a.u,4,"1&"))
-return}throw A.e(A.bA("Unexpected extended operation "+A.m(s)))},
-eF(a,b){var s=b.splice(a.p)
-A.eJ(a.u,a.e,s)
+default:throw A.e(A.bD("Unexpected state under `()`: "+A.n(o)))}},
+h9(a,b){var s=b.pop()
+if(0===s){b.push(A.bv(a.u,1,"0&"))
+return}if(1===s){b.push(A.bv(a.u,4,"1&"))
+return}throw A.e(A.bD("Unexpected extended operation "+A.n(s)))},
+eI(a,b){var s=b.splice(a.p)
+A.eM(a.u,a.e,s)
 a.p=b.pop()
 return s},
-a9(a,b,c){if(typeof c=="string")return A.br(a,c,a.sEA)
+a9(a,b,c){if(typeof c=="string")return A.bu(a,c,a.sEA)
 else if(typeof c=="number"){b.toString
-return A.h8(a,b,c)}else return c},
-eJ(a,b,c){var s,r=c.length
+return A.hb(a,b,c)}else return c},
+eM(a,b,c){var s,r=c.length
 for(s=0;s<r;++s)c[s]=A.a9(a,b,c[s])},
-h9(a,b,c){var s,r=c.length
+hc(a,b,c){var s,r=c.length
 for(s=2;s<r;s+=3)c[s]=A.a9(a,b,c[s])},
-h8(a,b,c){var s,r,q=b.w
+hb(a,b,c){var s,r,q=b.w
 if(q===9){if(c===0)return b.x
 s=b.y
 r=s.length
@@ -1193,32 +1193,32 @@ if(c<=r)return s[c-1]
 c-=r
 b=b.x
 q=b.w}else if(c===0)return b
-if(q!==8)throw A.e(A.bA("Indexed base must be an interface type"))
+if(q!==8)throw A.e(A.bD("Indexed base must be an interface type"))
 s=b.y
 if(c<=s.length)return s[c-1]
-throw A.e(A.bA("Bad index "+c+" for "+b.i(0)))},
-ip(a,b,c){var s,r=b.d
+throw A.e(A.bD("Bad index "+c+" for "+b.i(0)))},
+it(a,b,c){var s,r=b.d
 if(r==null)r=b.d=new Map()
 s=r.get(c)
-if(s==null){s=A.t(a,b,null,c,null)
+if(s==null){s=A.u(a,b,null,c,null)
 r.set(c,s)}return s},
-t(a,b,c,d,e){var s,r,q,p,o,n,m,l,k,j,i
+u(a,b,c,d,e){var s,r,q,p,o,n,m,l,k,j,i
 if(b===d)return!0
-if(A.ah(d))return!0
+if(A.ai(d))return!0
 s=b.w
 if(s===4)return!0
-if(A.ah(b))return!1
+if(A.ai(b))return!1
 if(b.w===1)return!0
 r=s===13
-if(r)if(A.t(a,c[b.x],c,d,e))return!0
+if(r)if(A.u(a,c[b.x],c,d,e))return!0
 q=d.w
 p=t.P
-if(b===p||b===t.T){if(q===7)return A.t(a,b,c,d.x,e)
-return d===p||d===t.T||q===6}if(d===t.K){if(s===7)return A.t(a,b.x,c,d,e)
-return s!==6}if(s===7){if(!A.t(a,b.x,c,d,e))return!1
-return A.t(a,A.dS(a,b),c,d,e)}if(s===6)return A.t(a,p,c,d,e)&&A.t(a,b.x,c,d,e)
-if(q===7){if(A.t(a,b,c,d.x,e))return!0
-return A.t(a,b,c,A.dS(a,d),e)}if(q===6)return A.t(a,b,c,p,e)||A.t(a,b,c,d.x,e)
+if(b===p||b===t.T){if(q===7)return A.u(a,b,c,d.x,e)
+return d===p||d===t.T||q===6}if(d===t.K){if(s===7)return A.u(a,b.x,c,d,e)
+return s!==6}if(s===7){if(!A.u(a,b.x,c,d,e))return!1
+return A.u(a,A.dU(a,b),c,d,e)}if(s===6)return A.u(a,p,c,d,e)&&A.u(a,b.x,c,d,e)
+if(q===7){if(A.u(a,b,c,d.x,e))return!0
+return A.u(a,b,c,A.dU(a,d),e)}if(q===6)return A.u(a,b,c,p,e)||A.u(a,b,c,d.x,e)
 if(r)return!1
 p=s!==11
 if((!p||s===12)&&d===t.Z)return!0
@@ -1234,13 +1234,13 @@ c=c==null?n:n.concat(c)
 e=e==null?m:m.concat(e)
 for(k=0;k<l;++k){j=n[k]
 i=m[k]
-if(!A.t(a,j,c,i,e)||!A.t(a,i,e,j,c))return!1}return A.eU(a,b.x,c,d.x,e)}if(q===11){if(b===t.g)return!0
+if(!A.u(a,j,c,i,e)||!A.u(a,i,e,j,c))return!1}return A.eX(a,b.x,c,d.x,e)}if(q===11){if(b===t.g)return!0
 if(p)return!1
-return A.eU(a,b,c,d,e)}if(s===8){if(q!==8)return!1
-return A.hJ(a,b,c,d,e)}if(o&&q===10)return A.hO(a,b,c,d,e)
+return A.eX(a,b,c,d,e)}if(s===8){if(q!==8)return!1
+return A.hN(a,b,c,d,e)}if(o&&q===10)return A.hS(a,b,c,d,e)
 return!1},
-eU(a3,a4,a5,a6,a7){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d,c,b,a,a0,a1,a2
-if(!A.t(a3,a4.x,a5,a6.x,a7))return!1
+eX(a3,a4,a5,a6,a7){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d,c,b,a,a0,a1,a2
+if(!A.u(a3,a4.x,a5,a6.x,a7))return!1
 s=a4.y
 r=a6.y
 q=s.a
@@ -1255,9 +1255,9 @@ j=l.length
 i=k.length
 if(o+j<n+i)return!1
 for(h=0;h<o;++h){g=q[h]
-if(!A.t(a3,p[h],a7,g,a5))return!1}for(h=0;h<m;++h){g=l[h]
-if(!A.t(a3,p[o+h],a7,g,a5))return!1}for(h=0;h<i;++h){g=l[m+h]
-if(!A.t(a3,k[h],a7,g,a5))return!1}f=s.c
+if(!A.u(a3,p[h],a7,g,a5))return!1}for(h=0;h<m;++h){g=l[h]
+if(!A.u(a3,p[o+h],a7,g,a5))return!1}for(h=0;h<i;++h){g=l[m+h]
+if(!A.u(a3,k[h],a7,g,a5))return!1}f=s.c
 e=r.c
 d=f.length
 c=e.length
@@ -1271,10 +1271,10 @@ if(a1<a0){if(a2)return!1
 continue}g=e[a+1]
 if(a2&&!g)return!1
 g=f[b-1]
-if(!A.t(a3,e[a+2],a7,g,a5))return!1
+if(!A.u(a3,e[a+2],a7,g,a5))return!1
 break}}while(b<d){if(f[b+1])return!1
 b+=3}return!0},
-hJ(a,b,c,d,e){var s,r,q,p,o,n=b.x,m=d.x
+hN(a,b,c,d,e){var s,r,q,p,o,n=b.x,m=d.x
 while(n!==m){s=a.tR[n]
 if(s==null)return!1
 if(typeof s=="string"){n=s
@@ -1282,89 +1282,89 @@ continue}r=s[m]
 if(r==null)return!1
 q=r.length
 p=q>0?new Array(q):v.typeUniverse.sEA
-for(o=0;o<q;++o)p[o]=A.bt(a,b,r[o])
-return A.eR(a,p,null,c,d.y,e)}return A.eR(a,b.y,null,c,d.y,e)},
-eR(a,b,c,d,e,f){var s,r=b.length
-for(s=0;s<r;++s)if(!A.t(a,b[s],d,e[s],f))return!1
+for(o=0;o<q;++o)p[o]=A.bw(a,b,r[o])
+return A.eU(a,p,null,c,d.y,e)}return A.eU(a,b.y,null,c,d.y,e)},
+eU(a,b,c,d,e,f){var s,r=b.length
+for(s=0;s<r;++s)if(!A.u(a,b[s],d,e[s],f))return!1
 return!0},
-hO(a,b,c,d,e){var s,r=b.y,q=d.y,p=r.length
+hS(a,b,c,d,e){var s,r=b.y,q=d.y,p=r.length
 if(p!==q.length)return!1
 if(b.x!==d.x)return!1
-for(s=0;s<p;++s)if(!A.t(a,r[s],c,q[s],e))return!1
+for(s=0;s<p;++s)if(!A.u(a,r[s],c,q[s],e))return!1
 return!0},
 aF(a){var s=a.w,r=!0
-if(!(a===t.P||a===t.T))if(!A.ah(a))if(s!==6)r=s===7&&A.aF(a.x)
+if(!(a===t.P||a===t.T))if(!A.ai(a))if(s!==6)r=s===7&&A.aF(a.x)
 return r},
-ah(a){var s=a.w
+ai(a){var s=a.w
 return s===2||s===3||s===4||s===5||a===t.X},
-eQ(a,b){var s,r,q=Object.keys(b),p=q.length
+eT(a,b){var s,r,q=Object.keys(b),p=q.length
 for(s=0;s<p;++s){r=q[s]
 a[r]=b[r]}},
-dd(a){return a>0?new Array(a):v.typeUniverse.sEA},
+de(a){return a>0?new Array(a):v.typeUniverse.sEA},
 J:function J(a,b){var _=this
 _.a=a
 _.b=b
 _.r=_.f=_.d=_.c=null
 _.w=0
 _.as=_.Q=_.z=_.y=_.x=null},
-cg:function cg(){this.c=this.b=this.a=null},
-db:function db(a){this.a=a},
-cf:function cf(){},
-bp:function bp(a){this.a=a},
-h0(){var s,r,q
-if(self.scheduleImmediate!=null)return A.i4()
+ci:function ci(){this.c=this.b=this.a=null},
+dc:function dc(a){this.a=a},
+ch:function ch(){},
+bs:function bs(a){this.a=a},
+h3(){var s,r,q
+if(self.scheduleImmediate!=null)return A.i8()
 if(self.MutationObserver!=null&&self.document!=null){s={}
 r=self.document.createElement("div")
 q=self.document.createElement("span")
 s.a=null
-new self.MutationObserver(A.aD(new A.cS(s),1)).observe(r,{childList:true})
-return new A.cR(s,r,q)}else if(self.setImmediate!=null)return A.i5()
-return A.i6()},
-h1(a){self.scheduleImmediate(A.aD(new A.cT(t.M.a(a)),0))},
-h2(a){self.setImmediate(A.aD(new A.cU(t.M.a(a)),0))},
-h3(a){t.M.a(a)
-A.ha(0,a)},
-ey(a,b){return A.hb(a.a/1000|0,b)},
-ha(a,b){var s=new A.bo(!0)
-s.ap(a,b)
+new self.MutationObserver(A.aD(new A.cT(s),1)).observe(r,{childList:true})
+return new A.cS(s,r,q)}else if(self.setImmediate!=null)return A.i9()
+return A.ia()},
+h4(a){self.scheduleImmediate(A.aD(new A.cU(t.M.a(a)),0))},
+h5(a){self.setImmediate(A.aD(new A.cV(t.M.a(a)),0))},
+h6(a){t.M.a(a)
+A.hd(0,a)},
+eB(a,b){return A.he(a.a/1000|0,b)},
+hd(a,b){var s=new A.br(!0)
+s.ar(a,b)
 return s},
-hb(a,b){var s=new A.bo(!1)
-s.aq(a,b)
+he(a,b){var s=new A.br(!1)
+s.au(a,b)
 return s},
-dl(a){return new A.cc(new A.v($.n,a.h("v<0>")),a.h("cc<0>"))},
+dl(a){return new A.ce(new A.r($.m,a.h("r<0>")),a.h("ce<0>"))},
 dh(a,b){a.$2(0,null)
 b.b=!0
 return b.a},
-e_(a,b){A.ht(a,b)},
+e1(a,b){A.hw(a,b)},
 dg(a,b){b.a_(a)},
-df(a,b){b.a0(A.aj(a),A.ag(a))},
-ht(a,b){var s,r,q=new A.di(b),p=new A.dj(b)
-if(a instanceof A.v)a.af(q,p,t.z)
+df(a,b){b.a0(A.ak(a),A.ah(a))},
+hw(a,b){var s,r,q=new A.di(b),p=new A.dj(b)
+if(a instanceof A.r)a.af(q,p,t.z)
 else{s=t.z
-if(a instanceof A.v)a.a3(q,p,s)
-else{r=new A.v($.n,t._)
+if(a instanceof A.r)a.a3(q,p,s)
+else{r=new A.r($.m,t._)
 r.a=8
 r.c=a
 r.af(q,p,s)}}},
-dp(a){var s=function(b,c){return function(d,e){while(true){try{b(d,e)
+dq(a){var s=function(b,c){return function(d,e){while(true){try{b(d,e)
 break}catch(r){e=r
 d=c}}}}(a,1)
-return $.n.ak(new A.dq(s),t.H,t.S,t.z)},
-eK(a,b,c){return 0},
-dJ(a){var s
+return $.m.ak(new A.dr(s),t.H,t.S,t.z)},
+eN(a,b,c){return 0},
+dL(a){var s
 if(t.C.b(a)){s=a.gF()
 if(s!=null)return s}return B.e},
-hF(a,b){if($.n===B.b)return null
+hJ(a,b){if($.m===B.b)return null
 return null},
-hG(a,b){if($.n!==B.b)A.hF(a,b)
+hK(a,b){if($.m!==B.b)A.hJ(a,b)
 if(b==null)if(t.C.b(a)){b=a.gF()
-if(b==null){A.eu(a,B.e)
+if(b==null){A.ey(a,B.e)
 b=B.e}}else b=B.e
-else if(t.C.b(a))A.eu(a,b)
+else if(t.C.b(a))A.ey(a,b)
 return new A.H(a,b)},
-dV(a,b,c){var s,r,q,p,o={},n=o.a=a
+dX(a,b,c){var s,r,q,p,o={},n=o.a=a
 for(s=t._;r=n.a,(r&4)!==0;n=a){a=s.a(n.c)
-o.a=a}if(n===b){s=A.fS()
+o.a=a}if(n===b){s=A.fV()
 b.O(new A.H(new A.Q(!0,n,null,"Cannot complete a future with itself"),s))
 return}q=b.a&1
 s=n.a=r|q
@@ -1375,21 +1375,21 @@ n.ad(p)
 return}if(!c)if(b.c==null)n=(s&16)===0||q!==0
 else n=!1
 else n=!0
-if(n){p=b.H()
-b.G(o.a)
-A.as(b,p)
+if(n){p=b.I()
+b.H(o.a)
+A.at(b,p)
 return}b.a^=2
-A.cm(null,null,b.b,t.M.a(new A.cZ(o,b)))},
-as(a,b){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d={},c=d.a=a
+A.co(null,null,b.b,t.M.a(new A.d_(o,b)))},
+at(a,b){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d={},c=d.a=a
 for(s=t.n,r=t.F;;){q={}
 p=c.a
 o=(p&16)===0
 n=!o
 if(b==null){if(n&&(p&1)===0){m=s.a(c.c)
-A.dm(m.a,m.b)}return}q.a=b
+A.dn(m.a,m.b)}return}q.a=b
 l=b.a
 for(c=b;l!=null;c=l,l=k){c.a=null
-A.as(d.a,c)
+A.at(d.a,c)
 q.a=l
 k=l.a}p=d.a
 j=p.c
@@ -1401,29 +1401,29 @@ if(i){h=c.b.b
 if(n){p=p.b===h
 p=!(p||p)}else p=!1
 if(p){s.a(j)
-A.dm(j.a,j.b)
-return}g=$.n
-if(g!==h)$.n=h
+A.dn(j.a,j.b)
+return}g=$.m
+if(g!==h)$.m=h
 else g=null
 c=c.c
-if((c&15)===8)new A.d2(q,d,n).$0()
-else if(o){if((c&1)!==0)new A.d1(q,j).$0()}else if((c&2)!==0)new A.d0(d,q).$0()
-if(g!=null)$.n=g
+if((c&15)===8)new A.d3(q,d,n).$0()
+else if(o){if((c&1)!==0)new A.d2(q,j).$0()}else if((c&2)!==0)new A.d1(d,q).$0()
+if(g!=null)$.m=g
 c=q.c
-if(c instanceof A.v){p=q.a.$ti
+if(c instanceof A.r){p=q.a.$ti
 p=p.h("M<2>").b(c)||!p.y[1].b(c)}else p=!1
 if(p){f=q.a.b
 if((c.a&24)!==0){e=r.a(f.c)
 f.c=null
-b=f.I(e)
+b=f.J(e)
 f.a=c.a&30|f.a&1
 f.c=c.c
 d.a=c
-continue}else A.dV(c,f,!0)
+continue}else A.dX(c,f,!0)
 return}}f=q.a.b
 e=r.a(f.c)
 f.c=null
-b=f.I(e)
+b=f.J(e)
 c=q.b
 p=q.c
 if(!c){f.$ti.c.a(p)
@@ -1432,107 +1432,109 @@ f.c=p}else{s.a(p)
 f.a=f.a&1|16
 f.c=p}d.a=f
 c=f}},
-hV(a,b){var s
+f2(a,b){var s
 if(t.Q.b(a))return b.ak(a,t.z,t.K,t.l)
 s=t.v
 if(s.b(a))return s.a(a)
-throw A.e(A.eh(a,"onError",u.c))},
-hT(){var s,r
-for(s=$.aA;s!=null;s=$.aA){$.bw=null
+throw A.e(A.el(a,"onError",u.c))},
+hX(){var s,r
+for(s=$.aA;s!=null;s=$.aA){$.bA=null
 r=s.b
 $.aA=r
-if(r==null)$.bv=null
+if(r==null)$.bz=null
 s.a.$0()}},
-i_(){$.e1=!0
-try{A.hT()}finally{$.bw=null
-$.e1=!1
-if($.aA!=null)$.ef().$1(A.f4())}},
-f2(a){var s=new A.cd(a),r=$.bv
-if(r==null){$.aA=$.bv=s
-if(!$.e1)$.ef().$1(A.f4())}else $.bv=r.b=s},
-hX(a){var s,r,q,p=$.aA
-if(p==null){A.f2(a)
-$.bw=$.bv
-return}s=new A.cd(a)
-r=$.bw
+i3(){$.e3=!0
+try{A.hX()}finally{$.bA=null
+$.e3=!1
+if($.aA!=null)$.ej().$1(A.f8())}},
+f6(a){var s=new A.cf(a),r=$.bz
+if(r==null){$.aA=$.bz=s
+if(!$.e3)$.ej().$1(A.f8())}else $.bz=r.b=s},
+i0(a){var s,r,q,p=$.aA
+if(p==null){A.f6(a)
+$.bA=$.bz
+return}s=new A.cf(a)
+r=$.bA
 if(r==null){s.b=p
-$.aA=$.bw=s}else{q=r.b
+$.aA=$.bA=s}else{q=r.b
 s.b=q
-$.bw=r.b=s
-if(q==null)$.bv=s}},
-iA(a,b){A.dr(a,"stream",t.K)
-return new A.ci(b.h("ci<0>"))},
-fT(a,b){var s=$.n
-if(s===B.b)return A.ey(a,t.d.a(b))
-return A.ey(a,t.d.a(s.aH(b,t.p)))},
-dm(a,b){A.hX(new A.dn(a,b))},
-f_(a,b,c,d,e){var s,r=$.n
+$.bA=r.b=s
+if(q==null)$.bz=s}},
+iE(a,b){A.ds(a,"stream",t.K)
+return new A.ck(b.h("ck<0>"))},
+fW(a,b){var s=$.m
+if(s===B.b)return A.eB(a,t.d.a(b))
+return A.eB(a,t.d.a(s.aJ(b,t.p)))},
+dn(a,b){A.i0(new A.dp(a,b))},
+f3(a,b,c,d,e){var s,r=$.m
 if(r===c)return d.$0()
-$.n=c
+$.m=c
 s=r
 try{r=d.$0()
-return r}finally{$.n=s}},
-f0(a,b,c,d,e,f,g){var s,r=$.n
+return r}finally{$.m=s}},
+f4(a,b,c,d,e,f,g){var s,r=$.m
 if(r===c)return d.$1(e)
-$.n=c
+$.m=c
 s=r
 try{r=d.$1(e)
-return r}finally{$.n=s}},
-hW(a,b,c,d,e,f,g,h,i){var s,r=$.n
+return r}finally{$.m=s}},
+i_(a,b,c,d,e,f,g,h,i){var s,r=$.m
 if(r===c)return d.$2(e,f)
-$.n=c
+$.m=c
 s=r
 try{r=d.$2(e,f)
-return r}finally{$.n=s}},
-cm(a,b,c,d){t.M.a(d)
-if(B.b!==c){d=c.aG(d)
-d=d}A.f2(d)},
-cS:function cS(a){this.a=a},
-cR:function cR(a,b,c){this.a=a
+return r}finally{$.m=s}},
+co(a,b,c,d){t.M.a(d)
+if(B.b!==c){d=c.aI(d)
+d=d}A.f6(d)},
+cT:function cT(a){this.a=a},
+cS:function cS(a,b,c){this.a=a
 this.b=b
 this.c=c},
-cT:function cT(a){this.a=a},
 cU:function cU(a){this.a=a},
-bo:function bo(a){this.a=a
+cV:function cV(a){this.a=a},
+br:function br(a){this.a=a
 this.b=null
 this.c=0},
-da:function da(a,b){this.a=a
+db:function db(a,b){this.a=a
 this.b=b},
-d9:function d9(a,b,c,d){var _=this
+da:function da(a,b,c,d){var _=this
 _.a=a
 _.b=b
 _.c=c
 _.d=d},
-cc:function cc(a,b){this.a=a
+ce:function ce(a,b){this.a=a
 this.b=!1
 this.$ti=b},
 di:function di(a){this.a=a},
 dj:function dj(a){this.a=a},
-dq:function dq(a){this.a=a},
-bn:function bn(a,b){var _=this
+dr:function dr(a){this.a=a},
+bq:function bq(a,b){var _=this
 _.a=a
 _.e=_.d=_.c=_.b=null
 _.$ti=b},
-aw:function aw(a,b){this.a=a
+ax:function ax(a,b){this.a=a
 this.$ti=b},
 H:function H(a,b){this.a=a
 this.b=b},
-ce:function ce(){},
-b9:function b9(a,b){this.a=a
+cg:function cg(){},
+bc:function bc(a,b){this.a=a
 this.$ti=b},
-a8:function a8(a,b,c,d,e){var _=this
+V:function V(a,b,c,d,e){var _=this
 _.a=null
 _.b=a
 _.c=b
 _.d=c
 _.e=d
 _.$ti=e},
-v:function v(a,b){var _=this
+r:function r(a,b){var _=this
 _.a=0
 _.b=a
 _.c=null
 _.$ti=b},
-cW:function cW(a,b){this.a=a
+cX:function cX(a,b){this.a=a
+this.b=b},
+d0:function d0(a,b){this.a=a
 this.b=b},
 d_:function d_(a,b){this.a=a
 this.b=b},
@@ -1540,59 +1542,57 @@ cZ:function cZ(a,b){this.a=a
 this.b=b},
 cY:function cY(a,b){this.a=a
 this.b=b},
-cX:function cX(a,b){this.a=a
-this.b=b},
-d2:function d2(a,b,c){this.a=a
+d3:function d3(a,b,c){this.a=a
 this.b=b
 this.c=c},
-d3:function d3(a,b){this.a=a
+d4:function d4(a,b){this.a=a
 this.b=b},
-d4:function d4(a){this.a=a},
+d5:function d5(a){this.a=a},
+d2:function d2(a,b){this.a=a
+this.b=b},
 d1:function d1(a,b){this.a=a
 this.b=b},
-d0:function d0(a,b){this.a=a
-this.b=b},
-cd:function cd(a){this.a=a
+cf:function cf(a){this.a=a
 this.b=null},
-ci:function ci(a){this.$ti=a},
-bu:function bu(){},
-dn:function dn(a,b){this.a=a
+ck:function ck(a){this.$ti=a},
+bx:function bx(){},
+dp:function dp(a,b){this.a=a
 this.b=b},
-ch:function ch(){},
-d7:function d7(a,b){this.a=a
+cj:function cj(){},
+d8:function d8(a,b){this.a=a
 this.b=b},
-d8:function d8(a,b,c){this.a=a
+d9:function d9(a,b,c){this.a=a
 this.b=b
 this.c=c},
-eE(a,b){var s=a[b]
+eH(a,b){var s=a[b]
 return s===a?null:s},
-dX(a,b,c){if(c==null)a[b]=a
+dZ(a,b,c){if(c==null)a[b]=a
 else a[b]=c},
-dW(){var s=Object.create(null)
-A.dX(s,"<non-identifier-key>",s)
+dY(){var s=Object.create(null)
+A.dZ(s,"<non-identifier-key>",s)
 delete s["<non-identifier-key>"]
 return s},
-C(a,b,c){return b.h("@<0>").k(c).h("eq<1,2>").a(A.id(a,new A.a6(b.h("@<0>").k(c).h("a6<1,2>"))))},
-dO(a,b){return new A.a6(a.h("@<0>").k(b).h("a6<1,2>"))},
-dP(a){var s,r
-if(A.ea(a))return"{...}"
-s=new A.c5("")
+B(a,b,c){return b.h("@<0>").k(c).h("eu<1,2>").a(A.ii(a,new A.a7(b.h("@<0>").k(c).h("a7<1,2>"))))},
+dQ(a,b){return new A.a7(a.h("@<0>").k(b).h("a7<1,2>"))},
+dR(a){var s,r
+if(A.ed(a))return"{...}"
+s=new A.c7("")
 try{r={}
 B.a.u($.G,a)
 s.a+="{"
 r.a=!0
-a.E(0,new A.cA(r,s))
+a.E(0,new A.cB(r,s))
 s.a+="}"}finally{if(0>=$.G.length)return A.y($.G,-1)
 $.G.pop()}r=s.a
 return r.charCodeAt(0)==0?r:r},
-bb:function bb(){},
-at:function at(a){var _=this
+be:function be(){},
+au:function au(a){var _=this
 _.a=0
 _.e=_.d=_.c=_.b=null
 _.$ti=a},
-bc:function bc(a,b){this.a=a
+bf:function bf(a,b){this.a=a
 this.$ti=b},
-bd:function bd(a,b,c){var _=this
+bg:function bg(a,b,c){var _=this
 _.a=a
 _.b=b
 _.c=0
@@ -1600,82 +1600,85 @@ _.d=null
 _.$ti=c},
 f:function f(){},
 k:function k(){},
-cz:function cz(a){this.a=a},
-cA:function cA(a,b){this.a=a
+cA:function cA(a){this.a=a},
+cB:function cB(a,b){this.a=a
 this.b=b},
-fz(a,b){a=A.w(a,new Error())
-if(a==null)a=A.ay(a)
+fB(a,b){a=A.w(a,new Error())
+if(a==null)a=A.aa(a)
 a.stack=b.i(0)
 throw a},
-fH(a,b,c,d){var s,r=c?J.fE(a,d):J.fD(a,d)
+fJ(a,b,c,d){var s,r=c?J.fG(a,d):J.fF(a,d)
 if(a!==0&&b!=null)for(s=0;s<r.length;++s)r[s]=b
 return r},
-fI(a,b,c){var s,r,q=A.K([],c.h("x<0>"))
-for(s=a.length,r=0;r<a.length;a.length===s||(0,A.fb)(a),++r)B.a.u(q,c.a(a[r]))
+fK(a,b,c){var s,r,q=A.K([],c.h("x<0>"))
+for(s=a.length,r=0;r<a.length;a.length===s||(0,A.fd)(a),++r)B.a.u(q,c.a(a[r]))
 q.$flags=1
 return q},
-fG(a,b){var s,r=A.K([],b.h("x<0>"))
+fI(a,b){var s,r=A.K([],b.h("x<0>"))
 for(s=a.gp(a);s.m();)B.a.u(r,s.gn())
 return r},
-ex(a,b,c){var s=J.dH(b)
+eA(a,b,c){var s=J.dJ(b)
 if(!s.m())return a
-if(c.length===0){do a+=A.m(s.gn())
-while(s.m())}else{a+=A.m(s.gn())
-while(s.m())a=a+c+A.m(s.gn())}return a},
-fS(){return A.ag(new Error())},
-fy(a){var s=Math.abs(a),r=a<0?"-":""
+if(c.length===0){do a+=A.n(s.gn())
+while(s.m())}else{a+=A.n(s.gn())
+while(s.m())a=a+c+A.n(s.gn())}return a},
+fV(){return A.ah(new Error())},
+fA(a){var s=Math.abs(a),r=a<0?"-":""
 if(s>=1000)return""+a
 if(s>=100)return r+"0"+s
 if(s>=10)return r+"00"+s
 return r+"000"+s},
-en(a){if(a>=100)return""+a
+er(a){if(a>=100)return""+a
 if(a>=10)return"0"+a
 return"00"+a},
-bF(a){if(a>=10)return""+a
+bI(a){if(a>=10)return""+a
 return"0"+a},
-cr(a){if(typeof a=="number"||A.dk(a)||a==null)return J.aH(a)
+cs(a){if(typeof a=="number"||A.dk(a)||a==null)return J.aI(a)
 if(typeof a=="string")return JSON.stringify(a)
-return A.et(a)},
-fA(a,b){A.dr(a,"error",t.K)
-A.dr(b,"stackTrace",t.l)
-A.fz(a,b)},
-bA(a){return new A.bz(a)},
-ak(a,b){return new A.Q(!1,null,b,a)},
-eh(a,b,c){return new A.Q(!0,a,b,c)},
-ev(a,b,c,d,e){return new A.b3(b,c,!0,a,d,"Invalid value")},
-fB(a,b,c,d){return new A.bH(b,!0,a,d,"Index out of range")},
-cK(a){return new A.b8(a)},
-eA(a){return new A.c8(a)},
-dT(a){return new A.c3(a)},
-am(a){return new A.bD(a)},
-fC(a,b,c){var s,r
-if(A.ea(a)){if(b==="("&&c===")")return"(...)"
+return A.ex(a)},
+fC(a,b){A.ds(a,"error",t.K)
+A.ds(b,"stackTrace",t.l)
+A.fB(a,b)},
+bD(a){return new A.bC(a)},
+al(a,b){return new A.Q(!1,null,b,a)},
+el(a,b,c){return new A.Q(!0,a,b,c)},
+c3(a,b,c,d,e){return new A.b6(b,c,!0,a,d,"Invalid value")},
+fT(a,b,c){if(0>a||a>c)throw A.e(A.c3(a,0,c,"start",null))
+if(b!=null){if(a>b||b>c)throw A.e(A.c3(b,a,c,"end",null))
+return b}return c},
+fD(a,b,c,d){return new A.bK(b,!0,a,d,"Index out of range")},
+cL(a){return new A.bb(a)},
+eD(a){return new A.ca(a)},
+dV(a){return new A.c5(a)},
+an(a){return new A.bG(a)},
+fE(a,b,c){var s,r
+if(A.ed(a)){if(b==="("&&c===")")return"(...)"
 return b+"..."+c}s=A.K([],t.s)
 B.a.u($.G,a)
-try{A.hS(a,s)}finally{if(0>=$.G.length)return A.y($.G,-1)
-$.G.pop()}r=A.ex(b,t.R.a(s),", ")+c
+try{A.hW(a,s)}finally{if(0>=$.G.length)return A.y($.G,-1)
+$.G.pop()}r=A.eA(b,t.R.a(s),", ")+c
 return r.charCodeAt(0)==0?r:r},
-eo(a,b,c){var s,r
-if(A.ea(a))return b+"..."+c
-s=new A.c5(b)
+es(a,b,c){var s,r
+if(A.ed(a))return b+"..."+c
+s=new A.c7(b)
 B.a.u($.G,a)
 try{r=s
-r.a=A.ex(r.a,a,", ")}finally{if(0>=$.G.length)return A.y($.G,-1)
+r.a=A.eA(r.a,a,", ")}finally{if(0>=$.G.length)return A.y($.G,-1)
 $.G.pop()}s.a+=c
 r=s.a
 return r.charCodeAt(0)==0?r:r},
-hS(a,b){var s,r,q,p,o,n,m,l=a.gp(a),k=0,j=0
+hW(a,b){var s,r,q,p,o,n,m,l=a.gp(a),k=0,j=0
 for(;;){if(!(k<80||j<3))break
 if(!l.m())return
-s=A.m(l.gn())
+s=A.n(l.gn())
 B.a.u(b,s)
 k+=s.length+2;++j}if(!l.m()){if(j<=5)return
 if(0>=b.length)return A.y(b,-1)
 r=b.pop()
 if(0>=b.length)return A.y(b,-1)
 q=b.pop()}else{p=l.gn();++j
-if(!l.m()){if(j<=4){B.a.u(b,A.m(p))
-return}r=A.m(p)
+if(!l.m()){if(j<=4){B.a.u(b,A.n(p))
+return}r=A.n(p)
 if(0>=b.length)return A.y(b,-1)
 q=b.pop()
 k+=r.length+2}else{o=l.gn();++j
@@ -1683,8 +1686,8 @@ for(;l.m();p=o,o=n){n=l.gn();++j
 if(j>100){for(;;){if(!(k>75&&j>3))break
 if(0>=b.length)return A.y(b,-1)
 k-=b.pop().length+2;--j}B.a.u(b,"...")
-return}}q=A.m(p)
-r=A.m(o)
+return}}q=A.n(p)
+r=A.n(o)
 k+=r.length+q.length+4}}if(j>b.length+2){k+=5
 m="..."}else m=null
 for(;;){if(!(k>80&&b.length>3))break
@@ -1694,213 +1697,232 @@ if(m==null){k+=5
 m="..."}}if(m!=null)B.a.u(b,m)
 B.a.u(b,q)
 B.a.u(b,r)},
-er(a,b,c,d,e){return new A.a4(a,b.h("@<0>").k(c).k(d).k(e).h("a4<1,2,3,4>"))},
-dR(a,b,c,d){var s
+ev(a,b,c,d,e){return new A.a5(a,b.h("@<0>").k(c).k(d).k(e).h("a5<1,2,3,4>"))},
+dT(a,b,c,d){var s
 if(B.d===c){s=B.c.gq(a)
-b=J.W(b)
-return A.dU(A.a_(A.a_($.dG(),s),b))}if(B.d===d){s=B.c.gq(a)
-b=J.W(b)
-c=J.W(c)
-return A.dU(A.a_(A.a_(A.a_($.dG(),s),b),c))}s=B.c.gq(a)
-b=J.W(b)
-c=J.W(c)
-d=J.W(d)
-d=A.dU(A.a_(A.a_(A.a_(A.a_($.dG(),s),b),c),d))
+b=J.X(b)
+return A.dW(A.a0(A.a0($.dI(),s),b))}if(B.d===d){s=B.c.gq(a)
+b=J.X(b)
+c=J.X(c)
+return A.dW(A.a0(A.a0(A.a0($.dI(),s),b),c))}s=B.c.gq(a)
+b=J.X(b)
+c=J.X(c)
+d=J.X(d)
+d=A.dW(A.a0(A.a0(A.a0(A.a0($.dI(),s),b),c),d))
 return d},
-bE:function bE(a,b,c){this.a=a
+bH:function bH(a,b,c){this.a=a
 this.b=b
 this.c=c},
-bG:function bG(a){this.a=a},
+bJ:function bJ(a){this.a=a},
 l:function l(){},
-bz:function bz(a){this.a=a},
+bC:function bC(a){this.a=a},
 T:function T(){},
 Q:function Q(a,b,c,d){var _=this
 _.a=a
 _.b=b
 _.c=c
 _.d=d},
-b3:function b3(a,b,c,d,e,f){var _=this
+b6:function b6(a,b,c,d,e,f){var _=this
 _.e=a
 _.f=b
 _.a=c
 _.b=d
 _.c=e
 _.d=f},
-bH:function bH(a,b,c,d,e){var _=this
+bK:function bK(a,b,c,d,e){var _=this
 _.f=a
 _.a=b
 _.b=c
 _.c=d
 _.d=e},
-b8:function b8(a){this.a=a},
-c8:function c8(a){this.a=a},
-c3:function c3(a){this.a=a},
-bD:function bD(a){this.a=a},
-bZ:function bZ(){},
-b5:function b5(){},
-cV:function cV(a){this.a=a},
+bb:function bb(a){this.a=a},
+ca:function ca(a){this.a=a},
+c5:function c5(a){this.a=a},
+bG:function bG(a){this.a=a},
+c_:function c_(){},
+b8:function b8(){},
+cW:function cW(a){this.a=a},
 b:function b(){},
-p:function p(a,b,c){this.a=a
+q:function q(a,b,c){this.a=a
 this.b=b
 this.$ti=c},
-q:function q(){},
-d:function d(){},
-cj:function cj(){},
-c5:function c5(a){this.a=a},
-cB:function cB(a){this.a=a},
-hu(a,b,c){t.Z.a(a)
-if(A.a1(c)>=1)return a.$1(b)
+p:function p(){},
+c:function c(){},
+cl:function cl(){},
+c7:function c7(a){this.a=a},
+cC:function cC(a){this.a=a},
+hx(a,b,c){t.Z.a(a)
+if(A.a2(c)>=1)return a.$1(b)
 return a.$0()},
-hv(a,b,c,d,e){t.Z.a(a)
-A.a1(e)
+hy(a,b,c,d,e){t.Z.a(a)
+A.a2(e)
 if(e>=3)return a.$3(b,c,d)
 if(e===2)return a.$2(b,c)
 if(e===1)return a.$1(b)
 return a.$0()},
-eY(a){return a==null||A.dk(a)||typeof a=="number"||typeof a=="string"||t.D.b(a)||t.bX.b(a)||t.ca.b(a)||t.W.b(a)||t.a.b(a)||t.k.b(a)||t.x.b(a)||t.B.b(a)||t.q.b(a)||t.J.b(a)||t.Y.b(a)},
-by(a){if(A.eY(a))return a
-return new A.dB(new A.at(t.A)).$1(a)},
-f9(a,b){var s=new A.v($.n,b.h("v<0>")),r=new A.b9(s,b.h("b9<0>"))
-a.then(A.aD(new A.dE(r,b),1),A.aD(new A.dF(r),1))
+f0(a){return a==null||A.dk(a)||typeof a=="number"||typeof a=="string"||t.D.b(a)||t.bX.b(a)||t.ca.b(a)||t.W.b(a)||t.a.b(a)||t.k.b(a)||t.x.b(a)||t.B.b(a)||t.q.b(a)||t.J.b(a)||t.Y.b(a)},
+aG(a){if(A.f0(a))return a
+return new A.dD(new A.au(t.A)).$1(a)},
+ef(a,b){var s=new A.r($.m,b.h("r<0>")),r=new A.bc(s,b.h("bc<0>"))
+a.then(A.aD(new A.dG(r,b),1),A.aD(new A.dH(r),1))
 return s},
-eX(a){return a==null||typeof a==="boolean"||typeof a==="number"||typeof a==="string"||a instanceof Int8Array||a instanceof Uint8Array||a instanceof Uint8ClampedArray||a instanceof Int16Array||a instanceof Uint16Array||a instanceof Int32Array||a instanceof Uint32Array||a instanceof Float32Array||a instanceof Float64Array||a instanceof ArrayBuffer||a instanceof DataView},
-e6(a){if(A.eX(a))return a
-return new A.ds(new A.at(t.A)).$1(a)},
-dB:function dB(a){this.a=a},
-dE:function dE(a,b){this.a=a
+f_(a){return a==null||typeof a==="boolean"||typeof a==="number"||typeof a==="string"||a instanceof Int8Array||a instanceof Uint8Array||a instanceof Uint8ClampedArray||a instanceof Int16Array||a instanceof Uint16Array||a instanceof Int32Array||a instanceof Uint32Array||a instanceof Float32Array||a instanceof Float64Array||a instanceof ArrayBuffer||a instanceof DataView},
+e8(a){if(A.f_(a))return a
+return new A.dt(new A.au(t.A)).$1(a)},
+dD:function dD(a){this.a=a},
+dG:function dG(a,b){this.a=a
 this.b=b},
-dF:function dF(a){this.a=a},
-ds:function ds(a){this.a=a},
-iw(){var s=$.aG()
-s.a=t.e.a(A.i7())
-s.saM(A.i8())},
-ij(a){var s,r,q,p,o,n=null,m="threshold"
+dH:function dH(a){this.a=a},
+dt:function dt(a){this.a=a},
+iA(){var s=$.aH()
+s.a=t.e.a(A.ib())
+s.saO(A.ic())},
+io(a){var s,r,q,p,o,n=null,m="threshold"
 if(!t.f.b(a))return
-switch(a.j(0,"op")){case"watch":s=A.cl(a.j(0,"city"))
+switch(a.j(0,"op")){case"watch":s=A.cn(a.j(0,"city"))
 r=s==null?n:s.toLowerCase()
 if(r==null)r="cardiff"
-q=A.ck(a.j(0,m))
+q=A.cm(a.j(0,m))
 if(q==null)q=n
-s=$.bx
+s=$.bB
 if(s!=null)s.Y()
-A.ab(A.C(["kind","watching","city",r,"threshold",q],t.N,t.X))
-A.eZ(r,q)
-$.bx=A.fT(B.r,new A.dw(r,q))
+A.ac(A.B(["kind","watching","city",r,"threshold",q],t.N,t.X))
+A.f1(r,q)
+$.bB=A.fW(B.t,new A.dy(r,q))
 break
-case"stop":s=$.bx
+case"stop":s=$.bB
 if(s!=null)s.Y()
-$.bx=null
-A.ab(A.C(["kind","stopped"],t.N,t.X))
+$.bB=null
+A.ac(A.B(["kind","stopped"],t.N,t.X))
 break
-case"check":s=A.cl(a.j(0,"city"))
+case"check":s=A.cn(a.j(0,"city"))
 r=s==null?n:s.toLowerCase()
 if(r==null)r="cardiff"
-q=A.ck(a.j(0,m))
+q=A.cm(a.j(0,m))
 if(q==null)q=n
 s=t.N
 p=t.X
-A.ab(A.C(["kind","task-start","city",r],s,p))
-o=A.e3(r)
-A.ab(A.C(["kind","task-done","city",r,"tempC",o,"below",q!=null&&o<q],s,p))
+A.ac(A.B(["kind","task-start","city",r],s,p))
+o=A.e5(r)
+A.ac(A.B(["kind","task-done","city",r,"tempC",o,"below",q!=null&&o<q],s,p))
 break
-case"text":A.ab(A.C(["kind","echo","text",a.j(0,"text")],t.N,t.X))
+case"text":A.ac(A.B(["kind","echo","text",a.j(0,"text")],t.N,t.X))
 break}},
-eZ(a,b){var s,r=A.e3(a),q=b!=null&&r<b
-A.ab(A.C(["kind",q?"alert":"tick","city",a,"tempC",r,"threshold",b],t.N,t.X))
-if(q){s=$.bx
+f1(a,b){var s,r=A.e5(a),q=b!=null&&r<b
+A.ac(A.B(["kind",q?"alert":"tick","city",a,"tempC",r,"threshold",b],t.N,t.X))
+if(q){s=$.bB
 if(s!=null)s.Y()
-$.bx=null}},
-ab(a){var s=$.aG().c
+$.bB=null}},
+ac(a){var s=$.aH().c
 if(s!=null)s.$1(a)},
-e3(a){var s=B.x.j(0,a)
+e5(a){var s=B.y.j(0,a)
 if(s==null)s=15
-return s*(1+(B.c.al(A.hB(a+":"+B.c.X(Date.now(),3e4)),1000)/1000*0.1-0.05))},
-hB(a){var s,r,q,p
-for(s=new A.aK(a),r=t.V,s=new A.R(s,s.gl(0),r.h("R<f.E>")),r=r.h("f.E"),q=0;s.m();){p=s.d
+return s*(1+(B.c.al(A.hF(a+":"+B.c.X(Date.now(),3e4)),1000)/1000*0.1-0.05))},
+hF(a){var s,r,q,p
+for(s=new A.aL(a),r=t.V,s=new A.R(s,s.gl(0),r.h("R<f.E>")),r=r.h("f.E"),q=0;s.m();){p=s.d
 if(p==null)p=r.a(p)
 q=q*31+p&2147483647}return q},
-e8(a,b){return A.ii(a,t.h.a(b))},
-ii(a,b){var s=0,r=A.dl(t.y),q,p,o,n,m,l,k,j
-var $async$e8=A.dp(function(c,d){if(c===1)return A.df(d,r)
-for(;;)switch(s){case 0:j=b==null
-if(!j&&J.P(b.j(0,"fail"),!0)){q=!1
+eb(a,b){return A.im(a,t.h.a(b))},
+im(a,b){var s=0,r=A.dl(t.y),q,p,o,n,m,l,k,j,i,h
+var $async$eb=A.dq(function(c,d){if(c===1)return A.df(d,r)
+for(;;)switch(s){case 0:h=b==null
+if(!h&&J.P(b.j(0,"fail"),!0)){q=!1
 s=1
-break}p=A.cl(j?null:b.j(0,"city"))
+break}p=A.cn(h?null:b.j(0,"city"))
 o=p==null?null:p.toLowerCase()
 if(o==null)o="cardiff"
-n=A.ck(j?null:b.j(0,"threshold"))
+n=A.cm(h?null:b.j(0,"threshold"))
 if(n==null)n=null
 for(m=0,l=0;l<2e6;++l)m+=l
-j=t.N
+h=t.N
 p=t.X
-A.ab(A.C(["kind","task-start","city",o,"threshold",n],j,p))
-k=A.e3(o)
-A.ab(A.C(["kind","task-done","city",o,"tempC",k,"below",n!=null&&k<n],j,p))
+A.ac(A.B(["kind","task-start","city",o,"threshold",n],h,p))
+k=A.e5(o)
+j=n!=null&&k<n
+A.ac(A.B(["kind","task-done","city",o,"tempC",k,"below",j],h,p))
+h=j?"\u2744\ufe0f "+o+" below the alert threshold":"Temperature check: "+A.hz(o)
+p=B.v.aX(k,1)
+i=j?"below the alert threshold":"all good"
+A.hY(h,p+"\xb0C \u2014 "+i)
 q=!0
 s=1
 break
 case 1:return A.dg(q,r)}})
-return A.dh($async$e8,r)},
-dw:function dw(a,b){this.a=a
+return A.dh($async$eb,r)},
+hY(a,b){var s,r,q,p,o=v.G
+if(!("registration" in o))return
+s=t.X
+s=A.ef(A.by(A.aT(A.by(o.registration),"showNotification",a,A.aG(A.B(["body",b,"tag","workmanager-demo"],t.N,s)),s)),s)
+r=new A.dm()
+q=s.$ti
+p=$.m
+if(p!==B.b)r=A.f2(r,p)
+s.G(new A.V(new A.r(p,q),2,null,r,q.h("V<1,1>")))},
+hz(a){var s=a.length
+if(s===0)return a
+if(0>=s)return A.y(a,0)
+return a[0].toUpperCase()+B.j.an(a,1)},
+dy:function dy(a,b){this.a=a
 this.b=b},
-ca:function ca(){this.c=this.b=this.a=null},
-h_(a){var s,r,q,p,o="Attempting to rewrap a JS function."
-if($.eB)return
-$.eB=!0
-$.aG()
+dm:function dm(){},
+cc:function cc(){this.c=this.b=this.a=null},
+h2(a){var s,r,q,p,o="Attempting to rewrap a JS function."
+if($.eE)return
+$.eE=!0
+$.aH()
 a.$0()
 s=v.G
-if(typeof A.ed()=="function")A.co(A.ak(o,null))
-r=function(b,c){return function(d,e,f){return b(c,d,e,f,arguments.length)}}(A.hv,A.ed())
-q=$.ee()
-r[q]=A.ed()
+if(typeof A.eh()=="function")A.cp(A.al(o,null))
+r=function(b,c){return function(d,e,f){return b(c,d,e,f,arguments.length)}}(A.hy,A.eh())
+q=$.ei()
+r[q]=A.eh()
 s.__wmTrigger=r
-p=new A.cQ()
-if(typeof p=="function")A.co(A.ak(o,null))
-r=function(b,c){return function(d){return b(c,d,arguments.length)}}(A.hu,p)
+p=new A.cR()
+if(typeof p=="function")A.cp(A.al(o,null))
+r=function(b,c){return function(d){return b(c,d,arguments.length)}}(A.hx,p)
 r[q]=p
 q=t.X
-A.bN(s,"addEventListener","message",r,q)
-A.fZ()
-A.bN(s,"postMessage",A.by(A.C(["type","ready"],t.N,q)),null,q)},
-fZ(){var s=v.G,r=$.aG()
-if("clients" in s)r.sa4(new A.cO(s))
-else r.sa4(new A.cP(s))},
-fW(a){var s,r,q=A.fV(a)
-if(q!=null||J.P(a.$ti.h("4?").a(a.a.j(0,"type")),"message")){s=$.aG().b
+A.aT(s,"addEventListener","message",r,q)
+A.h1()
+A.aT(s,"postMessage",A.aG(A.B(["type","ready"],t.N,q)),null,q)},
+h1(){var s=v.G,r=$.aH()
+if("clients" in s)r.sa4(new A.cP(s))
+else r.sa4(new A.cQ(s))},
+fZ(a){var s,r,q=A.fY(a)
+if(q!=null||J.P(a.$ti.h("4?").a(a.a.j(0,"type")),"message")){s=$.aH().b
 if(s!=null)s.$1(q)
-return}r=A.fU(a)
+return}r=A.fX(a)
 if(r==null)return
-A.cM(r.b,r.c,r.a)},
-cM(a,b,c){var s=0,r=A.dl(t.H),q,p
-var $async$cM=A.dp(function(d,e){if(d===1)return A.df(e,r)
+A.cN(r.b,r.c,r.a)},
+cN(a,b,c){var s=0,r=A.dl(t.H),q,p
+var $async$cN=A.dq(function(d,e){if(d===1)return A.df(e,r)
 for(;;)switch(s){case 0:s=2
-return A.e_(A.cb(b,c),$async$cM)
+return A.e1(A.cd(b,c),$async$cN)
 case 2:q=e
 p=t.X
-A.bN(v.G,"postMessage",A.by(A.C(["type","result","requestId",a,"result",q.a,"error",q.b],t.N,p)),null,p)
+A.aT(v.G,"postMessage",A.aG(A.B(["type","result","requestId",a,"result",q.a,"error",q.b],t.N,p)),null,p)
 return A.dg(null,r)}})
-return A.dh($async$cM,r)},
-fY(a,b,c){A.cL(A.az(a),b,t.g.a(c))},
-cL(a,b,c){var s=0,r=A.dl(t.H),q,p,o,n,m
-var $async$cL=A.dp(function(d,e){if(d===1)return A.df(e,r)
+return A.dh($async$cN,r)},
+h0(a,b,c){A.cM(A.az(a),b,t.g.a(c))},
+cM(a,b,c){var s=0,r=A.dl(t.H),q,p,o,n,m
+var $async$cM=A.dq(function(d,e){if(d===1)return A.df(e,r)
 for(;;)switch(s){case 0:s=2
-return A.e_(A.cb(a,b==null?null:A.e6(b)),$async$cL)
+return A.e1(A.cd(a,b==null?null:A.e8(b)),$async$cM)
 case 2:q=e
 p=q.a
 o=q.b
-n=p==null?null:A.by(p)
+n=p==null?null:A.aG(p)
 m=o==null?null:o
 c.call(null,n,m)
 return A.dg(null,r)}})
-return A.dh($async$cL,r)},
-cb(a,b){return A.fX(a,b)},
-fX(a,b){var s=0,r=A.dl(t.t),q,p=2,o=[],n,m,l,k,j,i,h
-var $async$cb=A.dp(function(c,d){if(c===1){o.push(d)
+return A.dh($async$cM,r)},
+cd(a,b){return A.h_(a,b)},
+h_(a,b){var s=0,r=A.dl(t.t),q,p=2,o=[],n,m,l,k,j,i,h
+var $async$cd=A.dq(function(c,d){if(c===1){o.push(d)
 s=p}for(;;)switch(s){case 0:j=null
 i=null
 p=4
-l=$.aG()
+l=$.aH()
 n=l.a
 s=n==null?7:9
 break
@@ -1908,131 +1930,138 @@ case 7:j="No background task handler registered. Did the callbackDispatcher call
 s=8
 break
 case 9:s=10
-return A.e_(n.$2(a,l.aN(b)),$async$cb)
+return A.e1(n.$2(a,l.aP(b)),$async$cd)
 case 10:i=d
 case 8:p=2
 s=6
 break
 case 4:p=3
 h=o.pop()
-m=A.aj(h)
-j=J.aH(m)
+m=A.ak(h)
+j=J.aI(m)
 s=6
 break
 case 3:s=2
 break
-case 6:q=new A.bk(i,j)
+case 6:q=new A.bn(i,j)
 s=1
 break
 case 1:return A.dg(q,r)
 case 2:return A.df(o.at(-1),r)}})
-return A.dh($async$cb,r)},
-cQ:function cQ(){},
-cO:function cO(a){this.a=a},
-cN:function cN(a){this.a=a},
+return A.dh($async$cd,r)},
+cR:function cR(){},
 cP:function cP(a){this.a=a},
-iu(a){throw A.w(new A.bP("Field '"+a+"' has been assigned during initialization."),new Error())},
-ep(a,b,c,d,e,f){var s
+cO:function cO(a){this.a=a},
+cQ:function cQ(a){this.a=a},
+iy(a){throw A.w(new A.bQ("Field '"+a+"' has been assigned during initialization."),new Error())},
+et(a,b,c,d,e,f){var s
 if(c==null)return a[b]()
 else if(d==null)return a[b](c)
 else{s=a[b](c,d)
 return s}},
-bN(a,b,c,d,e){return e.a(A.ep(a,b,c,d,null,null))},
-fU(a){var s,r,q=a.a,p=a.$ti.h("4?")
+aT(a,b,c,d,e){return e.a(A.et(a,b,c,d,null,null))},
+fX(a){var s,r,q=a.a,p=a.$ti.h("4?")
 if(!J.P(p.a(q.j(0,"type")),"executeTask"))return null
 s=p.a(q.j(0,"requestId"))
 r=p.a(q.j(0,"taskName"))
-if(!A.e2(s)||typeof r!="string")return null
-return new A.bl(p.a(q.j(0,"inputData")),s,r)},
-fV(a){var s=a.a,r=a.$ti.h("4?")
+if(!A.e4(s)||typeof r!="string")return null
+return new A.bo(p.a(q.j(0,"inputData")),s,r)},
+fY(a){var s=a.a,r=a.$ti.h("4?")
 if(!J.P(r.a(s.j(0,"type")),"message"))return null
 return r.a(s.j(0,"payload"))},
-ir(){A.h_(A.i9())}},B={}
+iv(){A.h2(A.id())}},B={}
 var w=[A,J,B]
 var $={}
-A.dM.prototype={}
-J.bI.prototype={
+A.dO.prototype={}
+J.bL.prototype={
 C(a,b){return a===b},
-gq(a){return A.c0(a)},
-i(a){return"Instance of '"+A.c1(a)+"'"},
-gt(a){return A.ae(A.e0(this))}}
-J.bK.prototype={
+gq(a){return A.c1(a)},
+i(a){return"Instance of '"+A.c2(a)+"'"},
+gt(a){return A.af(A.e2(this))}}
+J.bN.prototype={
 i(a){return String(a)},
 gq(a){return a?519018:218159},
-gt(a){return A.ae(t.y)},
+gt(a){return A.af(t.y)},
 $ij:1,
-$iad:1}
-J.aQ.prototype={
+$iae:1}
+J.aR.prototype={
 C(a,b){return null==b},
 i(a){return"null"},
 gq(a){return 0},
 $ij:1,
-$iq:1}
-J.aS.prototype={$io:1}
-J.Y.prototype={
+$ip:1}
+J.aV.prototype={$io:1}
+J.Z.prototype={
 gq(a){return 0},
 i(a){return String(a)}}
-J.c_.prototype={}
-J.b6.prototype={}
+J.c0.prototype={}
+J.b9.prototype={}
 J.N.prototype={
-i(a){var s=a[$.ee()]
-if(s==null)return this.an(a)
-return"JavaScript function for "+J.aH(s)},
-$ia5:1}
-J.aR.prototype={
+i(a){var s=a[$.ei()]
+if(s==null)return this.ap(a)
+return"JavaScript function for "+J.aI(s)},
+$ia6:1}
+J.aU.prototype={
 gq(a){return 0},
 i(a){return String(a)}}
-J.aT.prototype={
+J.aW.prototype={
 gq(a){return 0},
 i(a){return String(a)}}
 J.x.prototype={
-u(a,b){A.ax(a).c.a(b)
-a.$flags&1&&A.ec(a,29)
+u(a,b){A.ay(a).c.a(b)
+a.$flags&1&&A.eg(a,29)
 a.push(b)},
-aF(a,b){var s
-A.ax(a).h("b<1>").a(b)
-a.$flags&1&&A.ec(a,"addAll",2)
+aH(a,b){var s
+A.ay(a).h("b<1>").a(b)
+a.$flags&1&&A.eg(a,"addAll",2)
 for(s=b.gp(b);s.m();)a.push(s.gn())},
-L(a,b,c){var s=A.ax(a)
+M(a,b,c){var s=A.ay(a)
 return new A.S(a,s.k(c).h("1(2)").a(b),s.h("@<1>").k(c).h("S<1,2>"))},
-K(a,b){if(!(b<a.length))return A.y(a,b)
+L(a,b){if(!(b<a.length))return A.y(a,b)
 return a[b]},
-i(a){return A.eo(a,"[","]")},
-gp(a){return new J.aI(a,a.length,A.ax(a).h("aI<1>"))},
-gq(a){return A.c0(a)},
+i(a){return A.es(a,"[","]")},
+gp(a){return new J.aJ(a,a.length,A.ay(a).h("aJ<1>"))},
+gq(a){return A.c1(a)},
 gl(a){return a.length},
-j(a,b){if(!(b>=0&&b<a.length))throw A.e(A.dt(a,b))
+j(a,b){if(!(b>=0&&b<a.length))throw A.e(A.du(a,b))
 return a[b]},
-v(a,b,c){A.ax(a).c.a(c)
-a.$flags&2&&A.ec(a)
-if(!(b>=0&&b<a.length))throw A.e(A.dt(a,b))
+v(a,b,c){A.ay(a).c.a(c)
+a.$flags&2&&A.eg(a)
+if(!(b>=0&&b<a.length))throw A.e(A.du(a,b))
 a[b]=c},
-$ic:1,
+$id:1,
 $ib:1,
 $ii:1}
-J.bJ.prototype={
-aV(a){var s,r,q
+J.bM.prototype={
+aY(a){var s,r,q
 if(!Array.isArray(a))return null
 s=a.$flags|0
 if((s&4)!==0)r="const, "
 else if((s&2)!==0)r="unmodifiable, "
 else r=(s&1)!==0?"fixed, ":""
-q="Instance of '"+A.c1(a)+"'"
+q="Instance of '"+A.c2(a)+"'"
 if(r==="")return q
 return q+" ("+r+"length: "+a.length+")"}}
-J.cx.prototype={}
-J.aI.prototype={
+J.cy.prototype={}
+J.aJ.prototype={
 gn(){var s=this.d
 return s==null?this.$ti.c.a(s):s},
 m(){var s,r=this,q=r.a,p=q.length
-if(r.b!==p){q=A.fb(q)
+if(r.b!==p){q=A.fd(q)
 throw A.e(q)}s=r.c
 if(s>=p){r.d=null
 return!1}r.d=q[s]
 r.c=s+1
 return!0},
 $iz:1}
-J.bM.prototype={
+J.aS.prototype={
+aX(a,b){var s,r
+if(b>20)throw A.e(A.c3(b,0,20,"fractionDigits",null))
+s=a.toFixed(b)
+if(a===0)r=1/a<0
+else r=!1
+if(r)return"-"+s
+return s},
 i(a){if(a===0&&1/a<0)return"-0.0"
 else return""+a},
 gq(a){var s,r,q,p,o=a|0
@@ -2046,38 +2075,40 @@ al(a,b){var s=a%b
 if(s===0)return 0
 if(s>0)return s
 return s+b},
-ao(a,b){if((a|0)===a)if(b>=1)return a/b|0
+aq(a,b){if((a|0)===a)if(b>=1)return a/b|0
 return this.ae(a,b)},
 X(a,b){return(a|0)===a?a/b|0:this.ae(a,b)},
 ae(a,b){var s=a/b
 if(s>=-2147483648&&s<=2147483647)return s|0
 if(s>0){if(s!==1/0)return Math.floor(s)}else if(s>-1/0)return Math.ceil(s)
-throw A.e(A.cK("Result of truncating division is "+A.m(s)+": "+A.m(a)+" ~/ "+b))},
-aE(a,b){var s
-if(a>0)s=this.aD(a,b)
+throw A.e(A.cL("Result of truncating division is "+A.n(s)+": "+A.n(a)+" ~/ "+b))},
+aG(a,b){var s
+if(a>0)s=this.aF(a,b)
 else{s=b>31?31:b
 s=a>>s>>>0}return s},
-aD(a,b){return b>31?0:a>>>b},
-gt(a){return A.ae(t.o)},
+aF(a,b){return b>31?0:a>>>b},
+gt(a){return A.af(t.o)},
 $ih:1,
-$iai:1}
-J.aP.prototype={
-gt(a){return A.ae(t.S)},
+$iaj:1}
+J.aQ.prototype={
+gt(a){return A.af(t.S)},
 $ij:1,
 $ia:1}
-J.bL.prototype={
-gt(a){return A.ae(t.i)},
+J.bO.prototype={
+gt(a){return A.af(t.i)},
 $ij:1}
-J.an.prototype={
+J.ao.prototype={
+ao(a,b,c){return a.substring(b,A.fT(b,c,a.length))},
+an(a,b){return this.ao(a,b,null)},
 am(a,b){var s,r
 if(0>=b)return""
 if(b===1||a.length===0)return a
-if(b!==b>>>0)throw A.e(B.q)
+if(b!==b>>>0)throw A.e(B.r)
 for(s=a,r="";;){if((b&1)===1)r=s+r
 b=b>>>1
 if(b===0)break
 s+=s}return r},
-aP(a,b,c){var s=b-a.length
+aR(a,b,c){var s=b-a.length
 if(s<=0)return a
 return this.am(c,s)+a},
 i(a){return a},
@@ -2087,73 +2118,73 @@ r=r+((r&524287)<<10)&536870911
 r^=r>>6}r=r+((r&67108863)<<3)&536870911
 r^=r>>11
 return r+((r&16383)<<15)&536870911},
-gt(a){return A.ae(t.N)},
+gt(a){return A.af(t.N)},
 gl(a){return a.length},
 $ij:1,
-$iu:1}
-A.ar.prototype={
+$iv:1}
+A.as.prototype={
 gp(a){var s=this.a
-return new A.aJ(s.gp(s),A.r(this).h("aJ<1,2>"))},
+return new A.aK(s.gp(s),A.t(this).h("aK<1,2>"))},
 gl(a){var s=this.a
 return s.gl(s)},
 i(a){return this.a.i(0)}}
-A.aJ.prototype={
+A.aK.prototype={
 m(){return this.a.m()},
 gn(){return this.$ti.y[1].a(this.a.gn())},
 $iz:1}
-A.a3.prototype={}
-A.ba.prototype={$ic:1}
-A.a4.prototype={
-Z(a,b,c){return new A.a4(this.a,this.$ti.h("@<1,2>").k(b).k(c).h("a4<1,2,3,4>"))},
+A.a4.prototype={}
+A.bd.prototype={$id:1}
+A.a5.prototype={
+Z(a,b,c){return new A.a5(this.a,this.$ti.h("@<1,2>").k(b).k(c).h("a5<1,2,3,4>"))},
 j(a,b){return this.$ti.h("4?").a(this.a.j(0,b))},
-E(a,b){this.a.E(0,new A.cq(this,this.$ti.h("~(3,4)").a(b)))},
+E(a,b){this.a.E(0,new A.cr(this,this.$ti.h("~(3,4)").a(b)))},
 gB(){var s=this.$ti
-return A.fs(this.a.gB(),s.c,s.y[2])},
+return A.fu(this.a.gB(),s.c,s.y[2])},
 gl(a){var s=this.a
 return s.gl(s)},
-gD(){var s=this.a.gD(),r=this.$ti.h("p<3,4>"),q=A.r(s)
-return A.dQ(s,q.k(r).h("1(b.E)").a(new A.cp(this)),q.h("b.E"),r)}}
-A.cq.prototype={
+gD(){var s=this.a.gD(),r=this.$ti.h("q<3,4>"),q=A.t(s)
+return A.dS(s,q.k(r).h("1(b.E)").a(new A.cq(this)),q.h("b.E"),r)}}
+A.cr.prototype={
 $2(a,b){var s=this.a.$ti
 s.c.a(a)
 s.y[1].a(b)
 this.b.$2(s.y[2].a(a),s.y[3].a(b))},
 $S(){return this.a.$ti.h("~(1,2)")}}
-A.cp.prototype={
+A.cq.prototype={
 $1(a){var s=this.a.$ti
-s.h("p<1,2>").a(a)
-return new A.p(s.y[2].a(a.a),s.y[3].a(a.b),s.h("p<3,4>"))},
-$S(){return this.a.$ti.h("p<3,4>(p<1,2>)")}}
-A.bP.prototype={
+s.h("q<1,2>").a(a)
+return new A.q(s.y[2].a(a.a),s.y[3].a(a.b),s.h("q<3,4>"))},
+$S(){return this.a.$ti.h("q<3,4>(q<1,2>)")}}
+A.bQ.prototype={
 i(a){return"LateInitializationError: "+this.a}}
-A.aK.prototype={
+A.aL.prototype={
 gl(a){return this.a.length},
 j(a,b){var s=this.a
 if(!(b>=0&&b<s.length))return A.y(s,b)
 return s.charCodeAt(b)}}
-A.cD.prototype={}
-A.c.prototype={}
+A.cE.prototype={}
+A.d.prototype={}
 A.O.prototype={
 gp(a){return new A.R(this,this.gl(0),this.$ti.h("R<O.E>"))},
-L(a,b,c){var s=this.$ti
+M(a,b,c){var s=this.$ti
 return new A.S(this,s.k(c).h("1(O.E)").a(b),s.h("@<O.E>").k(c).h("S<1,2>"))}}
 A.R.prototype={
 gn(){var s=this.d
 return s==null?this.$ti.c.a(s):s},
-m(){var s,r=this,q=r.a,p=J.f6(q),o=p.gl(q)
-if(r.b!==o)throw A.e(A.am(q))
+m(){var s,r=this,q=r.a,p=J.e9(q),o=p.gl(q)
+if(r.b!==o)throw A.e(A.an(q))
 s=r.c
 if(s>=o){r.d=null
-return!1}r.d=p.K(q,s);++r.c
+return!1}r.d=p.L(q,s);++r.c
 return!0},
 $iz:1}
-A.a7.prototype={
+A.a8.prototype={
 gp(a){var s=this.a
-return new A.aY(s.gp(s),this.b,A.r(this).h("aY<1,2>"))},
+return new A.b0(s.gp(s),this.b,A.t(this).h("b0<1,2>"))},
 gl(a){var s=this.a
 return s.gl(s)}}
-A.aN.prototype={$ic:1}
-A.aY.prototype={
+A.aO.prototype={$id:1}
+A.b0.prototype={
 m(){var s=this,r=s.b
 if(r.m()){s.a=s.c.$1(r.gn())
 return!0}s.a=null
@@ -2162,53 +2193,53 @@ gn(){var s=this.a
 return s==null?this.$ti.y[1].a(s):s},
 $iz:1}
 A.S.prototype={
-gl(a){return J.dI(this.a)},
-K(a,b){return this.b.$1(J.fo(this.a,b))}}
+gl(a){return J.dK(this.a)},
+L(a,b){return this.b.$1(J.fq(this.a,b))}}
 A.A.prototype={}
-A.b7.prototype={}
-A.aq.prototype={}
-A.bk.prototype={$r:"+(1,2)",$s:1}
-A.bl.prototype={$r:"+inputData,requestId,taskName(1,2,3)",$s:2}
-A.aL.prototype={
-Z(a,b,c){var s=A.r(this)
-return A.er(this,s.c,s.y[1],b,c)},
-i(a){return A.dP(this)},
-gD(){return new A.aw(this.aI(),A.r(this).h("aw<p<1,2>>"))},
-aI(){var s=this
+A.ba.prototype={}
+A.ar.prototype={}
+A.bn.prototype={$r:"+(1,2)",$s:1}
+A.bo.prototype={$r:"+inputData,requestId,taskName(1,2,3)",$s:2}
+A.aM.prototype={
+Z(a,b,c){var s=A.t(this)
+return A.ev(this,s.c,s.y[1],b,c)},
+i(a){return A.dR(this)},
+gD(){return new A.ax(this.aK(),A.t(this).h("ax<q<1,2>>"))},
+aK(){var s=this
 return function(){var r=0,q=1,p=[],o,n,m,l,k
 return function $async$gD(a,b,c){if(b===1){p.push(c)
-r=q}for(;;)switch(r){case 0:o=s.gB(),o=o.gp(o),n=A.r(s),m=n.y[1],n=n.h("p<1,2>")
+r=q}for(;;)switch(r){case 0:o=s.gB(),o=o.gp(o),n=A.t(s),m=n.y[1],n=n.h("q<1,2>")
 case 2:if(!o.m()){r=3
 break}l=o.gn()
 k=s.j(0,l)
 r=4
-return a.b=new A.p(l,k==null?m.a(k):k,n),1
+return a.b=new A.q(l,k==null?m.a(k):k,n),1
 case 4:r=2
 break
 case 3:return 0
 case 1:return a.c=p.at(-1),3}}}},
 $iD:1}
-A.aM.prototype={
+A.aN.prototype={
 gl(a){return this.b.length},
 gac(){var s=this.$keys
 if(s==null){s=Object.keys(this.a)
 this.$keys=s}return s},
-J(a){if(typeof a!="string")return!1
+K(a){if(typeof a!="string")return!1
 if("__proto__"===a)return!1
 return this.a.hasOwnProperty(a)},
-j(a,b){if(!this.J(b))return null
+j(a,b){if(!this.K(b))return null
 return this.b[this.a[b]]},
 E(a,b){var s,r,q,p
 this.$ti.h("~(1,2)").a(b)
 s=this.gac()
 r=this.b
 for(q=s.length,p=0;p<q;++p)b.$2(s[p],r[p])},
-gB(){return new A.be(this.gac(),this.$ti.h("be<1>"))}}
-A.be.prototype={
+gB(){return new A.bh(this.gac(),this.$ti.h("bh<1>"))}}
+A.bh.prototype={
 gl(a){return this.a.length},
 gp(a){var s=this.a
-return new A.bf(s,s.length,this.$ti.h("bf<1>"))}}
-A.bf.prototype={
+return new A.bi(s,s.length,this.$ti.h("bi<1>"))}}
+A.bi.prototype={
 gn(){var s=this.d
 return s==null?this.$ti.c.a(s):s},
 m(){var s=this,r=s.c
@@ -2217,8 +2248,8 @@ return!1}s.d=s.a[r]
 s.c=r+1
 return!0},
 $iz:1}
-A.b4.prototype={}
-A.cE.prototype={
+A.b7.prototype={}
+A.cF.prototype={
 A(a){var s,r,q=this,p=new RegExp(q.a).exec(a)
 if(p==null)return null
 s=Object.create(null)
@@ -2233,55 +2264,55 @@ if(r!==-1)s.method=p[r+1]
 r=q.f
 if(r!==-1)s.receiver=p[r+1]
 return s}}
-A.b2.prototype={
+A.b5.prototype={
 i(a){return"Null check operator used on a null value"}}
-A.bO.prototype={
+A.bP.prototype={
 i(a){var s,r=this,q="NoSuchMethodError: method not found: '",p=r.b
 if(p==null)return"NoSuchMethodError: "+r.a
 s=r.c
 if(s==null)return q+p+"' ("+r.a+")"
 return q+p+"' on '"+s+"' ("+r.a+")"}}
-A.c9.prototype={
+A.cb.prototype={
 i(a){var s=this.a
 return s.length===0?"Error":"Error: "+s}}
-A.cC.prototype={
+A.cD.prototype={
 i(a){return"Throw of null ('"+(this.a===null?"null":"undefined")+"' from JavaScript)"}}
-A.aO.prototype={}
-A.bm.prototype={
+A.aP.prototype={}
+A.bp.prototype={
 i(a){var s,r=this.b
 if(r!=null)return r
 r=this.a
 s=r!==null&&typeof r==="object"?r.stack:null
 return this.b=s==null?"":s},
-$iZ:1}
-A.X.prototype={
+$ia_:1}
+A.Y.prototype={
 i(a){var s=this.constructor,r=s==null?null:s.name
-return"Closure '"+A.fc(r==null?"unknown":r)+"'"},
-$ia5:1,
-gaW(){return this},
+return"Closure '"+A.fe(r==null?"unknown":r)+"'"},
+$ia6:1,
+gaZ(){return this},
 $C:"$1",
 $R:1,
 $D:null}
-A.bB.prototype={$C:"$0",$R:0}
-A.bC.prototype={$C:"$2",$R:2}
-A.c6.prototype={}
-A.c4.prototype={
+A.bE.prototype={$C:"$0",$R:0}
+A.bF.prototype={$C:"$2",$R:2}
+A.c8.prototype={}
+A.c6.prototype={
 i(a){var s=this.$static_name
 if(s==null)return"Closure of unknown static method"
-return"Closure '"+A.fc(s)+"'"}}
-A.al.prototype={
+return"Closure '"+A.fe(s)+"'"}}
+A.am.prototype={
 C(a,b){if(b==null)return!1
 if(this===b)return!0
-if(!(b instanceof A.al))return!1
+if(!(b instanceof A.am))return!1
 return this.$_target===b.$_target&&this.a===b.a},
-gq(a){return(A.dD(this.a)^A.c0(this.$_target))>>>0},
-i(a){return"Closure '"+this.$_name+"' of "+("Instance of '"+A.c1(this.a)+"'")}}
-A.c2.prototype={
+gq(a){return(A.dF(this.a)^A.c1(this.$_target))>>>0},
+i(a){return"Closure '"+this.$_name+"' of "+("Instance of '"+A.c2(this.a)+"'")}}
+A.c4.prototype={
 i(a){return"RuntimeError: "+this.a}}
-A.a6.prototype={
+A.a7.prototype={
 gl(a){return this.a},
-gB(){return new A.aX(this,A.r(this).h("aX<1>"))},
-gD(){return new A.aU(this,A.r(this).h("aU<1,2>"))},
+gB(){return new A.b_(this,A.t(this).h("b_<1>"))},
+gD(){return new A.aX(this,A.t(this).h("aX<1,2>"))},
 j(a,b){var s,r,q,p,o=null
 if(typeof b=="string"){s=this.b
 if(s==null)return o
@@ -2291,14 +2322,14 @@ return q}else if(typeof b=="number"&&(b&0x3fffffff)===b){p=this.c
 if(p==null)return o
 r=p[b]
 q=r==null?o:r.b
-return q}else return this.aK(b)},
-aK(a){var s,r,q=this.d
+return q}else return this.aM(b)},
+aM(a){var s,r,q=this.d
 if(q==null)return null
 s=q[this.ai(a)]
 r=this.aj(s,a)
 if(r<0)return null
 return s[r].b},
-v(a,b,c){var s,r,q,p,o,n,m=this,l=A.r(m)
+v(a,b,c){var s,r,q,p,o,n,m=this,l=A.t(m)
 l.c.a(b)
 l.y[1].a(c)
 if(typeof b=="string"){s=m.b
@@ -2312,236 +2343,236 @@ else{n=m.aj(o,b)
 if(n>=0)o[n].b=c
 else o.push(m.W(b,c))}}},
 E(a,b){var s,r,q=this
-A.r(q).h("~(1,2)").a(b)
+A.t(q).h("~(1,2)").a(b)
 s=q.e
 r=q.r
 while(s!=null){b.$2(s.a,s.b)
-if(r!==q.r)throw A.e(A.am(q))
+if(r!==q.r)throw A.e(A.an(q))
 s=s.c}},
-a5(a,b,c){var s,r=A.r(this)
+a5(a,b,c){var s,r=A.t(this)
 r.c.a(b)
 r.y[1].a(c)
 s=a[b]
 if(s==null)a[b]=this.W(b,c)
 else s.b=c},
-W(a,b){var s=this,r=A.r(s),q=new A.cy(r.c.a(a),r.y[1].a(b))
+W(a,b){var s=this,r=A.t(s),q=new A.cz(r.c.a(a),r.y[1].a(b))
 if(s.e==null)s.e=s.f=q
 else s.f=s.f.c=q;++s.a
 s.r=s.r+1&1073741823
 return q},
-ai(a){return J.W(a)&1073741823},
+ai(a){return J.X(a)&1073741823},
 aj(a,b){var s,r
 if(a==null)return-1
 s=a.length
 for(r=0;r<s;++r)if(J.P(a[r].a,b))return r
 return-1},
-i(a){return A.dP(this)},
+i(a){return A.dR(this)},
 V(){var s=Object.create(null)
 s["<non-identifier-key>"]=s
 delete s["<non-identifier-key>"]
 return s},
-$ieq:1}
-A.cy.prototype={}
-A.aX.prototype={
+$ieu:1}
+A.cz.prototype={}
+A.b_.prototype={
 gl(a){return this.a.a},
 gp(a){var s=this.a
-return new A.aW(s,s.r,s.e,this.$ti.h("aW<1>"))}}
-A.aW.prototype={
+return new A.aZ(s,s.r,s.e,this.$ti.h("aZ<1>"))}}
+A.aZ.prototype={
 gn(){return this.d},
 m(){var s,r=this,q=r.a
-if(r.b!==q.r)throw A.e(A.am(q))
+if(r.b!==q.r)throw A.e(A.an(q))
 s=r.c
 if(s==null){r.d=null
 return!1}else{r.d=s.a
 r.c=s.c
 return!0}},
 $iz:1}
-A.aU.prototype={
+A.aX.prototype={
 gl(a){return this.a.a},
 gp(a){var s=this.a
-return new A.aV(s,s.r,s.e,this.$ti.h("aV<1,2>"))}}
-A.aV.prototype={
+return new A.aY(s,s.r,s.e,this.$ti.h("aY<1,2>"))}}
+A.aY.prototype={
 gn(){var s=this.d
 s.toString
 return s},
 m(){var s,r=this,q=r.a
-if(r.b!==q.r)throw A.e(A.am(q))
+if(r.b!==q.r)throw A.e(A.an(q))
 s=r.c
 if(s==null){r.d=null
-return!1}else{r.d=new A.p(s.a,s.b,r.$ti.h("p<1,2>"))
+return!1}else{r.d=new A.q(s.a,s.b,r.$ti.h("q<1,2>"))
 r.c=s.c
 return!0}},
 $iz:1}
-A.dx.prototype={
+A.dz.prototype={
 $1(a){return this.a(a)},
 $S:7}
-A.dy.prototype={
+A.dA.prototype={
 $2(a,b){return this.a(a,b)},
 $S:8}
-A.dz.prototype={
+A.dB.prototype={
 $1(a){return this.a(A.az(a))},
 $S:9}
-A.V.prototype={
+A.W.prototype={
 i(a){return this.ag(!1)},
-ag(a){var s,r,q,p,o,n=this.az(),m=this.U(),l=(a?"Record ":"")+"("
+ag(a){var s,r,q,p,o,n=this.aB(),m=this.U(),l=(a?"Record ":"")+"("
 for(s=n.length,r="",q=0;q<s;++q,r=", "){l+=r
 p=n[q]
 if(typeof p=="string")l=l+p+": "
 if(!(q<m.length))return A.y(m,q)
 o=m[q]
-l=a?l+A.et(o):l+A.m(o)}l+=")"
+l=a?l+A.ex(o):l+A.n(o)}l+=")"
 return l.charCodeAt(0)==0?l:l},
-az(){var s,r=this.$s
-while($.d6.length<=r)B.a.u($.d6,null)
-s=$.d6[r]
-if(s==null){s=this.av()
-B.a.v($.d6,r,s)}return s},
-av(){var s,r,q,p=this.$r,o=p.indexOf("("),n=p.substring(1,o),m=p.substring(o),l=m==="()"?0:m.replace(/[^,]/g,"").length+1,k=A.K(new Array(l),t.G)
+aB(){var s,r=this.$s
+while($.d7.length<=r)B.a.u($.d7,null)
+s=$.d7[r]
+if(s==null){s=this.az()
+B.a.v($.d7,r,s)}return s},
+az(){var s,r,q,p=this.$r,o=p.indexOf("("),n=p.substring(1,o),m=p.substring(o),l=m==="()"?0:m.replace(/[^,]/g,"").length+1,k=A.K(new Array(l),t.G)
 for(s=0;s<l;++s)k[s]=s
 if(n!==""){r=n.split(",")
 s=r.length
 for(q=l;s>0;){--q;--s
-B.a.v(k,q,r[s])}}k=A.fI(k,!1,t.K)
+B.a.v(k,q,r[s])}}k=A.fK(k,!1,t.K)
 k.$flags=3
 return k}}
-A.au.prototype={
+A.av.prototype={
 U(){return[this.a,this.b]},
 C(a,b){if(b==null)return!1
-return b instanceof A.au&&this.$s===b.$s&&J.P(this.a,b.a)&&J.P(this.b,b.b)},
-gq(a){return A.dR(this.$s,this.a,this.b,B.d)}}
-A.av.prototype={
+return b instanceof A.av&&this.$s===b.$s&&J.P(this.a,b.a)&&J.P(this.b,b.b)},
+gq(a){return A.dT(this.$s,this.a,this.b,B.d)}}
+A.aw.prototype={
 U(){return[this.a,this.b,this.c]},
 C(a,b){var s=this
 if(b==null)return!1
-return b instanceof A.av&&s.$s===b.$s&&J.P(s.a,b.a)&&J.P(s.b,b.b)&&J.P(s.c,b.c)},
+return b instanceof A.aw&&s.$s===b.$s&&J.P(s.a,b.a)&&J.P(s.b,b.b)&&J.P(s.c,b.c)},
 gq(a){var s=this
-return A.dR(s.$s,s.a,s.b,s.c)}}
-A.ao.prototype={
-gt(a){return B.z},
-$ij:1,
-$idK:1}
-A.b0.prototype={}
-A.bQ.prototype={
+return A.dT(s.$s,s.a,s.b,s.c)}}
+A.ap.prototype={
 gt(a){return B.A},
 $ij:1,
-$idL:1}
-A.ap.prototype={
-gl(a){return a.length},
-$iB:1}
-A.aZ.prototype={
-j(a,b){A.aa(b,a,a.length)
-return a[b]},
-$ic:1,
-$ib:1,
-$ii:1}
-A.b_.prototype={$ic:1,$ib:1,$ii:1}
+$idM:1}
+A.b3.prototype={}
 A.bR.prototype={
 gt(a){return B.B},
 $ij:1,
-$ics:1}
+$idN:1}
+A.aq.prototype={
+gl(a){return a.length},
+$iC:1}
+A.b1.prototype={
+j(a,b){A.ab(b,a,a.length)
+return a[b]},
+$id:1,
+$ib:1,
+$ii:1}
+A.b2.prototype={$id:1,$ib:1,$ii:1}
 A.bS.prototype={
 gt(a){return B.C},
 $ij:1,
 $ict:1}
 A.bT.prototype={
 gt(a){return B.D},
-j(a,b){A.aa(b,a,a.length)
-return a[b]},
 $ij:1,
 $icu:1}
 A.bU.prototype={
 gt(a){return B.E},
-j(a,b){A.aa(b,a,a.length)
+j(a,b){A.ab(b,a,a.length)
 return a[b]},
 $ij:1,
 $icv:1}
 A.bV.prototype={
 gt(a){return B.F},
-j(a,b){A.aa(b,a,a.length)
+j(a,b){A.ab(b,a,a.length)
 return a[b]},
 $ij:1,
 $icw:1}
 A.bW.prototype={
-gt(a){return B.H},
-j(a,b){A.aa(b,a,a.length)
+gt(a){return B.G},
+j(a,b){A.ab(b,a,a.length)
 return a[b]},
 $ij:1,
-$icG:1}
+$icx:1}
 A.bX.prototype={
 gt(a){return B.I},
-j(a,b){A.aa(b,a,a.length)
+j(a,b){A.ab(b,a,a.length)
 return a[b]},
 $ij:1,
 $icH:1}
-A.b1.prototype={
+A.bY.prototype={
 gt(a){return B.J},
-gl(a){return a.length},
-j(a,b){A.aa(b,a,a.length)
+j(a,b){A.ab(b,a,a.length)
 return a[b]},
 $ij:1,
 $icI:1}
-A.bY.prototype={
+A.b4.prototype={
 gt(a){return B.K},
 gl(a){return a.length},
-j(a,b){A.aa(b,a,a.length)
+j(a,b){A.ab(b,a,a.length)
 return a[b]},
 $ij:1,
 $icJ:1}
-A.bg.prototype={}
-A.bh.prototype={}
-A.bi.prototype={}
+A.bZ.prototype={
+gt(a){return B.L},
+gl(a){return a.length},
+j(a,b){A.ab(b,a,a.length)
+return a[b]},
+$ij:1,
+$icK:1}
 A.bj.prototype={}
+A.bk.prototype={}
+A.bl.prototype={}
+A.bm.prototype={}
 A.J.prototype={
-h(a){return A.bt(v.typeUniverse,this,a)},
-k(a){return A.eP(v.typeUniverse,this,a)}}
-A.cg.prototype={}
-A.db.prototype={
+h(a){return A.bw(v.typeUniverse,this,a)},
+k(a){return A.eS(v.typeUniverse,this,a)}}
+A.ci.prototype={}
+A.dc.prototype={
 i(a){return A.F(this.a,null)}}
-A.cf.prototype={
+A.ch.prototype={
 i(a){return this.a}}
-A.bp.prototype={$iT:1}
-A.cS.prototype={
+A.bs.prototype={$iT:1}
+A.cT.prototype={
 $1(a){var s=this.a,r=s.a
 s.a=null
 r.$0()},
 $S:6}
-A.cR.prototype={
+A.cS.prototype={
 $1(a){var s,r
 this.a.a=t.M.a(a)
 s=this.b
 r=this.c
 s.firstChild?s.removeChild(r):s.appendChild(r)},
 $S:10}
-A.cT.prototype={
-$0(){this.a.$0()},
-$S:1}
 A.cU.prototype={
 $0(){this.a.$0()},
 $S:1}
-A.bo.prototype={
-ap(a,b){if(self.setTimeout!=null)this.b=self.setTimeout(A.aD(new A.da(this,b),0),a)
-else throw A.e(A.cK("`setTimeout()` not found."))},
-aq(a,b){if(self.setTimeout!=null)this.b=self.setInterval(A.aD(new A.d9(this,a,Date.now(),b),0),a)
-else throw A.e(A.cK("Periodic timer."))},
+A.cV.prototype={
+$0(){this.a.$0()},
+$S:1}
+A.br.prototype={
+ar(a,b){if(self.setTimeout!=null)this.b=self.setTimeout(A.aD(new A.db(this,b),0),a)
+else throw A.e(A.cL("`setTimeout()` not found."))},
+au(a,b){if(self.setTimeout!=null)this.b=self.setInterval(A.aD(new A.da(this,a,Date.now(),b),0),a)
+else throw A.e(A.cL("Periodic timer."))},
 Y(){if(self.setTimeout!=null){var s=this.b
 if(s==null)return
 if(this.a)self.clearTimeout(s)
 else self.clearInterval(s)
-this.b=null}else throw A.e(A.cK("Canceling a timer."))},
-$ic7:1}
-A.da.prototype={
+this.b=null}else throw A.e(A.cL("Canceling a timer."))},
+$ic9:1}
+A.db.prototype={
 $0(){var s=this.a
 s.b=null
 s.c=1
 this.b.$0()},
 $S:0}
-A.d9.prototype={
+A.da.prototype={
 $0(){var s,r=this,q=r.a,p=q.c+1,o=r.b
 if(o>0){s=Date.now()-r.c
-if(s>(p+1)*o)p=B.c.ao(s,o)}q.c=p
+if(s>(p+1)*o)p=B.c.aq(s,o)}q.c=p
 r.d.$1(q)},
 $S:1}
-A.cc.prototype={
+A.ce.prototype={
 a_(a){var s,r=this,q=r.$ti
 q.h("1/?").a(a)
 if(a==null)a=q.c.a(a)
@@ -2556,16 +2587,16 @@ A.di.prototype={
 $1(a){return this.a.$2(0,a)},
 $S:2}
 A.dj.prototype={
-$2(a,b){this.a.$2(1,new A.aO(a,t.l.a(b)))},
+$2(a,b){this.a.$2(1,new A.aP(a,t.l.a(b)))},
 $S:11}
-A.dq.prototype={
-$2(a,b){this.a(A.a1(a),b)},
+A.dr.prototype={
+$2(a,b){this.a(A.a2(a),b)},
 $S:12}
-A.bn.prototype={
+A.bq.prototype={
 gn(){var s=this.b
 return s==null?this.$ti.c.a(s):s},
-aB(a,b){var s,r,q
-a=A.a1(a)
+aD(a,b){var s,r,q
+a=A.a2(a)
 b=b
 s=this.a
 for(;;)try{r=s(this,a,b)
@@ -2576,11 +2607,11 @@ for(;;){s=o.d
 if(s!=null)try{if(s.m()){o.b=s.gn()
 return!0}else o.d=null}catch(r){n=r
 m=1
-o.d=null}q=o.aB(m,n)
+o.d=null}q=o.aD(m,n)
 if(1===q)return!0
 if(0===q){o.b=null
 p=o.e
-if(p==null||p.length===0){o.a=A.eK
+if(p==null||p.length===0){o.a=A.eN
 return!1}if(0>=p.length)return A.y(p,-1)
 o.a=p.pop()
 m=0
@@ -2591,71 +2622,71 @@ continue}if(3===q){n=o.c
 o.c=null
 p=o.e
 if(p==null||p.length===0){o.b=null
-o.a=A.eK
+o.a=A.eN
 throw n
 return!1}if(0>=p.length)return A.y(p,-1)
 o.a=p.pop()
 m=1
-continue}throw A.e(A.dT("sync*"))}return!1},
-aX(a){var s,r,q=this
-if(a instanceof A.aw){s=a.a()
+continue}throw A.e(A.dV("sync*"))}return!1},
+b_(a){var s,r,q=this
+if(a instanceof A.ax){s=a.a()
 r=q.e
 if(r==null)r=q.e=[]
 B.a.u(r,q.a)
 q.a=s
-return 2}else{q.d=J.dH(a)
+return 2}else{q.d=J.dJ(a)
 return 2}},
 $iz:1}
-A.aw.prototype={
-gp(a){return new A.bn(this.a(),this.$ti.h("bn<1>"))}}
+A.ax.prototype={
+gp(a){return new A.bq(this.a(),this.$ti.h("bq<1>"))}}
 A.H.prototype={
-i(a){return A.m(this.a)},
+i(a){return A.n(this.a)},
 $il:1,
 gF(){return this.b}}
-A.ce.prototype={
+A.cg.prototype={
 a0(a,b){var s=this.a
-if((s.a&30)!==0)throw A.e(A.dT("Future already completed"))
-s.O(A.hG(a,b))},
+if((s.a&30)!==0)throw A.e(A.dV("Future already completed"))
+s.O(A.hK(a,b))},
 ah(a){return this.a0(a,null)}}
-A.b9.prototype={
+A.bc.prototype={
 a_(a){var s,r=this.$ti
 r.h("1/?").a(a)
 s=this.a
-if((s.a&30)!==0)throw A.e(A.dT("Future already completed"))
+if((s.a&30)!==0)throw A.e(A.dV("Future already completed"))
 s.a6(r.h("1/").a(a))}}
-A.a8.prototype={
-aL(a){if((this.c&15)!==6)return!0
+A.V.prototype={
+aN(a){if((this.c&15)!==6)return!0
 return this.b.b.a2(t.bG.a(this.d),a.a,t.y,t.K)},
-aJ(a){var s,r=this,q=r.e,p=null,o=t.z,n=t.K,m=a.a,l=r.b.b
-if(t.Q.b(q))p=l.aR(q,m,a.b,o,n,t.l)
+aL(a){var s,r=this,q=r.e,p=null,o=t.z,n=t.K,m=a.a,l=r.b.b
+if(t.Q.b(q))p=l.aT(q,m,a.b,o,n,t.l)
 else p=l.a2(t.v.a(q),m,o,n)
 try{o=r.$ti.h("2/").a(p)
-return o}catch(s){if(t.c.b(A.aj(s))){if((r.c&1)!==0)throw A.e(A.ak("The error handler of Future.then must return a value of the returned future's type","onError"))
-throw A.e(A.ak("The error handler of Future.catchError must return a value of the future's type","onError"))}else throw s}}}
-A.v.prototype={
+return o}catch(s){if(t.c.b(A.ak(s))){if((r.c&1)!==0)throw A.e(A.al("The error handler of Future.then must return a value of the returned future's type","onError"))
+throw A.e(A.al("The error handler of Future.catchError must return a value of the future's type","onError"))}else throw s}}}
+A.r.prototype={
 a3(a,b,c){var s,r,q,p=this.$ti
 p.k(c).h("1/(2)").a(a)
-s=$.n
-if(s===B.b){if(b!=null&&!t.Q.b(b)&&!t.v.b(b))throw A.e(A.eh(b,"onError",u.c))}else{c.h("@<0/>").k(p.c).h("1(2)").a(a)
-if(b!=null)b=A.hV(b,s)}r=new A.v(s,c.h("v<0>"))
+s=$.m
+if(s===B.b){if(b!=null&&!t.Q.b(b)&&!t.v.b(b))throw A.e(A.el(b,"onError",u.c))}else{c.h("@<0/>").k(p.c).h("1(2)").a(a)
+if(b!=null)b=A.f2(b,s)}r=new A.r(s,c.h("r<0>"))
 q=b==null?1:3
-this.N(new A.a8(r,q,a,b,p.h("@<1>").k(c).h("a8<1,2>")))
+this.G(new A.V(r,q,a,b,p.h("@<1>").k(c).h("V<1,2>")))
 return r},
-aU(a,b){return this.a3(a,null,b)},
+aW(a,b){return this.a3(a,null,b)},
 af(a,b,c){var s,r=this.$ti
 r.k(c).h("1/(2)").a(a)
-s=new A.v($.n,c.h("v<0>"))
-this.N(new A.a8(s,19,a,b,r.h("@<1>").k(c).h("a8<1,2>")))
+s=new A.r($.m,c.h("r<0>"))
+this.G(new A.V(s,19,a,b,r.h("@<1>").k(c).h("V<1,2>")))
 return s},
-aC(a){this.a=this.a&1|16
+aE(a){this.a=this.a&1|16
 this.c=a},
-G(a){this.a=a.a&30|this.a&1
+H(a){this.a=a.a&30|this.a&1
 this.c=a.c},
-N(a){var s,r=this,q=r.a
+G(a){var s,r=this,q=r.a
 if(q<=3){a.a=t.F.a(r.c)
 r.c=a}else{if((q&4)!==0){s=t._.a(r.c)
-if((s.a&24)===0){s.N(a)
-return}r.G(s)}A.cm(null,null,r.b,t.M.a(new A.cW(r,a)))}},
+if((s.a&24)===0){s.G(a)
+return}r.H(s)}A.co(null,null,r.b,t.M.a(new A.cX(r,a)))}},
 ad(a){var s,r,q,p,o,n,m=this,l={}
 l.a=a
 if(a==null)return
@@ -2666,179 +2697,179 @@ if(r!=null){q=a.a
 for(p=a;q!=null;p=q,q=o)o=q.a
 p.a=r}}else{if((s&4)!==0){n=t._.a(m.c)
 if((n.a&24)===0){n.ad(a)
-return}m.G(n)}l.a=m.I(a)
-A.cm(null,null,m.b,t.M.a(new A.d_(l,m)))}},
-H(){var s=t.F.a(this.c)
+return}m.H(n)}l.a=m.J(a)
+A.co(null,null,m.b,t.M.a(new A.d0(l,m)))}},
+I(){var s=t.F.a(this.c)
 this.c=null
-return this.I(s)},
-I(a){var s,r,q
+return this.J(s)},
+J(a){var s,r,q
 for(s=a,r=null;s!=null;r=s,s=q){q=s.a
 s.a=r}return r},
 a9(a){var s,r=this
 r.$ti.c.a(a)
-s=r.H()
+s=r.I()
 r.a=8
 r.c=a
-A.as(r,s)},
-au(a){var s,r,q=this
+A.at(r,s)},
+aw(a){var s,r,q=this
 if((a.a&16)!==0){s=q.b===a.b
 s=!(s||s)}else s=!1
 if(s)return
-r=q.H()
-q.G(a)
-A.as(q,r)},
-P(a){var s=this.H()
-this.aC(a)
-A.as(this,s)},
+r=q.I()
+q.H(a)
+A.at(q,r)},
+P(a){var s=this.I()
+this.aE(a)
+A.at(this,s)},
 a6(a){var s=this.$ti
 s.h("1/").a(a)
 if(s.h("M<1>").b(a)){this.a7(a)
-return}this.ar(a)},
-ar(a){var s=this
+return}this.av(a)},
+av(a){var s=this
 s.$ti.c.a(a)
 s.a^=2
-A.cm(null,null,s.b,t.M.a(new A.cY(s,a)))},
-a7(a){A.dV(this.$ti.h("M<1>").a(a),this,!1)
+A.co(null,null,s.b,t.M.a(new A.cZ(s,a)))},
+a7(a){A.dX(this.$ti.h("M<1>").a(a),this,!1)
 return},
 O(a){this.a^=2
-A.cm(null,null,this.b,t.M.a(new A.cX(this,a)))},
+A.co(null,null,this.b,t.M.a(new A.cY(this,a)))},
 $iM:1}
-A.cW.prototype={
-$0(){A.as(this.a,this.b)},
+A.cX.prototype={
+$0(){A.at(this.a,this.b)},
+$S:0}
+A.d0.prototype={
+$0(){A.at(this.b,this.a.a)},
 $S:0}
 A.d_.prototype={
-$0(){A.as(this.b,this.a.a)},
+$0(){A.dX(this.a.a,this.b,!0)},
 $S:0}
 A.cZ.prototype={
-$0(){A.dV(this.a.a,this.b,!0)},
-$S:0}
-A.cY.prototype={
 $0(){this.a.a9(this.b)},
 $S:0}
-A.cX.prototype={
+A.cY.prototype={
 $0(){this.a.P(this.b)},
 $S:0}
-A.d2.prototype={
+A.d3.prototype={
 $0(){var s,r,q,p,o,n,m,l,k=this,j=null
 try{q=k.a.a
-j=q.b.b.aQ(t.bd.a(q.d),t.z)}catch(p){s=A.aj(p)
-r=A.ag(p)
+j=q.b.b.aS(t.bd.a(q.d),t.z)}catch(p){s=A.ak(p)
+r=A.ah(p)
 if(k.c&&t.n.a(k.b.a.c).a===s){q=k.a
 q.c=t.n.a(k.b.a.c)}else{q=s
 o=r
-if(o==null)o=A.dJ(q)
+if(o==null)o=A.dL(q)
 n=k.a
 n.c=new A.H(q,o)
 q=n}q.b=!0
-return}if(j instanceof A.v&&(j.a&24)!==0){if((j.a&16)!==0){q=k.a
+return}if(j instanceof A.r&&(j.a&24)!==0){if((j.a&16)!==0){q=k.a
 q.c=t.n.a(j.c)
-q.b=!0}return}if(j instanceof A.v){m=k.b.a
-l=new A.v(m.b,m.$ti)
-j.a3(new A.d3(l,m),new A.d4(l),t.H)
+q.b=!0}return}if(j instanceof A.r){m=k.b.a
+l=new A.r(m.b,m.$ti)
+j.a3(new A.d4(l,m),new A.d5(l),t.H)
 q=k.a
 q.c=l
 q.b=!1}},
 $S:0}
-A.d3.prototype={
-$1(a){this.a.au(this.b)},
-$S:6}
 A.d4.prototype={
-$2(a,b){A.ay(a)
+$1(a){this.a.aw(this.b)},
+$S:6}
+A.d5.prototype={
+$2(a,b){A.aa(a)
 t.l.a(b)
 this.a.P(new A.H(a,b))},
 $S:13}
-A.d1.prototype={
+A.d2.prototype={
 $0(){var s,r,q,p,o,n,m,l
 try{q=this.a
 p=q.a
 o=p.$ti
 n=o.c
 m=n.a(this.b)
-q.c=p.b.b.a2(o.h("2/(1)").a(p.d),m,o.h("2/"),n)}catch(l){s=A.aj(l)
-r=A.ag(l)
+q.c=p.b.b.a2(o.h("2/(1)").a(p.d),m,o.h("2/"),n)}catch(l){s=A.ak(l)
+r=A.ah(l)
 q=s
 p=r
-if(p==null)p=A.dJ(q)
+if(p==null)p=A.dL(q)
 o=this.a
 o.c=new A.H(q,p)
 o.b=!0}},
 $S:0}
-A.d0.prototype={
+A.d1.prototype={
 $0(){var s,r,q,p,o,n,m,l=this
 try{s=t.n.a(l.a.a.c)
 p=l.b
-if(p.a.aL(s)&&p.a.e!=null){p.c=p.a.aJ(s)
-p.b=!1}}catch(o){r=A.aj(o)
-q=A.ag(o)
+if(p.a.aN(s)&&p.a.e!=null){p.c=p.a.aL(s)
+p.b=!1}}catch(o){r=A.ak(o)
+q=A.ah(o)
 p=t.n.a(l.a.a.c)
 if(p.a===r){n=l.b
 n.c=p
 p=n}else{p=r
 n=q
-if(n==null)n=A.dJ(p)
+if(n==null)n=A.dL(p)
 m=l.b
 m.c=new A.H(p,n)
 p=m}p.b=!0}},
 $S:0}
-A.cd.prototype={}
-A.ci.prototype={}
-A.bu.prototype={$ieC:1}
-A.dn.prototype={
-$0(){A.fA(this.a,this.b)},
+A.cf.prototype={}
+A.ck.prototype={}
+A.bx.prototype={$ieF:1}
+A.dp.prototype={
+$0(){A.fC(this.a,this.b)},
 $S:0}
-A.ch.prototype={
-aS(a){var s,r,q
+A.cj.prototype={
+aU(a){var s,r,q
 t.M.a(a)
-try{if(B.b===$.n){a.$0()
-return}A.f_(null,null,this,a,t.H)}catch(q){s=A.aj(q)
-r=A.ag(q)
-A.dm(A.ay(s),t.l.a(r))}},
-aT(a,b,c){var s,r,q
+try{if(B.b===$.m){a.$0()
+return}A.f3(null,null,this,a,t.H)}catch(q){s=A.ak(q)
+r=A.ah(q)
+A.dn(A.aa(s),t.l.a(r))}},
+aV(a,b,c){var s,r,q
 c.h("~(0)").a(a)
 c.a(b)
-try{if(B.b===$.n){a.$1(b)
-return}A.f0(null,null,this,a,b,t.H,c)}catch(q){s=A.aj(q)
-r=A.ag(q)
-A.dm(A.ay(s),t.l.a(r))}},
-aG(a){return new A.d7(this,t.M.a(a))},
-aH(a,b){return new A.d8(this,b.h("~(0)").a(a),b)},
-aQ(a,b){b.h("0()").a(a)
-if($.n===B.b)return a.$0()
-return A.f_(null,null,this,a,b)},
+try{if(B.b===$.m){a.$1(b)
+return}A.f4(null,null,this,a,b,t.H,c)}catch(q){s=A.ak(q)
+r=A.ah(q)
+A.dn(A.aa(s),t.l.a(r))}},
+aI(a){return new A.d8(this,t.M.a(a))},
+aJ(a,b){return new A.d9(this,b.h("~(0)").a(a),b)},
+aS(a,b){b.h("0()").a(a)
+if($.m===B.b)return a.$0()
+return A.f3(null,null,this,a,b)},
 a2(a,b,c,d){c.h("@<0>").k(d).h("1(2)").a(a)
 d.a(b)
-if($.n===B.b)return a.$1(b)
-return A.f0(null,null,this,a,b,c,d)},
-aR(a,b,c,d,e,f){d.h("@<0>").k(e).k(f).h("1(2,3)").a(a)
+if($.m===B.b)return a.$1(b)
+return A.f4(null,null,this,a,b,c,d)},
+aT(a,b,c,d,e,f){d.h("@<0>").k(e).k(f).h("1(2,3)").a(a)
 e.a(b)
 f.a(c)
-if($.n===B.b)return a.$2(b,c)
-return A.hW(null,null,this,a,b,c,d,e,f)},
+if($.m===B.b)return a.$2(b,c)
+return A.i_(null,null,this,a,b,c,d,e,f)},
 ak(a,b,c,d){return b.h("@<0>").k(c).k(d).h("1(2,3)").a(a)}}
-A.d7.prototype={
-$0(){return this.a.aS(this.b)},
-$S:0}
 A.d8.prototype={
+$0(){return this.a.aU(this.b)},
+$S:0}
+A.d9.prototype={
 $1(a){var s=this.c
-return this.a.aT(this.b,s.a(a),s)},
+return this.a.aV(this.b,s.a(a),s)},
 $S(){return this.c.h("~(0)")}}
-A.bb.prototype={
+A.be.prototype={
 gl(a){return this.a},
-gB(){return new A.bc(this,this.$ti.h("bc<1>"))},
-J(a){var s,r
+gB(){return new A.bf(this,this.$ti.h("bf<1>"))},
+K(a){var s,r
 if(typeof a=="string"&&a!=="__proto__"){s=this.b
 return s==null?!1:s[a]!=null}else if(typeof a=="number"&&(a&1073741823)===a){r=this.c
-return r==null?!1:r[a]!=null}else return this.aw(a)},
-aw(a){var s=this.d
+return r==null?!1:r[a]!=null}else return this.aA(a)},
+aA(a){var s=this.d
 if(s==null)return!1
 return this.T(this.ab(s,a),a)>=0},
 j(a,b){var s,r,q
 if(typeof b=="string"&&b!=="__proto__"){s=this.b
-r=s==null?null:A.eE(s,b)
+r=s==null?null:A.eH(s,b)
 return r}else if(typeof b=="number"&&(b&1073741823)===b){q=this.c
-r=q==null?null:A.eE(q,b)
-return r}else return this.aA(b)},
-aA(a){var s,r,q=this.d
+r=q==null?null:A.eH(q,b)
+return r}else return this.aC(b)},
+aC(a){var s,r,q=this.d
 if(q==null)return null
 s=this.ab(q,a)
 r=this.T(s,a)
@@ -2847,12 +2878,12 @@ v(a,b,c){var s,r,q,p,o,n,m=this,l=m.$ti
 l.c.a(b)
 l.y[1].a(c)
 if(typeof b=="string"&&b!=="__proto__"){s=m.b
-m.a8(s==null?m.b=A.dW():s,b,c)}else if(typeof b=="number"&&(b&1073741823)===b){r=m.c
-m.a8(r==null?m.c=A.dW():r,b,c)}else{q=m.d
-if(q==null)q=m.d=A.dW()
-p=A.dD(b)&1073741823
+m.a8(s==null?m.b=A.dY():s,b,c)}else if(typeof b=="number"&&(b&1073741823)===b){r=m.c
+m.a8(r==null?m.c=A.dY():r,b,c)}else{q=m.d
+if(q==null)q=m.d=A.dY()
+p=A.dF(b)&1073741823
 o=q[p]
-if(o==null){A.dX(q,p,[b,c]);++m.a
+if(o==null){A.dZ(q,p,[b,c]);++m.a
 m.e=null}else{n=m.T(o,b)
 if(n>=0)o[n+1]=c
 else{o.push(b,c);++m.a
@@ -2864,10 +2895,10 @@ for(r=s.length,q=l.c,l=l.y[1],p=0;p<r;++p){o=s[p]
 q.a(o)
 n=m.j(0,o)
 b.$2(o,n==null?l.a(n):n)
-if(s!==m.e)throw A.e(A.am(m))}},
+if(s!==m.e)throw A.e(A.an(m))}},
 aa(){var s,r,q,p,o,n,m,l,k,j,i=this,h=i.e
 if(h!=null)return h
-h=A.fH(i.a,null,!1,t.z)
+h=A.fJ(i.a,null,!1,t.z)
 s=i.b
 r=0
 if(s!=null){q=Object.getOwnPropertyNames(s)
@@ -2885,23 +2916,23 @@ a8(a,b,c){var s=this.$ti
 s.c.a(b)
 s.y[1].a(c)
 if(a[b]==null){++this.a
-this.e=null}A.dX(a,b,c)},
-ab(a,b){return a[A.dD(b)&1073741823]}}
-A.at.prototype={
+this.e=null}A.dZ(a,b,c)},
+ab(a,b){return a[A.dF(b)&1073741823]}}
+A.au.prototype={
 T(a,b){var s,r,q
 if(a==null)return-1
 s=a.length
 for(r=0;r<s;r+=2){q=a[r]
 if(q==null?b==null:q===b)return r}return-1}}
-A.bc.prototype={
+A.bf.prototype={
 gl(a){return this.a.a},
 gp(a){var s=this.a
-return new A.bd(s,s.aa(),this.$ti.h("bd<1>"))}}
-A.bd.prototype={
+return new A.bg(s,s.aa(),this.$ti.h("bg<1>"))}}
+A.bg.prototype={
 gn(){var s=this.d
 return s==null?this.$ti.c.a(s):s},
 m(){var s=this,r=s.b,q=s.c,p=s.a
-if(r!==p.e)throw A.e(A.am(p))
+if(r!==p.e)throw A.e(A.an(p))
 else if(q>=r.length){s.d=null
 return!1}else{s.d=r[q]
 s.c=q+1
@@ -2909,67 +2940,67 @@ return!0}},
 $iz:1}
 A.f.prototype={
 gp(a){return new A.R(a,this.gl(a),A.aE(a).h("R<f.E>"))},
-K(a,b){return this.j(a,b)},
-L(a,b,c){var s=A.aE(a)
+L(a,b){return this.j(a,b)},
+M(a,b,c){var s=A.aE(a)
 return new A.S(a,s.k(c).h("1(f.E)").a(b),s.h("@<f.E>").k(c).h("S<1,2>"))},
-i(a){return A.eo(a,"[","]")},
-$ic:1,
+i(a){return A.es(a,"[","]")},
+$id:1,
 $ib:1,
 $ii:1}
 A.k.prototype={
-Z(a,b,c){var s=A.r(this)
-return A.er(this,s.h("k.K"),s.h("k.V"),b,c)},
-E(a,b){var s,r,q,p=A.r(this)
+Z(a,b,c){var s=A.t(this)
+return A.ev(this,s.h("k.K"),s.h("k.V"),b,c)},
+E(a,b){var s,r,q,p=A.t(this)
 p.h("~(k.K,k.V)").a(b)
 for(s=this.gB(),s=s.gp(s),p=p.h("k.V");s.m();){r=s.gn()
 q=this.j(0,r)
 b.$2(r,q==null?p.a(q):q)}},
-gD(){var s=this.gB(),r=A.r(this).h("p<k.K,k.V>"),q=A.r(s)
-return A.dQ(s,q.k(r).h("1(b.E)").a(new A.cz(this)),q.h("b.E"),r)},
+gD(){var s=this.gB(),r=A.t(this).h("q<k.K,k.V>"),q=A.t(s)
+return A.dS(s,q.k(r).h("1(b.E)").a(new A.cA(this)),q.h("b.E"),r)},
 gl(a){var s=this.gB()
 return s.gl(s)},
-i(a){return A.dP(this)},
+i(a){return A.dR(this)},
 $iD:1}
-A.cz.prototype={
-$1(a){var s=this.a,r=A.r(s)
+A.cA.prototype={
+$1(a){var s=this.a,r=A.t(s)
 r.h("k.K").a(a)
 s=s.j(0,a)
 if(s==null)s=r.h("k.V").a(s)
-return new A.p(a,s,r.h("p<k.K,k.V>"))},
-$S(){return A.r(this.a).h("p<k.K,k.V>(k.K)")}}
-A.cA.prototype={
+return new A.q(a,s,r.h("q<k.K,k.V>"))},
+$S(){return A.t(this.a).h("q<k.K,k.V>(k.K)")}}
+A.cB.prototype={
 $2(a,b){var s,r=this.a
 if(!r.a)this.b.a+=", "
 r.a=!1
 r=this.b
-s=A.m(a)
+s=A.n(a)
 r.a=(r.a+=s)+": "
-s=A.m(b)
+s=A.n(b)
 r.a+=s},
 $S:14}
-A.bE.prototype={
+A.bH.prototype={
 C(a,b){if(b==null)return!1
-return b instanceof A.bE&&this.a===b.a&&this.b===b.b&&this.c===b.c},
-gq(a){return A.dR(this.a,this.b,B.d,B.d)},
-i(a){var s=this,r=A.fy(A.fQ(s)),q=A.bF(A.fO(s)),p=A.bF(A.fK(s)),o=A.bF(A.fL(s)),n=A.bF(A.fN(s)),m=A.bF(A.fP(s)),l=A.en(A.fM(s)),k=s.b,j=k===0?"":A.en(k)
+return b instanceof A.bH&&this.a===b.a&&this.b===b.b&&this.c===b.c},
+gq(a){return A.dT(this.a,this.b,B.d,B.d)},
+i(a){var s=this,r=A.fA(A.fS(s)),q=A.bI(A.fQ(s)),p=A.bI(A.fM(s)),o=A.bI(A.fN(s)),n=A.bI(A.fP(s)),m=A.bI(A.fR(s)),l=A.er(A.fO(s)),k=s.b,j=k===0?"":A.er(k)
 k=r+"-"+q
 if(s.c)return k+"-"+p+" "+o+":"+n+":"+m+"."+l+j+"Z"
 else return k+"-"+p+" "+o+":"+n+":"+m+"."+l+j}}
-A.bG.prototype={
+A.bJ.prototype={
 C(a,b){if(b==null)return!1
-return b instanceof A.bG&&this.a===b.a},
+return b instanceof A.bJ&&this.a===b.a},
 gq(a){return B.c.gq(this.a)},
 i(a){var s,r,q,p=this.a,o=p%36e8,n=B.c.X(o,6e7)
 o%=6e7
 s=n<10?"0":""
 r=B.c.X(o,1e6)
 q=r<10?"0":""
-return""+(p/36e8|0)+":"+s+n+":"+q+r+"."+B.u.aP(B.c.i(o%1e6),6,"0")}}
+return""+(p/36e8|0)+":"+s+n+":"+q+r+"."+B.j.aR(B.c.i(o%1e6),6,"0")}}
 A.l.prototype={
-gF(){return A.fJ(this)}}
-A.bz.prototype={
+gF(){return A.fL(this)}}
+A.bC.prototype={
 i(a){var s=this.a
-if(s!=null)return"Assertion failed: "+A.cr(s)
+if(s!=null)return"Assertion failed: "+A.cs(s)
 return"Assertion failed"}}
 A.T.prototype={}
 A.Q.prototype={
@@ -2977,232 +3008,237 @@ gS(){return"Invalid argument"+(!this.a?"(s)":"")},
 gR(){return""},
 i(a){var s=this,r=s.c,q=r==null?"":" ("+r+")",p=s.d,o=p==null?"":": "+p,n=s.gS()+q+o
 if(!s.a)return n
-return n+s.gR()+": "+A.cr(s.ga1())},
+return n+s.gR()+": "+A.cs(s.ga1())},
 ga1(){return this.b}}
-A.b3.prototype={
-ga1(){return A.ck(this.b)},
+A.b6.prototype={
+ga1(){return A.cm(this.b)},
 gS(){return"RangeError"},
 gR(){var s,r=this.e,q=this.f
-if(r==null)s=q!=null?": Not less than or equal to "+A.m(q):""
-else if(q==null)s=": Not greater than or equal to "+A.m(r)
-else if(q>r)s=": Not in inclusive range "+A.m(r)+".."+A.m(q)
-else s=q<r?": Valid value range is empty":": Only valid value is "+A.m(r)
+if(r==null)s=q!=null?": Not less than or equal to "+A.n(q):""
+else if(q==null)s=": Not greater than or equal to "+A.n(r)
+else if(q>r)s=": Not in inclusive range "+A.n(r)+".."+A.n(q)
+else s=q<r?": Valid value range is empty":": Only valid value is "+A.n(r)
 return s}}
-A.bH.prototype={
-ga1(){return A.a1(this.b)},
+A.bK.prototype={
+ga1(){return A.a2(this.b)},
 gS(){return"RangeError"},
-gR(){if(A.a1(this.b)<0)return": index must not be negative"
+gR(){if(A.a2(this.b)<0)return": index must not be negative"
 var s=this.f
 if(s===0)return": no indices are valid"
 return": index should be less than "+s},
 gl(a){return this.f}}
-A.b8.prototype={
+A.bb.prototype={
 i(a){return"Unsupported operation: "+this.a}}
-A.c8.prototype={
+A.ca.prototype={
 i(a){return"UnimplementedError: "+this.a}}
-A.c3.prototype={
+A.c5.prototype={
 i(a){return"Bad state: "+this.a}}
-A.bD.prototype={
+A.bG.prototype={
 i(a){var s=this.a
 if(s==null)return"Concurrent modification during iteration."
-return"Concurrent modification during iteration: "+A.cr(s)+"."}}
-A.bZ.prototype={
+return"Concurrent modification during iteration: "+A.cs(s)+"."}}
+A.c_.prototype={
 i(a){return"Out of Memory"},
 gF(){return null},
 $il:1}
-A.b5.prototype={
+A.b8.prototype={
 i(a){return"Stack Overflow"},
 gF(){return null},
 $il:1}
-A.cV.prototype={
+A.cW.prototype={
 i(a){return"Exception: "+this.a}}
 A.b.prototype={
-L(a,b,c){var s=A.r(this)
-return A.dQ(this,s.k(c).h("1(b.E)").a(b),s.h("b.E"),c)},
+M(a,b,c){var s=A.t(this)
+return A.dS(this,s.k(c).h("1(b.E)").a(b),s.h("b.E"),c)},
 gl(a){var s,r=this.gp(this)
 for(s=0;r.m();)++s
 return s},
-i(a){return A.fC(this,"(",")")}}
-A.p.prototype={
-i(a){return"MapEntry("+A.m(this.a)+": "+A.m(this.b)+")"}}
+i(a){return A.fE(this,"(",")")}}
 A.q.prototype={
-gq(a){return A.d.prototype.gq.call(this,0)},
+i(a){return"MapEntry("+A.n(this.a)+": "+A.n(this.b)+")"}}
+A.p.prototype={
+gq(a){return A.c.prototype.gq.call(this,0)},
 i(a){return"null"}}
-A.d.prototype={$id:1,
+A.c.prototype={$ic:1,
 C(a,b){return this===b},
-gq(a){return A.c0(this)},
-i(a){return"Instance of '"+A.c1(this)+"'"},
-gt(a){return A.ig(this)},
+gq(a){return A.c1(this)},
+i(a){return"Instance of '"+A.c2(this)+"'"},
+gt(a){return A.ik(this)},
 toString(){return this.i(this)}}
-A.cj.prototype={
+A.cl.prototype={
 i(a){return""},
-$iZ:1}
-A.c5.prototype={
+$ia_:1}
+A.c7.prototype={
 gl(a){return this.a.length},
 i(a){var s=this.a
 return s.charCodeAt(0)==0?s:s}}
-A.cB.prototype={
+A.cC.prototype={
 i(a){return"Promise was rejected with a value of `"+(this.a?"undefined":"null")+"`."}}
-A.dB.prototype={
+A.dD.prototype={
 $1(a){var s,r,q,p
-if(A.eY(a))return a
+if(A.f0(a))return a
 s=this.a
-if(s.J(a))return s.j(0,a)
+if(s.K(a))return s.j(0,a)
 if(t.f.b(a)){r={}
 s.v(0,a,r)
 for(s=a.gB(),s=s.gp(s);s.m();){q=s.gn()
 r[q]=this.$1(a.j(0,q))}return r}else if(t.R.b(a)){p=[]
 s.v(0,a,p)
-B.a.aF(p,J.eg(a,this,t.z))
+B.a.aH(p,J.ek(a,this,t.z))
 return p}else return a},
 $S:3}
-A.dE.prototype={
+A.dG.prototype={
 $1(a){return this.a.a_(this.b.h("0/?").a(a))},
 $S:2}
-A.dF.prototype={
-$1(a){if(a==null)return this.a.ah(new A.cB(a===undefined))
+A.dH.prototype={
+$1(a){if(a==null)return this.a.ah(new A.cC(a===undefined))
 return this.a.ah(a)},
 $S:2}
-A.ds.prototype={
+A.dt.prototype={
 $1(a){var s,r,q,p,o,n,m,l,k,j,i,h
-if(A.eX(a))return a
+if(A.f_(a))return a
 s=this.a
 a.toString
-if(s.J(a))return s.j(0,a)
+if(s.K(a))return s.j(0,a)
 if(a instanceof Date){r=a.getTime()
-if(r<-864e13||r>864e13)A.co(A.ev(r,-864e13,864e13,"millisecondsSinceEpoch",null))
-A.dr(!0,"isUtc",t.y)
-return new A.bE(r,0,!0)}if(a instanceof RegExp)throw A.e(A.ak("structured clone of RegExp",null))
-if(a instanceof Promise)return A.f9(a,t.X)
+if(r<-864e13||r>864e13)A.cp(A.c3(r,-864e13,864e13,"millisecondsSinceEpoch",null))
+A.ds(!0,"isUtc",t.y)
+return new A.bH(r,0,!0)}if(a instanceof RegExp)throw A.e(A.al("structured clone of RegExp",null))
+if(a instanceof Promise)return A.ef(a,t.X)
 q=Object.getPrototypeOf(a)
 if(q===Object.prototype||q===null){p=t.X
-o=A.dO(p,p)
+o=A.dQ(p,p)
 s.v(0,a,o)
 n=Object.keys(a)
 m=[]
-for(s=J.cn(n),p=s.gp(n);p.m();)m.push(A.e6(p.gn()))
+for(s=J.dx(n),p=s.gp(n);p.m();)m.push(A.e8(p.gn()))
 for(l=0;l<s.gl(n);++l){k=s.j(n,l)
 if(!(l<m.length))return A.y(m,l)
 j=m[l]
 if(k!=null)o.v(0,j,this.$1(a[k]))}return o}if(a instanceof Array){i=a
 o=[]
 s.v(0,a,o)
-h=A.a1(a.length)
-for(s=J.cn(i),l=0;l<h;++l)o.push(this.$1(s.j(i,l)))
+h=A.a2(a.length)
+for(s=J.e9(i),l=0;l<h;++l)o.push(this.$1(s.j(i,l)))
 return o}return a},
 $S:3}
-A.dw.prototype={
+A.dy.prototype={
 $1(a){t.p.a(a)
-return A.eZ(this.a,this.b)},
+return A.f1(this.a,this.b)},
 $S:15}
-A.ca.prototype={
-aN(a){var s,r,q,p
-if(a==null)return null
-if(t.f.b(a)){s=A.dO(t.N,t.z)
-for(r=a.gD(),r=r.gp(r);r.m();){q=r.gn()
-p=q.a
-if(typeof p=="string")s.v(0,p,this.M(q.b))}return s}return A.C(["value",this.M(a)],t.N,t.z)},
-M(a){var s,r,q,p
-if(t.f.b(a)){s=A.dO(t.N,t.z)
-for(r=a.gD(),r=r.gp(r);r.m();){q=r.gn()
-p=q.a
-if(typeof p=="string")s.v(0,p,this.M(q.b))}return s}if(t.j.b(a)){r=J.eg(a,this.gaO(),t.X)
-r=A.fG(r,r.$ti.h("O.E"))
-return r}return a},
-saM(a){this.b=t.U.a(a)},
-sa4(a){this.c=t.U.a(a)}}
-A.cQ.prototype={
-$1(a){var s=A.de(a).data,r=s==null?null:A.e6(s)
-if(t.f.b(r)){s=t.X
-A.fW(r.Z(0,s,s))}},
+A.dm.prototype={
+$1(a){A.aa(a)
+return null},
 $S:16}
-A.cO.prototype={
-$1(a){var s=t.N,r=t.X,q=A.by(A.C(["type","workerMessage","payload",a],s,r))
-A.f9(A.de(A.bN(A.de(this.a.clients),"matchAll",A.by(A.C(["type","window","includeUncontrolled",!0],s,r)),null,r)),r).aU(new A.cN(q),t.P)},
-$S:4}
-A.cN.prototype={
-$1(a){var s,r,q,p
-if(!t.j.b(a))return
-for(s=J.dH(a),r=t.m,q=this.a;s.m();){p=s.gn()
-if(r.b(p))A.ep(p,"postMessage",q,null,null,null)}},
+A.cc.prototype={
+aP(a){var s,r,q,p
+if(a==null)return null
+if(t.f.b(a)){s=A.dQ(t.N,t.z)
+for(r=a.gD(),r=r.gp(r);r.m();){q=r.gn()
+p=q.a
+if(typeof p=="string")s.v(0,p,this.N(q.b))}return s}return A.B(["value",this.N(a)],t.N,t.z)},
+N(a){var s,r,q,p
+if(t.f.b(a)){s=A.dQ(t.N,t.z)
+for(r=a.gD(),r=r.gp(r);r.m();){q=r.gn()
+p=q.a
+if(typeof p=="string")s.v(0,p,this.N(q.b))}return s}if(t.j.b(a)){r=J.ek(a,this.gaQ(),t.X)
+r=A.fI(r,r.$ti.h("O.E"))
+return r}return a},
+saO(a){this.b=t.U.a(a)},
+sa4(a){this.c=t.U.a(a)}}
+A.cR.prototype={
+$1(a){var s=A.by(a).data,r=s==null?null:A.e8(s)
+if(t.f.b(r)){s=t.X
+A.fZ(r.Z(0,s,s))}},
 $S:17}
 A.cP.prototype={
+$1(a){var s=t.N,r=t.X,q=A.aG(A.B(["type","workerMessage","payload",a],s,r))
+A.ef(A.by(A.aT(A.by(this.a.clients),"matchAll",A.aG(A.B(["type","window","includeUncontrolled",!0],s,r)),null,r)),r).aW(new A.cO(q),t.P)},
+$S:4}
+A.cO.prototype={
+$1(a){var s,r,q,p
+if(!t.j.b(a))return
+for(s=J.dJ(a),r=t.m,q=this.a;s.m();){p=s.gn()
+if(r.b(p))A.et(p,"postMessage",q,null,null,null)}},
+$S:18}
+A.cQ.prototype={
 $1(a){var s=t.X
-A.bN(this.a,"postMessage",A.by(A.C(["type","workerMessage","payload",a],t.N,s)),null,s)},
-$S:4};(function aliases(){var s=J.Y.prototype
-s.an=s.i})();(function installTearOffs(){var s=hunkHelpers._static_1,r=hunkHelpers._static_0,q=hunkHelpers._static_2,p=hunkHelpers._instance_1u,o=hunkHelpers.installStaticTearOff
-s(A,"i4","h1",5)
-s(A,"i5","h2",5)
-s(A,"i6","h3",5)
-r(A,"f4","i_",0)
-r(A,"i9","iw",0)
-s(A,"i8","ij",4)
-q(A,"i7","e8",18)
-p(A.ca.prototype,"gaO","M",3)
-o(A,"ed",3,null,["$3"],["fY"],19,0)})();(function inheritance(){var s=hunkHelpers.mixin,r=hunkHelpers.inherit,q=hunkHelpers.inheritMany
-r(A.d,null)
-q(A.d,[A.dM,J.bI,A.b4,J.aI,A.b,A.aJ,A.k,A.X,A.l,A.f,A.cD,A.R,A.aY,A.A,A.b7,A.V,A.aL,A.bf,A.cE,A.cC,A.aO,A.bm,A.cy,A.aW,A.aV,A.J,A.cg,A.db,A.bo,A.cc,A.bn,A.H,A.ce,A.a8,A.v,A.cd,A.ci,A.bu,A.bd,A.bE,A.bG,A.bZ,A.b5,A.cV,A.p,A.q,A.cj,A.c5,A.cB,A.ca])
-q(J.bI,[J.bK,J.aQ,J.aS,J.aR,J.aT,J.bM,J.an])
-q(J.aS,[J.Y,J.x,A.ao,A.b0])
-q(J.Y,[J.c_,J.b6,J.N])
-r(J.bJ,A.b4)
-r(J.cx,J.x)
-q(J.bM,[J.aP,J.bL])
-q(A.b,[A.ar,A.c,A.a7,A.be,A.aw])
-r(A.a3,A.ar)
-r(A.ba,A.a3)
-q(A.k,[A.a4,A.a6,A.bb])
-q(A.X,[A.bC,A.cp,A.bB,A.c6,A.dx,A.dz,A.cS,A.cR,A.di,A.d3,A.d8,A.cz,A.dB,A.dE,A.dF,A.ds,A.dw,A.cQ,A.cO,A.cN,A.cP])
-q(A.bC,[A.cq,A.dy,A.dj,A.dq,A.d4,A.cA])
-q(A.l,[A.bP,A.T,A.bO,A.c9,A.c2,A.cf,A.bz,A.Q,A.b8,A.c8,A.c3,A.bD])
-r(A.aq,A.f)
-r(A.aK,A.aq)
-q(A.c,[A.O,A.aX,A.aU,A.bc])
-r(A.aN,A.a7)
+A.aT(this.a,"postMessage",A.aG(A.B(["type","workerMessage","payload",a],t.N,s)),null,s)},
+$S:4};(function aliases(){var s=J.Z.prototype
+s.ap=s.i})();(function installTearOffs(){var s=hunkHelpers._static_1,r=hunkHelpers._static_0,q=hunkHelpers._static_2,p=hunkHelpers._instance_1u,o=hunkHelpers.installStaticTearOff
+s(A,"i8","h4",5)
+s(A,"i9","h5",5)
+s(A,"ia","h6",5)
+r(A,"f8","i3",0)
+r(A,"id","iA",0)
+s(A,"ic","io",4)
+q(A,"ib","eb",19)
+p(A.cc.prototype,"gaQ","N",3)
+o(A,"eh",3,null,["$3"],["h0"],20,0)})();(function inheritance(){var s=hunkHelpers.mixin,r=hunkHelpers.inherit,q=hunkHelpers.inheritMany
+r(A.c,null)
+q(A.c,[A.dO,J.bL,A.b7,J.aJ,A.b,A.aK,A.k,A.Y,A.l,A.f,A.cE,A.R,A.b0,A.A,A.ba,A.W,A.aM,A.bi,A.cF,A.cD,A.aP,A.bp,A.cz,A.aZ,A.aY,A.J,A.ci,A.dc,A.br,A.ce,A.bq,A.H,A.cg,A.V,A.r,A.cf,A.ck,A.bx,A.bg,A.bH,A.bJ,A.c_,A.b8,A.cW,A.q,A.p,A.cl,A.c7,A.cC,A.cc])
+q(J.bL,[J.bN,J.aR,J.aV,J.aU,J.aW,J.aS,J.ao])
+q(J.aV,[J.Z,J.x,A.ap,A.b3])
+q(J.Z,[J.c0,J.b9,J.N])
+r(J.bM,A.b7)
+r(J.cy,J.x)
+q(J.aS,[J.aQ,J.bO])
+q(A.b,[A.as,A.d,A.a8,A.bh,A.ax])
+r(A.a4,A.as)
+r(A.bd,A.a4)
+q(A.k,[A.a5,A.a7,A.be])
+q(A.Y,[A.bF,A.cq,A.bE,A.c8,A.dz,A.dB,A.cT,A.cS,A.di,A.d4,A.d9,A.cA,A.dD,A.dG,A.dH,A.dt,A.dy,A.dm,A.cR,A.cP,A.cO,A.cQ])
+q(A.bF,[A.cr,A.dA,A.dj,A.dr,A.d5,A.cB])
+q(A.l,[A.bQ,A.T,A.bP,A.cb,A.c4,A.ch,A.bC,A.Q,A.bb,A.ca,A.c5,A.bG])
+r(A.ar,A.f)
+r(A.aL,A.ar)
+q(A.d,[A.O,A.b_,A.aX,A.bf])
+r(A.aO,A.a8)
 r(A.S,A.O)
-q(A.V,[A.au,A.av])
-r(A.bk,A.au)
-r(A.bl,A.av)
-r(A.aM,A.aL)
-r(A.b2,A.T)
-q(A.c6,[A.c4,A.al])
-q(A.b0,[A.bQ,A.ap])
-q(A.ap,[A.bg,A.bi])
-r(A.bh,A.bg)
-r(A.aZ,A.bh)
-r(A.bj,A.bi)
-r(A.b_,A.bj)
-q(A.aZ,[A.bR,A.bS])
-q(A.b_,[A.bT,A.bU,A.bV,A.bW,A.bX,A.b1,A.bY])
-r(A.bp,A.cf)
-q(A.bB,[A.cT,A.cU,A.da,A.d9,A.cW,A.d_,A.cZ,A.cY,A.cX,A.d2,A.d1,A.d0,A.dn,A.d7])
-r(A.b9,A.ce)
-r(A.ch,A.bu)
-r(A.at,A.bb)
-q(A.Q,[A.b3,A.bH])
-s(A.aq,A.b7)
-s(A.bg,A.f)
-s(A.bh,A.A)
-s(A.bi,A.f)
-s(A.bj,A.A)})()
-var v={G:typeof self!="undefined"?self:globalThis,typeUniverse:{eC:new Map(),tR:{},eT:{},tPV:{},sEA:[]},mangledGlobalNames:{a:"int",h:"double",ai:"num",u:"String",ad:"bool",q:"Null",i:"List",d:"Object",D:"Map",o:"JSObject"},mangledNames:{},types:["~()","q()","~(@)","d?(d?)","~(d?)","~(~())","q(@)","@(@)","@(@,u)","@(u)","q(~())","q(@,Z)","~(a,@)","q(d,Z)","~(d?,d?)","~(c7)","q(o)","q(d?)","M<ad>(u,D<u,@>?)","~(u,d?,N)"],interceptorsByTag:null,leafTags:null,arrayRti:Symbol("$ti"),rttc:{"2;":(a,b)=>c=>c instanceof A.bk&&a.b(c.a)&&b.b(c.b),"3;inputData,requestId,taskName":(a,b,c)=>d=>d instanceof A.bl&&a.b(d.a)&&b.b(d.b)&&c.b(d.c)}}
-A.hi(v.typeUniverse,JSON.parse('{"N":"Y","c_":"Y","b6":"Y","iy":"ao","bK":{"ad":[],"j":[]},"aQ":{"q":[],"j":[]},"aS":{"o":[]},"Y":{"o":[]},"x":{"i":["1"],"c":["1"],"o":[],"b":["1"]},"bJ":{"b4":[]},"cx":{"x":["1"],"i":["1"],"c":["1"],"o":[],"b":["1"]},"aI":{"z":["1"]},"bM":{"h":[],"ai":[]},"aP":{"h":[],"a":[],"ai":[],"j":[]},"bL":{"h":[],"ai":[],"j":[]},"an":{"u":[],"j":[]},"ar":{"b":["2"]},"aJ":{"z":["2"]},"a3":{"ar":["1","2"],"b":["2"],"b.E":"2"},"ba":{"a3":["1","2"],"ar":["1","2"],"c":["2"],"b":["2"],"b.E":"2"},"a4":{"k":["3","4"],"D":["3","4"],"k.K":"3","k.V":"4"},"bP":{"l":[]},"aK":{"f":["a"],"b7":["a"],"i":["a"],"c":["a"],"b":["a"],"f.E":"a"},"c":{"b":["1"]},"O":{"c":["1"],"b":["1"]},"R":{"z":["1"]},"a7":{"b":["2"],"b.E":"2"},"aN":{"a7":["1","2"],"c":["2"],"b":["2"],"b.E":"2"},"aY":{"z":["2"]},"S":{"O":["2"],"c":["2"],"b":["2"],"b.E":"2","O.E":"2"},"aq":{"f":["1"],"b7":["1"],"i":["1"],"c":["1"],"b":["1"]},"bk":{"au":[],"V":[]},"bl":{"av":[],"V":[]},"aL":{"D":["1","2"]},"aM":{"aL":["1","2"],"D":["1","2"]},"be":{"b":["1"],"b.E":"1"},"bf":{"z":["1"]},"b2":{"T":[],"l":[]},"bO":{"l":[]},"c9":{"l":[]},"bm":{"Z":[]},"X":{"a5":[]},"bB":{"a5":[]},"bC":{"a5":[]},"c6":{"a5":[]},"c4":{"a5":[]},"al":{"a5":[]},"c2":{"l":[]},"a6":{"k":["1","2"],"eq":["1","2"],"D":["1","2"],"k.K":"1","k.V":"2"},"aX":{"c":["1"],"b":["1"],"b.E":"1"},"aW":{"z":["1"]},"aU":{"c":["p<1,2>"],"b":["p<1,2>"],"b.E":"p<1,2>"},"aV":{"z":["p<1,2>"]},"au":{"V":[]},"av":{"V":[]},"ao":{"o":[],"dK":[],"j":[]},"b0":{"o":[]},"bQ":{"dL":[],"o":[],"j":[]},"ap":{"B":["1"],"o":[]},"aZ":{"f":["h"],"i":["h"],"B":["h"],"c":["h"],"o":[],"b":["h"],"A":["h"]},"b_":{"f":["a"],"i":["a"],"B":["a"],"c":["a"],"o":[],"b":["a"],"A":["a"]},"bR":{"cs":[],"f":["h"],"i":["h"],"B":["h"],"c":["h"],"o":[],"b":["h"],"A":["h"],"j":[],"f.E":"h"},"bS":{"ct":[],"f":["h"],"i":["h"],"B":["h"],"c":["h"],"o":[],"b":["h"],"A":["h"],"j":[],"f.E":"h"},"bT":{"cu":[],"f":["a"],"i":["a"],"B":["a"],"c":["a"],"o":[],"b":["a"],"A":["a"],"j":[],"f.E":"a"},"bU":{"cv":[],"f":["a"],"i":["a"],"B":["a"],"c":["a"],"o":[],"b":["a"],"A":["a"],"j":[],"f.E":"a"},"bV":{"cw":[],"f":["a"],"i":["a"],"B":["a"],"c":["a"],"o":[],"b":["a"],"A":["a"],"j":[],"f.E":"a"},"bW":{"cG":[],"f":["a"],"i":["a"],"B":["a"],"c":["a"],"o":[],"b":["a"],"A":["a"],"j":[],"f.E":"a"},"bX":{"cH":[],"f":["a"],"i":["a"],"B":["a"],"c":["a"],"o":[],"b":["a"],"A":["a"],"j":[],"f.E":"a"},"b1":{"cI":[],"f":["a"],"i":["a"],"B":["a"],"c":["a"],"o":[],"b":["a"],"A":["a"],"j":[],"f.E":"a"},"bY":{"cJ":[],"f":["a"],"i":["a"],"B":["a"],"c":["a"],"o":[],"b":["a"],"A":["a"],"j":[],"f.E":"a"},"cf":{"l":[]},"bp":{"T":[],"l":[]},"bo":{"c7":[]},"bn":{"z":["1"]},"aw":{"b":["1"],"b.E":"1"},"H":{"l":[]},"b9":{"ce":["1"]},"v":{"M":["1"]},"bu":{"eC":[]},"ch":{"bu":[],"eC":[]},"bb":{"k":["1","2"],"D":["1","2"]},"at":{"bb":["1","2"],"k":["1","2"],"D":["1","2"],"k.K":"1","k.V":"2"},"bc":{"c":["1"],"b":["1"],"b.E":"1"},"bd":{"z":["1"]},"f":{"i":["1"],"c":["1"],"b":["1"]},"k":{"D":["1","2"]},"h":{"ai":[]},"a":{"ai":[]},"i":{"c":["1"],"b":["1"]},"bz":{"l":[]},"T":{"l":[]},"Q":{"l":[]},"b3":{"l":[]},"bH":{"l":[]},"b8":{"l":[]},"c8":{"l":[]},"c3":{"l":[]},"bD":{"l":[]},"bZ":{"l":[]},"b5":{"l":[]},"cj":{"Z":[]},"cw":{"i":["a"],"c":["a"],"b":["a"]},"cJ":{"i":["a"],"c":["a"],"b":["a"]},"cI":{"i":["a"],"c":["a"],"b":["a"]},"cu":{"i":["a"],"c":["a"],"b":["a"]},"cG":{"i":["a"],"c":["a"],"b":["a"]},"cv":{"i":["a"],"c":["a"],"b":["a"]},"cH":{"i":["a"],"c":["a"],"b":["a"]},"cs":{"i":["h"],"c":["h"],"b":["h"]},"ct":{"i":["h"],"c":["h"],"b":["h"]}}'))
-A.hh(v.typeUniverse,JSON.parse('{"aq":1,"ap":1}'))
+q(A.W,[A.av,A.aw])
+r(A.bn,A.av)
+r(A.bo,A.aw)
+r(A.aN,A.aM)
+r(A.b5,A.T)
+q(A.c8,[A.c6,A.am])
+q(A.b3,[A.bR,A.aq])
+q(A.aq,[A.bj,A.bl])
+r(A.bk,A.bj)
+r(A.b1,A.bk)
+r(A.bm,A.bl)
+r(A.b2,A.bm)
+q(A.b1,[A.bS,A.bT])
+q(A.b2,[A.bU,A.bV,A.bW,A.bX,A.bY,A.b4,A.bZ])
+r(A.bs,A.ch)
+q(A.bE,[A.cU,A.cV,A.db,A.da,A.cX,A.d0,A.d_,A.cZ,A.cY,A.d3,A.d2,A.d1,A.dp,A.d8])
+r(A.bc,A.cg)
+r(A.cj,A.bx)
+r(A.au,A.be)
+q(A.Q,[A.b6,A.bK])
+s(A.ar,A.ba)
+s(A.bj,A.f)
+s(A.bk,A.A)
+s(A.bl,A.f)
+s(A.bm,A.A)})()
+var v={G:typeof self!="undefined"?self:globalThis,typeUniverse:{eC:new Map(),tR:{},eT:{},tPV:{},sEA:[]},mangledGlobalNames:{a:"int",h:"double",aj:"num",v:"String",ae:"bool",p:"Null",i:"List",c:"Object",D:"Map",o:"JSObject"},mangledNames:{},types:["~()","p()","~(@)","c?(c?)","~(c?)","~(~())","p(@)","@(@)","@(@,v)","@(v)","p(~())","p(@,a_)","~(a,@)","p(c,a_)","~(c?,c?)","~(c9)","p(c)","p(o)","p(c?)","M<ae>(v,D<v,@>?)","~(v,c?,N)"],interceptorsByTag:null,leafTags:null,arrayRti:Symbol("$ti"),rttc:{"2;":(a,b)=>c=>c instanceof A.bn&&a.b(c.a)&&b.b(c.b),"3;inputData,requestId,taskName":(a,b,c)=>d=>d instanceof A.bo&&a.b(d.a)&&b.b(d.b)&&c.b(d.c)}}
+A.hl(v.typeUniverse,JSON.parse('{"N":"Z","c0":"Z","b9":"Z","iC":"ap","bN":{"ae":[],"j":[]},"aR":{"p":[],"j":[]},"aV":{"o":[]},"Z":{"o":[]},"x":{"i":["1"],"d":["1"],"o":[],"b":["1"]},"bM":{"b7":[]},"cy":{"x":["1"],"i":["1"],"d":["1"],"o":[],"b":["1"]},"aJ":{"z":["1"]},"aS":{"h":[],"aj":[]},"aQ":{"h":[],"a":[],"aj":[],"j":[]},"bO":{"h":[],"aj":[],"j":[]},"ao":{"v":[],"j":[]},"as":{"b":["2"]},"aK":{"z":["2"]},"a4":{"as":["1","2"],"b":["2"],"b.E":"2"},"bd":{"a4":["1","2"],"as":["1","2"],"d":["2"],"b":["2"],"b.E":"2"},"a5":{"k":["3","4"],"D":["3","4"],"k.K":"3","k.V":"4"},"bQ":{"l":[]},"aL":{"f":["a"],"ba":["a"],"i":["a"],"d":["a"],"b":["a"],"f.E":"a"},"d":{"b":["1"]},"O":{"d":["1"],"b":["1"]},"R":{"z":["1"]},"a8":{"b":["2"],"b.E":"2"},"aO":{"a8":["1","2"],"d":["2"],"b":["2"],"b.E":"2"},"b0":{"z":["2"]},"S":{"O":["2"],"d":["2"],"b":["2"],"b.E":"2","O.E":"2"},"ar":{"f":["1"],"ba":["1"],"i":["1"],"d":["1"],"b":["1"]},"bn":{"av":[],"W":[]},"bo":{"aw":[],"W":[]},"aM":{"D":["1","2"]},"aN":{"aM":["1","2"],"D":["1","2"]},"bh":{"b":["1"],"b.E":"1"},"bi":{"z":["1"]},"b5":{"T":[],"l":[]},"bP":{"l":[]},"cb":{"l":[]},"bp":{"a_":[]},"Y":{"a6":[]},"bE":{"a6":[]},"bF":{"a6":[]},"c8":{"a6":[]},"c6":{"a6":[]},"am":{"a6":[]},"c4":{"l":[]},"a7":{"k":["1","2"],"eu":["1","2"],"D":["1","2"],"k.K":"1","k.V":"2"},"b_":{"d":["1"],"b":["1"],"b.E":"1"},"aZ":{"z":["1"]},"aX":{"d":["q<1,2>"],"b":["q<1,2>"],"b.E":"q<1,2>"},"aY":{"z":["q<1,2>"]},"av":{"W":[]},"aw":{"W":[]},"ap":{"o":[],"dM":[],"j":[]},"b3":{"o":[]},"bR":{"dN":[],"o":[],"j":[]},"aq":{"C":["1"],"o":[]},"b1":{"f":["h"],"i":["h"],"C":["h"],"d":["h"],"o":[],"b":["h"],"A":["h"]},"b2":{"f":["a"],"i":["a"],"C":["a"],"d":["a"],"o":[],"b":["a"],"A":["a"]},"bS":{"ct":[],"f":["h"],"i":["h"],"C":["h"],"d":["h"],"o":[],"b":["h"],"A":["h"],"j":[],"f.E":"h"},"bT":{"cu":[],"f":["h"],"i":["h"],"C":["h"],"d":["h"],"o":[],"b":["h"],"A":["h"],"j":[],"f.E":"h"},"bU":{"cv":[],"f":["a"],"i":["a"],"C":["a"],"d":["a"],"o":[],"b":["a"],"A":["a"],"j":[],"f.E":"a"},"bV":{"cw":[],"f":["a"],"i":["a"],"C":["a"],"d":["a"],"o":[],"b":["a"],"A":["a"],"j":[],"f.E":"a"},"bW":{"cx":[],"f":["a"],"i":["a"],"C":["a"],"d":["a"],"o":[],"b":["a"],"A":["a"],"j":[],"f.E":"a"},"bX":{"cH":[],"f":["a"],"i":["a"],"C":["a"],"d":["a"],"o":[],"b":["a"],"A":["a"],"j":[],"f.E":"a"},"bY":{"cI":[],"f":["a"],"i":["a"],"C":["a"],"d":["a"],"o":[],"b":["a"],"A":["a"],"j":[],"f.E":"a"},"b4":{"cJ":[],"f":["a"],"i":["a"],"C":["a"],"d":["a"],"o":[],"b":["a"],"A":["a"],"j":[],"f.E":"a"},"bZ":{"cK":[],"f":["a"],"i":["a"],"C":["a"],"d":["a"],"o":[],"b":["a"],"A":["a"],"j":[],"f.E":"a"},"ch":{"l":[]},"bs":{"T":[],"l":[]},"br":{"c9":[]},"bq":{"z":["1"]},"ax":{"b":["1"],"b.E":"1"},"H":{"l":[]},"bc":{"cg":["1"]},"r":{"M":["1"]},"bx":{"eF":[]},"cj":{"bx":[],"eF":[]},"be":{"k":["1","2"],"D":["1","2"]},"au":{"be":["1","2"],"k":["1","2"],"D":["1","2"],"k.K":"1","k.V":"2"},"bf":{"d":["1"],"b":["1"],"b.E":"1"},"bg":{"z":["1"]},"f":{"i":["1"],"d":["1"],"b":["1"]},"k":{"D":["1","2"]},"h":{"aj":[]},"a":{"aj":[]},"i":{"d":["1"],"b":["1"]},"bC":{"l":[]},"T":{"l":[]},"Q":{"l":[]},"b6":{"l":[]},"bK":{"l":[]},"bb":{"l":[]},"ca":{"l":[]},"c5":{"l":[]},"bG":{"l":[]},"c_":{"l":[]},"b8":{"l":[]},"cl":{"a_":[]},"cx":{"i":["a"],"d":["a"],"b":["a"]},"cK":{"i":["a"],"d":["a"],"b":["a"]},"cJ":{"i":["a"],"d":["a"],"b":["a"]},"cv":{"i":["a"],"d":["a"],"b":["a"]},"cH":{"i":["a"],"d":["a"],"b":["a"]},"cw":{"i":["a"],"d":["a"],"b":["a"]},"cI":{"i":["a"],"d":["a"],"b":["a"]},"ct":{"i":["h"],"d":["h"],"b":["h"]},"cu":{"i":["h"],"d":["h"],"b":["h"]}}'))
+A.hk(v.typeUniverse,JSON.parse('{"ar":1,"aq":1}'))
 var u={c:"Error handler must accept one Object or one Object and a StackTrace as arguments, and return a value of the returned future's type"}
-var t=(function rtii(){var s=A.dv
-return{n:s("H"),J:s("dK"),Y:s("dL"),V:s("aK"),O:s("c<@>"),C:s("l"),B:s("cs"),q:s("ct"),Z:s("a5"),e:s("M<ad>(u,D<u,@>?)"),W:s("cu"),k:s("cv"),D:s("cw"),R:s("b<@>"),G:s("x<d>"),s:s("x<u>"),b:s("x<@>"),T:s("aQ"),m:s("o"),g:s("N"),E:s("B<@>"),j:s("i<@>"),f:s("D<@,@>"),P:s("q"),K:s("d"),L:s("iz"),r:s("+()"),t:s("+(d?,u?)"),l:s("Z"),N:s("u"),p:s("c7"),w:s("j"),c:s("T"),a:s("cG"),x:s("cH"),ca:s("cI"),bX:s("cJ"),cr:s("b6"),_:s("v<@>"),A:s("at<d?,d?>"),y:s("ad"),bG:s("ad(d)"),i:s("h"),z:s("@"),bd:s("@()"),v:s("@(d)"),Q:s("@(d,Z)"),S:s("a"),bc:s("M<q>?"),aQ:s("o?"),h:s("D<u,@>?"),X:s("d?"),aD:s("u?"),F:s("a8<@,@>?"),u:s("ad?"),I:s("h?"),a3:s("a?"),ae:s("ai?"),U:s("~(d?)?"),o:s("ai"),H:s("~"),M:s("~()"),d:s("~(c7)")}})();(function constants(){B.t=J.bI.prototype
+var t=(function rtii(){var s=A.dw
+return{n:s("H"),J:s("dM"),Y:s("dN"),V:s("aL"),O:s("d<@>"),C:s("l"),B:s("ct"),q:s("cu"),Z:s("a6"),e:s("M<ae>(v,D<v,@>?)"),W:s("cv"),k:s("cw"),D:s("cx"),R:s("b<@>"),G:s("x<c>"),s:s("x<v>"),b:s("x<@>"),T:s("aR"),m:s("o"),g:s("N"),E:s("C<@>"),j:s("i<@>"),f:s("D<@,@>"),P:s("p"),K:s("c"),L:s("iD"),r:s("+()"),t:s("+(c?,v?)"),l:s("a_"),N:s("v"),p:s("c9"),w:s("j"),c:s("T"),a:s("cH"),x:s("cI"),ca:s("cJ"),bX:s("cK"),cr:s("b9"),_:s("r<@>"),A:s("au<c?,c?>"),y:s("ae"),bG:s("ae(c)"),i:s("h"),z:s("@"),bd:s("@()"),v:s("@(c)"),Q:s("@(c,a_)"),S:s("a"),bc:s("M<p>?"),aQ:s("o?"),h:s("D<v,@>?"),X:s("c?"),aD:s("v?"),F:s("V<@,@>?"),u:s("ae?"),I:s("h?"),a3:s("a?"),ae:s("aj?"),U:s("~(c?)?"),o:s("aj"),H:s("~"),M:s("~()"),d:s("~(c9)")}})();(function constants(){B.u=J.bL.prototype
 B.a=J.x.prototype
-B.c=J.aP.prototype
-B.u=J.an.prototype
-B.v=J.N.prototype
-B.w=J.aS.prototype
-B.j=J.c_.prototype
-B.f=J.b6.prototype
+B.c=J.aQ.prototype
+B.v=J.aS.prototype
+B.j=J.ao.prototype
+B.w=J.N.prototype
+B.x=J.aV.prototype
+B.k=J.c0.prototype
+B.f=J.b9.prototype
 B.h=function getTagFallback(o) {
   var s = Object.prototype.toString.call(o);
   return s.substring(8, s.length - 1);
 }
-B.k=function() {
+B.l=function() {
   var toStringFunction = Object.prototype.toString;
   function getTag(o) {
     var s = toStringFunction.call(o);
@@ -3234,7 +3270,7 @@ B.k=function() {
     prototypeForTag: prototypeForTag,
     discriminator: discriminator };
 }
-B.p=function(getTagFallback) {
+B.q=function(getTagFallback) {
   return function(hooks) {
     if (typeof navigator != "object") return hooks;
     var userAgent = navigator.userAgent;
@@ -3249,11 +3285,11 @@ B.p=function(getTagFallback) {
     hooks.getTag = getTagFallback;
   };
 }
-B.l=function(hooks) {
+B.m=function(hooks) {
   if (typeof dartExperimentalFixupGetTag != "function") return hooks;
   hooks.getTag = dartExperimentalFixupGetTag(hooks.getTag);
 }
-B.o=function(hooks) {
+B.p=function(hooks) {
   if (typeof navigator != "object") return hooks;
   var userAgent = navigator.userAgent;
   if (typeof userAgent != "string") return hooks;
@@ -3272,7 +3308,7 @@ B.o=function(hooks) {
   }
   hooks.getTag = getTagFirefox;
 }
-B.n=function(hooks) {
+B.o=function(hooks) {
   if (typeof navigator != "object") return hooks;
   var userAgent = navigator.userAgent;
   if (typeof userAgent != "string") return hooks;
@@ -3303,7 +3339,7 @@ B.n=function(hooks) {
   hooks.getTag = getTagIE;
   hooks.prototypeForTag = prototypeForTagIE;
 }
-B.m=function(hooks) {
+B.n=function(hooks) {
   var getTag = hooks.getTag;
   var prototypeForTag = hooks.prototypeForTag;
   function getTagFixed(o) {
@@ -3323,62 +3359,62 @@ B.m=function(hooks) {
 }
 B.i=function(hooks) { return hooks; }
 
-B.q=new A.bZ()
-B.d=new A.cD()
-B.b=new A.ch()
-B.e=new A.cj()
-B.r=new A.bG(3e6)
-B.y={cardiff:0,taipei:1}
-B.x=new A.aM(B.y,[11,26],A.dv("aM<u,h>"))
-B.z=A.L("dK")
-B.A=A.L("dL")
-B.B=A.L("cs")
+B.r=new A.c_()
+B.d=new A.cE()
+B.b=new A.cj()
+B.e=new A.cl()
+B.t=new A.bJ(3e6)
+B.z={cardiff:0,taipei:1}
+B.y=new A.aN(B.z,[11,26],A.dw("aN<v,h>"))
+B.A=A.L("dM")
+B.B=A.L("dN")
 B.C=A.L("ct")
 B.D=A.L("cu")
 B.E=A.L("cv")
 B.F=A.L("cw")
-B.G=A.L("d")
-B.H=A.L("cG")
+B.G=A.L("cx")
+B.H=A.L("c")
 B.I=A.L("cH")
 B.J=A.L("cI")
-B.K=A.L("cJ")})();(function staticFields(){$.d5=null
+B.K=A.L("cJ")
+B.L=A.L("cK")})();(function staticFields(){$.d6=null
 $.G=A.K([],t.G)
-$.es=null
-$.ek=null
-$.ej=null
-$.f7=null
-$.f3=null
+$.ew=null
+$.eo=null
+$.en=null
 $.fa=null
-$.du=null
-$.dA=null
-$.e9=null
-$.d6=A.K([],A.dv("x<i<d>?>"))
+$.f7=null
+$.fc=null
+$.dv=null
+$.dC=null
+$.ec=null
+$.d7=A.K([],A.dw("x<i<c>?>"))
 $.aA=null
-$.bv=null
-$.bw=null
-$.e1=!1
-$.n=B.b
-$.bx=null
-$.eB=!1})();(function lazyInitializers(){var s=hunkHelpers.lazyFinal
-s($,"ix","ee",()=>A.ie("_$dart_dartClosure"))
-s($,"iO","fn",()=>A.K([new J.bJ()],A.dv("x<b4>")))
-s($,"iB","fd",()=>A.U(A.cF({
+$.bz=null
+$.bA=null
+$.e3=!1
+$.m=B.b
+$.bB=null
+$.eE=!1})();(function lazyInitializers(){var s=hunkHelpers.lazyFinal
+s($,"iB","ei",()=>A.ij("_$dart_dartClosure"))
+s($,"iS","fp",()=>A.K([new J.bM()],A.dw("x<b7>")))
+s($,"iF","ff",()=>A.U(A.cG({
 toString:function(){return"$receiver$"}})))
-s($,"iC","fe",()=>A.U(A.cF({$method$:null,
+s($,"iG","fg",()=>A.U(A.cG({$method$:null,
 toString:function(){return"$receiver$"}})))
-s($,"iD","ff",()=>A.U(A.cF(null)))
-s($,"iE","fg",()=>A.U(function(){var $argumentsExpr$="$arguments$"
+s($,"iH","fh",()=>A.U(A.cG(null)))
+s($,"iI","fi",()=>A.U(function(){var $argumentsExpr$="$arguments$"
 try{null.$method$($argumentsExpr$)}catch(r){return r.message}}()))
-s($,"iH","fj",()=>A.U(A.cF(void 0)))
-s($,"iI","fk",()=>A.U(function(){var $argumentsExpr$="$arguments$"
+s($,"iL","fl",()=>A.U(A.cG(void 0)))
+s($,"iM","fm",()=>A.U(function(){var $argumentsExpr$="$arguments$"
 try{(void 0).$method$($argumentsExpr$)}catch(r){return r.message}}()))
-s($,"iG","fi",()=>A.U(A.ez(null)))
-s($,"iF","fh",()=>A.U(function(){try{null.$method$}catch(r){return r.message}}()))
-s($,"iK","fm",()=>A.U(A.ez(void 0)))
-s($,"iJ","fl",()=>A.U(function(){try{(void 0).$method$}catch(r){return r.message}}()))
-s($,"iM","ef",()=>A.h0())
-s($,"iN","dG",()=>A.dD(B.G))
-s($,"iL","aG",()=>new A.ca())})();(function nativeSupport(){!function(){var s=function(a){var m={}
+s($,"iK","fk",()=>A.U(A.eC(null)))
+s($,"iJ","fj",()=>A.U(function(){try{null.$method$}catch(r){return r.message}}()))
+s($,"iO","fo",()=>A.U(A.eC(void 0)))
+s($,"iN","fn",()=>A.U(function(){try{(void 0).$method$}catch(r){return r.message}}()))
+s($,"iQ","ej",()=>A.h3())
+s($,"iR","dI",()=>A.dF(B.H))
+s($,"iP","aH",()=>new A.cc())})();(function nativeSupport(){!function(){var s=function(a){var m={}
 m[a]=1
 return Object.keys(hunkHelpers.convertToFastObject(m))[0]}
 v.getIsolateTag=function(a){return s("___dart_"+a+v.isolateTag)}
@@ -3389,15 +3425,15 @@ for(var o=0;;o++){var n=s(p+"_"+o+"_")
 if(!(n in q)){q[n]=1
 v.isolateTag=n
 break}}v.dispatchPropertyName=v.getIsolateTag("dispatch_record")}()
-hunkHelpers.setOrUpdateInterceptorsByTag({ArrayBuffer:A.ao,SharedArrayBuffer:A.ao,ArrayBufferView:A.b0,DataView:A.bQ,Float32Array:A.bR,Float64Array:A.bS,Int16Array:A.bT,Int32Array:A.bU,Int8Array:A.bV,Uint16Array:A.bW,Uint32Array:A.bX,Uint8ClampedArray:A.b1,CanvasPixelArray:A.b1,Uint8Array:A.bY})
+hunkHelpers.setOrUpdateInterceptorsByTag({ArrayBuffer:A.ap,SharedArrayBuffer:A.ap,ArrayBufferView:A.b3,DataView:A.bR,Float32Array:A.bS,Float64Array:A.bT,Int16Array:A.bU,Int32Array:A.bV,Int8Array:A.bW,Uint16Array:A.bX,Uint32Array:A.bY,Uint8ClampedArray:A.b4,CanvasPixelArray:A.b4,Uint8Array:A.bZ})
 hunkHelpers.setOrUpdateLeafTags({ArrayBuffer:true,SharedArrayBuffer:true,ArrayBufferView:false,DataView:true,Float32Array:true,Float64Array:true,Int16Array:true,Int32Array:true,Int8Array:true,Uint16Array:true,Uint32Array:true,Uint8ClampedArray:true,CanvasPixelArray:true,Uint8Array:false})
-A.ap.$nativeSuperclassTag="ArrayBufferView"
-A.bg.$nativeSuperclassTag="ArrayBufferView"
-A.bh.$nativeSuperclassTag="ArrayBufferView"
-A.aZ.$nativeSuperclassTag="ArrayBufferView"
-A.bi.$nativeSuperclassTag="ArrayBufferView"
+A.aq.$nativeSuperclassTag="ArrayBufferView"
 A.bj.$nativeSuperclassTag="ArrayBufferView"
-A.b_.$nativeSuperclassTag="ArrayBufferView"})()
+A.bk.$nativeSuperclassTag="ArrayBufferView"
+A.b1.$nativeSuperclassTag="ArrayBufferView"
+A.bl.$nativeSuperclassTag="ArrayBufferView"
+A.bm.$nativeSuperclassTag="ArrayBufferView"
+A.b2.$nativeSuperclassTag="ArrayBufferView"})()
 Function.prototype.$1=function(a){return this(a)}
 Function.prototype.$2=function(a,b){return this(a,b)}
 Function.prototype.$0=function(){return this()}
@@ -3410,5 +3446,5 @@ convertToFastObject($);(function(a){if(typeof document==="undefined"){a(null)
 return}if(typeof document.currentScript!="undefined"){a(document.currentScript)
 return}var s=document.scripts
 function onLoad(b){for(var q=0;q<s.length;++q){s[q].removeEventListener("load",onLoad,false)}a(b.target)}for(var r=0;r<s.length;++r){s[r].addEventListener("load",onLoad,false)}})(function(a){v.currentScript=a
-var s=A.ir
+var s=A.iv
 if(typeof dartMainRunner==="function"){dartMainRunner(s,[])}else{s([])}})})()

--- a/example/web/background.dart.js
+++ b/example/web/background.dart.js
@@ -22,18 +22,18 @@ a[c]=function(){if(a[b]===s){a[b]=d()}a[c]=function(){return this[b]}
 return a[b]}}function lazyFinal(a,b,c,d){var s=a
 a[b]=s
 a[c]=function(){if(a[b]===s){var r=d()
-if(a[b]!==s){A.hW(b)}a[b]=r}var q=a[b]
+if(a[b]!==s){A.iu(b)}a[b]=r}var q=a[b]
 a[c]=function(){return q}
-return q}}function makeConstList(a,b){if(b!=null)A.H(a,b)
+return q}}function makeConstList(a,b){if(b!=null)A.K(a,b)
 a.$flags=7
 return a}function convertToFastObject(a){function t(){}t.prototype=a
 new t()
 return a}function convertAllToFastObject(a){for(var s=0;s<a.length;++s){convertToFastObject(a[s])}}var y=0
 function instanceTearOffGetter(a,b){var s=null
-return a?function(c){if(s===null)s=A.dz(b)
-return new s(c,this)}:function(){if(s===null)s=A.dz(b)
+return a?function(c){if(s===null)s=A.e5(b)
+return new s(c,this)}:function(){if(s===null)s=A.e5(b)
 return new s(this,null)}}function staticTearOffGetter(a){var s=null
-return function(){if(s===null)s=A.dz(a).prototype
+return function(){if(s===null)s=A.e5(a).prototype
 return s}}var x=0
 function tearOffParameters(a,b,c,d,e,f,g,h,i,j){if(typeof h=="number"){h+=x}return{co:a,iS:b,iI:c,rC:d,dV:e,cs:f,fs:g,fT:h,aI:i||0,nDA:j}}function installStaticTearOff(a,b,c,d,e,f,g,h){var s=tearOffParameters(a,true,false,c,d,e,f,g,h,false)
 var r=staticTearOffGetter(s)
@@ -52,225 +52,222 @@ return a}var hunkHelpers=function(){var s=function(a,b,c,d,e){return function(f,
 return{inherit:inherit,inheritMany:inheritMany,mixin:mixinEasy,mixinHard:mixinHard,installStaticTearOff:installStaticTearOff,installInstanceTearOff:installInstanceTearOff,_instance_0u:s(0,0,null,["$0"],0),_instance_1u:s(0,1,null,["$1"],0),_instance_2u:s(0,2,null,["$2"],0),_instance_0i:s(1,0,null,["$0"],0),_instance_1i:s(1,1,null,["$1"],0),_instance_2i:s(1,2,null,["$2"],0),_static_0:r(0,null,["$0"],0),_static_1:r(1,null,["$1"],0),_static_2:r(2,null,["$2"],0),makeConstList:makeConstList,lazy:lazy,lazyFinal:lazyFinal,updateHolder:updateHolder,convertToFastObject:convertToFastObject,updateTypes:updateTypes,setOrUpdateInterceptorsByTag:setOrUpdateInterceptorsByTag,setOrUpdateLeafTags:setOrUpdateLeafTags}}()
 function initializeDeferredHunk(a){x=v.types.length
 a(hunkHelpers,v,w,$)}var J={
-dI(a,b,c,d){return{i:a,p:b,e:c,x:d}},
-dD(a){var s,r,q,p,o,n=a[v.dispatchPropertyName]
-if(n==null)if($.dF==null){A.hN()
+eb(a,b,c,d){return{i:a,p:b,e:c,x:d}},
+e7(a){var s,r,q,p,o,n=a[v.dispatchPropertyName]
+if(n==null)if($.e9==null){A.il()
 n=a[v.dispatchPropertyName]}if(n!=null){s=n.p
 if(!1===s)return n.i
 if(!0===s)return a
 r=Object.getPrototypeOf(a)
 if(s===r)return n.i
-if(n.e===r)throw A.i(A.e6("Return interceptor for "+A.n(s(a,n))))}q=a.constructor
+if(n.e===r)throw A.e(A.eA("Return interceptor for "+A.m(s(a,n))))}q=a.constructor
 if(q==null)p=null
-else{o=$.cF
-if(o==null)o=$.cF=v.getIsolateTag("_$dart_js")
+else{o=$.d5
+if(o==null)o=$.d5=v.getIsolateTag("_$dart_js")
 p=q[o]}if(p!=null)return p
-p=A.hR(a)
+p=A.iq(a)
 if(p!=null)return p
-if(typeof a=="function")return B.r
+if(typeof a=="function")return B.v
 s=Object.getPrototypeOf(a)
 if(s==null)return B.j
 if(s===Object.prototype)return B.j
-if(typeof q=="function"){o=$.cF
-if(o==null)o=$.cF=v.getIsolateTag("_$dart_js")
+if(typeof q=="function"){o=$.d5
+if(o==null)o=$.d5=v.getIsolateTag("_$dart_js")
 Object.defineProperty(q,o,{value:B.f,enumerable:false,writable:true,configurable:true})
 return B.f}return B.f},
-f9(a,b){if(a>4294967295)throw A.i(A.e1(a,0,4294967295,"length",null))
-return J.fb(new Array(a),b)},
-fa(a,b){return A.H(new Array(a),b.h("t<0>"))},
-fb(a,b){var s=A.H(a,b.h("t<0>"))
+fD(a,b){if(a<0||a>4294967295)throw A.e(A.ev(a,0,4294967295,"length",null))
+return J.fF(new Array(a),b)},
+fE(a,b){if(a<0)throw A.e(A.ak("Length must be a non-negative integer: "+a,null))
+return A.K(new Array(a),b.h("x<0>"))},
+fF(a,b){var s=A.K(a,b.h("x<0>"))
 s.$flags=1
 return s},
-ab(a){if(typeof a=="number"){if(Math.floor(a)==a)return J.aD.prototype
-return J.bu.prototype}if(typeof a=="string")return J.aF.prototype
-if(a==null)return J.aE.prototype
-if(typeof a=="boolean")return J.bt.prototype
-if(Array.isArray(a))return J.t.prototype
-if(typeof a!="object"){if(typeof a=="function")return J.K.prototype
-if(typeof a=="symbol")return J.aI.prototype
-if(typeof a=="bigint")return J.aG.prototype
+af(a){if(typeof a=="number"){if(Math.floor(a)==a)return J.aP.prototype
+return J.bL.prototype}if(typeof a=="string")return J.an.prototype
+if(a==null)return J.aQ.prototype
+if(typeof a=="boolean")return J.bK.prototype
+if(Array.isArray(a))return J.x.prototype
+if(typeof a!="object"){if(typeof a=="function")return J.N.prototype
+if(typeof a=="symbol")return J.aT.prototype
+if(typeof a=="bigint")return J.aR.prototype
 return a}if(a instanceof A.d)return a
-return J.dD(a)},
-eE(a){if(typeof a=="string")return J.aF.prototype
+return J.e7(a)},
+f6(a){if(typeof a=="string")return J.an.prototype
 if(a==null)return a
-if(Array.isArray(a))return J.t.prototype
-if(typeof a!="object"){if(typeof a=="function")return J.K.prototype
-if(typeof a=="symbol")return J.aI.prototype
-if(typeof a=="bigint")return J.aG.prototype
+if(Array.isArray(a))return J.x.prototype
+if(typeof a!="object"){if(typeof a=="function")return J.N.prototype
+if(typeof a=="symbol")return J.aT.prototype
+if(typeof a=="bigint")return J.aR.prototype
 return a}if(a instanceof A.d)return a
-return J.dD(a)},
-dC(a){if(a==null)return a
-if(Array.isArray(a))return J.t.prototype
-if(typeof a!="object"){if(typeof a=="function")return J.K.prototype
-if(typeof a=="symbol")return J.aI.prototype
-if(typeof a=="bigint")return J.aG.prototype
+return J.e7(a)},
+cn(a){if(a==null)return a
+if(Array.isArray(a))return J.x.prototype
+if(typeof a!="object"){if(typeof a=="function")return J.N.prototype
+if(typeof a=="symbol")return J.aT.prototype
+if(typeof a=="bigint")return J.aR.prototype
 return a}if(a instanceof A.d)return a
-return J.dD(a)},
-Z(a,b){if(a==null)return b==null
+return J.e7(a)},
+P(a,b){if(a==null)return b==null
 if(typeof a!="object")return b!=null&&a===b
-return J.ab(a).B(a,b)},
-eU(a,b){return J.dC(a).J(a,b)},
-M(a){return J.ab(a).gn(a)},
-eV(a){return J.dC(a).gp(a)},
-da(a){return J.eE(a).gk(a)},
-eW(a){return J.ab(a).gq(a)},
-dO(a,b,c){return J.dC(a).K(a,b,c)},
-ax(a){return J.ab(a).i(a)},
-br:function br(){},
-bt:function bt(){},
-aE:function aE(){},
-aH:function aH(){},
-U:function U(){},
-bH:function bH(){},
-aW:function aW(){},
-K:function K(){},
-aG:function aG(){},
-aI:function aI(){},
-t:function t(a){this.$ti=a},
-bs:function bs(){},
-ca:function ca(a){this.$ti=a},
-az:function az(a,b,c){var _=this
+return J.af(a).C(a,b)},
+fo(a,b){return J.cn(a).K(a,b)},
+W(a){return J.af(a).gq(a)},
+dH(a){return J.cn(a).gp(a)},
+dI(a){return J.f6(a).gl(a)},
+fp(a){return J.af(a).gt(a)},
+eg(a,b,c){return J.cn(a).L(a,b,c)},
+aH(a){return J.af(a).i(a)},
+bI:function bI(){},
+bK:function bK(){},
+aQ:function aQ(){},
+aS:function aS(){},
+Y:function Y(){},
+c_:function c_(){},
+b6:function b6(){},
+N:function N(){},
+aR:function aR(){},
+aT:function aT(){},
+x:function x(a){this.$ti=a},
+bJ:function bJ(){},
+cx:function cx(a){this.$ti=a},
+aI:function aI(a,b,c){var _=this
 _.a=a
 _.b=b
 _.c=0
 _.d=null
 _.$ti=c},
-bv:function bv(){},
-aD:function aD(){},
-bu:function bu(){},
-aF:function aF(){}},A={df:function df(){},
-eZ(a,b,c){if(t.O.b(a))return new A.aZ(a,b.h("@<0>").j(c).h("aZ<1,2>"))
-return new A.a_(a,b.h("@<0>").j(c).h("a_<1,2>"))},
-W(a,b){a=a+b&536870911
+bM:function bM(){},
+aP:function aP(){},
+bL:function bL(){},
+an:function an(){}},A={dM:function dM(){},
+fs(a,b,c){if(t.O.b(a))return new A.ba(a,b.h("@<0>").k(c).h("ba<1,2>"))
+return new A.a3(a,b.h("@<0>").k(c).h("a3<1,2>"))},
+a_(a,b){a=a+b&536870911
 a=a+((a&524287)<<10)&536870911
 return a^a>>>6},
-dm(a){a=a+((a&67108863)<<3)&536870911
+dU(a){a=a+((a&67108863)<<3)&536870911
 a^=a>>>11
 return a+((a&16383)<<15)&536870911},
-cX(a,b,c){return a},
-dG(a){var s,r
-for(s=$.B.length,r=0;r<s;++r)if(a===$.B[r])return!0
+dr(a,b,c){return a},
+ea(a){var s,r
+for(s=$.G.length,r=0;r<s;++r)if(a===$.G[r])return!0
 return!1},
-dj(a,b,c,d){if(t.O.b(a))return new A.aB(a,b,c.h("@<0>").j(d).h("aB<1,2>"))
-return new A.a4(a,b,c.h("@<0>").j(d).h("a4<1,2>"))},
-aj:function aj(){},
-aA:function aA(a,b){this.a=a
+dQ(a,b,c,d){if(t.O.b(a))return new A.aN(a,b,c.h("@<0>").k(d).h("aN<1,2>"))
+return new A.a7(a,b,c.h("@<0>").k(d).h("a7<1,2>"))},
+ar:function ar(){},
+aJ:function aJ(a,b){this.a=a
 this.$ti=b},
-a_:function a_(a,b){this.a=a
+a3:function a3(a,b){this.a=a
 this.$ti=b},
-aZ:function aZ(a,b){this.a=a
+ba:function ba(a,b){this.a=a
 this.$ti=b},
-a0:function a0(a,b){this.a=a
+a4:function a4(a,b){this.a=a
 this.$ti=b},
-c3:function c3(a,b){this.a=a
+cq:function cq(a,b){this.a=a
 this.b=b},
-c2:function c2(a){this.a=a},
-bx:function bx(a){this.a=a},
-cg:function cg(){},
+cp:function cp(a){this.a=a},
+bP:function bP(a){this.a=a},
+aK:function aK(a){this.a=a},
+cD:function cD(){},
 c:function c(){},
-L:function L(){},
-a3:function a3(a,b,c){var _=this
+O:function O(){},
+R:function R(a,b,c){var _=this
 _.a=a
 _.b=b
 _.c=0
 _.d=null
 _.$ti=c},
-a4:function a4(a,b,c){this.a=a
+a7:function a7(a,b,c){this.a=a
 this.b=b
 this.$ti=c},
-aB:function aB(a,b,c){this.a=a
+aN:function aN(a,b,c){this.a=a
 this.b=b
 this.$ti=c},
-aN:function aN(a,b,c){var _=this
+aY:function aY(a,b,c){var _=this
 _.a=null
 _.b=a
 _.c=b
 _.$ti=c},
-P:function P(a,b,c){this.a=a
+S:function S(a,b,c){this.a=a
 this.b=b
 this.$ti=c},
-y:function y(){},
-eI(a){var s=v.mangledGlobalNames[a]
+A:function A(){},
+b7:function b7(){},
+aq:function aq(){},
+fc(a){var s=v.mangledGlobalNames[a]
 if(s!=null)return s
 return"minified:"+a},
-ih(a,b){var s
+iP(a,b){var s
 if(b!=null){s=b.x
-if(s!=null)return s}return t.p.b(a)},
-n(a){var s
+if(s!=null)return s}return t.E.b(a)},
+m(a){var s
 if(typeof a=="string")return a
 if(typeof a=="number"){if(a!==0)return""+a}else if(!0===a)return"true"
 else if(!1===a)return"false"
 else if(a==null)return"null"
-s=J.ax(a)
+s=J.aH(a)
 return s},
-bI(a){var s,r=$.dZ
-if(r==null)r=$.dZ=Symbol("identityHashCode")
+c0(a){var s,r=$.es
+if(r==null)r=$.es=Symbol("identityHashCode")
 s=a[r]
 if(s==null){s=Math.random()*0x3fffffff|0
 a[r]=s}return s},
-bJ(a){var s,r,q,p
-if(a instanceof A.d)return A.A(A.au(a),null)
-s=J.ab(a)
-if(s===B.q||s===B.t||t.G.b(a)){r=B.h(a)
+c1(a){var s,r,q,p
+if(a instanceof A.d)return A.F(A.aE(a),null)
+s=J.af(a)
+if(s===B.t||s===B.w||t.cr.b(a)){r=B.h(a)
 if(r!=="Object"&&r!=="")return r
 q=a.constructor
 if(typeof q=="function"){p=q.name
-if(typeof p=="string"&&p!=="Object"&&p!=="")return p}}return A.A(A.au(a),null)},
-e_(a){var s,r,q
-if(a==null||typeof a=="number"||A.cS(a))return J.ax(a)
+if(typeof p=="string"&&p!=="Object"&&p!=="")return p}}return A.F(A.aE(a),null)},
+et(a){var s,r,q
+if(a==null||typeof a=="number"||A.dk(a))return J.aH(a)
 if(typeof a=="string")return JSON.stringify(a)
-if(a instanceof A.T)return a.i(0)
-if(a instanceof A.S)return a.a8(!0)
-s=$.eT()
-for(r=0;r<1;++r){q=s[r].aE(a)
-if(q!=null)return q}return"Instance of '"+A.bJ(a)+"'"},
-ai(a){if(a.date===void 0)a.date=new Date(a.a)
+if(a instanceof A.X)return a.i(0)
+if(a instanceof A.V)return a.ag(!0)
+s=$.fn()
+for(r=0;r<1;++r){q=s[r].aV(a)
+if(q!=null)return q}return"Instance of '"+A.c1(a)+"'"},
+E(a){if(a.date===void 0)a.date=new Date(a.a)
 return a.date},
-fn(a){var s=A.ai(a).getUTCFullYear()+0
-return s},
-fl(a){var s=A.ai(a).getUTCMonth()+1
-return s},
-fh(a){var s=A.ai(a).getUTCDate()+0
-return s},
-fi(a){var s=A.ai(a).getUTCHours()+0
-return s},
-fk(a){var s=A.ai(a).getUTCMinutes()+0
-return s},
-fm(a){var s=A.ai(a).getUTCSeconds()+0
-return s},
-fj(a){var s=A.ai(a).getUTCMilliseconds()+0
-return s},
-fg(a){var s=a.$thrownJsError
+fQ(a){return a.c?A.E(a).getUTCFullYear()+0:A.E(a).getFullYear()+0},
+fO(a){return a.c?A.E(a).getUTCMonth()+1:A.E(a).getMonth()+1},
+fK(a){return a.c?A.E(a).getUTCDate()+0:A.E(a).getDate()+0},
+fL(a){return a.c?A.E(a).getUTCHours()+0:A.E(a).getHours()+0},
+fN(a){return a.c?A.E(a).getUTCMinutes()+0:A.E(a).getMinutes()+0},
+fP(a){return a.c?A.E(a).getUTCSeconds()+0:A.E(a).getSeconds()+0},
+fM(a){return a.c?A.E(a).getUTCMilliseconds()+0:A.E(a).getMilliseconds()+0},
+fJ(a){var s=a.$thrownJsError
 if(s==null)return null
-return A.at(s)},
-e0(a,b){var s
+return A.ag(s)},
+eu(a,b){var s
 if(a.$thrownJsError==null){s=new Error()
-A.r(a,s)
+A.w(a,s)
 a.$thrownJsError=s
 s.stack=b.i(0)}},
-x(a,b){if(a==null)J.da(a)
-throw A.i(A.eD(a,b))},
-eD(a,b){var s,r="index"
-if(!A.dw(b))return new A.N(!0,b,r,null)
-s=J.da(a)
-if(b<0||b>=s)return A.f7(b,s,a,r)
-return new A.aT(null,null,!0,b,r,"Value not in range")},
-i(a){return A.r(a,new Error())},
-r(a,b){var s
-if(a==null)a=new A.Q()
+y(a,b){if(a==null)J.dI(a)
+throw A.e(A.dt(a,b))},
+dt(a,b){var s,r="index"
+if(!A.e2(b))return new A.Q(!0,b,r,null)
+s=J.dI(a)
+if(b<0||b>=s)return A.fB(b,s,a,r)
+return new A.b3(null,null,!0,b,r,"Value not in range")},
+e(a){return A.w(a,new Error())},
+w(a,b){var s
+if(a==null)a=new A.T()
 b.dartException=a
-s=A.hX
+s=A.iv
 if("defineProperty" in Object){Object.defineProperty(b,"message",{get:s})
 b.name=""}else b.toString=s
 return b},
-hX(){return J.ax(this.dartException)},
-c1(a,b){throw A.r(a,b==null?new Error():b)},
-dK(a,b,c){var s
+iv(){return J.aH(this.dartException)},
+co(a,b){throw A.w(a,b==null?new Error():b)},
+ec(a,b,c){var s
 if(b==null)b=0
 if(c==null)c=0
 s=Error()
-A.c1(A.h0(a,b,c),s)},
-h0(a,b,c){var s,r,q,p,o,n,m,l,k
+A.co(A.hw(a,b,c),s)},
+hw(a,b,c){var s,r,q,p,o,n,m,l,k
 if(typeof b=="string")s=b
 else{r="[]=;add;removeWhere;retainWhere;removeRange;setRange;setInt8;setInt16;setInt32;setUint8;setUint16;setUint32;setFloat32;setFloat64".split(";")
 q=r.length
@@ -283,84 +280,84 @@ l="a "
 if((m&4)!==0)k="constant "
 else if((m&2)!==0){k="unmodifiable "
 l="an "}else k=(m&1)!==0?"fixed-length ":""
-return new A.aX("'"+s+"': Cannot "+o+" "+l+k+n)},
-dJ(a){throw A.i(A.af(a))},
-R(a){var s,r,q,p,o,n
-a=A.hV(a.replace(String({}),"$receiver$"))
+return new A.b8("'"+s+"': Cannot "+o+" "+l+k+n)},
+fb(a){throw A.e(A.am(a))},
+U(a){var s,r,q,p,o,n
+a=A.it(a.replace(String({}),"$receiver$"))
 s=a.match(/\\\$[a-zA-Z]+\\\$/g)
-if(s==null)s=A.H([],t.s)
+if(s==null)s=A.K([],t.s)
 r=s.indexOf("\\$arguments\\$")
 q=s.indexOf("\\$argumentsExpr\\$")
 p=s.indexOf("\\$expr\\$")
 o=s.indexOf("\\$method\\$")
 n=s.indexOf("\\$receiver\\$")
-return new A.ch(a.replace(new RegExp("\\\\\\$arguments\\\\\\$","g"),"((?:x|[^x])*)").replace(new RegExp("\\\\\\$argumentsExpr\\\\\\$","g"),"((?:x|[^x])*)").replace(new RegExp("\\\\\\$expr\\\\\\$","g"),"((?:x|[^x])*)").replace(new RegExp("\\\\\\$method\\\\\\$","g"),"((?:x|[^x])*)").replace(new RegExp("\\\\\\$receiver\\\\\\$","g"),"((?:x|[^x])*)"),r,q,p,o,n)},
-ci(a){return function($expr$){var $argumentsExpr$="$arguments$"
+return new A.cE(a.replace(new RegExp("\\\\\\$arguments\\\\\\$","g"),"((?:x|[^x])*)").replace(new RegExp("\\\\\\$argumentsExpr\\\\\\$","g"),"((?:x|[^x])*)").replace(new RegExp("\\\\\\$expr\\\\\\$","g"),"((?:x|[^x])*)").replace(new RegExp("\\\\\\$method\\\\\\$","g"),"((?:x|[^x])*)").replace(new RegExp("\\\\\\$receiver\\\\\\$","g"),"((?:x|[^x])*)"),r,q,p,o,n)},
+cF(a){return function($expr$){var $argumentsExpr$="$arguments$"
 try{$expr$.$method$($argumentsExpr$)}catch(s){return s.message}}(a)},
-e5(a){return function($expr$){try{$expr$.$method$}catch(s){return s.message}}(a)},
-dg(a,b){var s=b==null,r=s?null:b.method
-return new A.bw(a,r,s?null:b.receiver)},
-aw(a){var s
-if(a==null)return new A.cf(a)
-if(a instanceof A.aC){s=a.a
-return A.Y(a,s==null?A.bf(s):s)}if(typeof a!=="object")return a
-if("dartException" in a)return A.Y(a,a.dartException)
-return A.hy(a)},
-Y(a,b){if(t.C.b(b))if(b.$thrownJsError==null)b.$thrownJsError=a
+ez(a){return function($expr$){try{$expr$.$method$}catch(s){return s.message}}(a)},
+dN(a,b){var s=b==null,r=s?null:b.method
+return new A.bO(a,r,s?null:b.receiver)},
+aj(a){var s
+if(a==null)return new A.cC(a)
+if(a instanceof A.aO){s=a.a
+return A.a2(a,s==null?A.ay(s):s)}if(typeof a!=="object")return a
+if("dartException" in a)return A.a2(a,a.dartException)
+return A.i3(a)},
+a2(a,b){if(t.C.b(b))if(b.$thrownJsError==null)b.$thrownJsError=a
 return b},
-hy(a){var s,r,q,p,o,n,m,l,k,j,i,h,g
+i3(a){var s,r,q,p,o,n,m,l,k,j,i,h,g
 if(!("message" in a))return a
 s=a.message
 if("number" in a&&typeof a.number=="number"){r=a.number
 q=r&65535
-if((B.e.ap(r,16)&8191)===10)switch(q){case 438:return A.Y(a,A.dg(A.n(s)+" (Error "+q+")",null))
-case 445:case 5007:A.n(s)
-return A.Y(a,new A.aS())}}if(a instanceof TypeError){p=$.eJ()
-o=$.eK()
-n=$.eL()
-m=$.eM()
-l=$.eP()
-k=$.eQ()
-j=$.eO()
-$.eN()
-i=$.eS()
-h=$.eR()
+if((B.c.aE(r,16)&8191)===10)switch(q){case 438:return A.a2(a,A.dN(A.m(s)+" (Error "+q+")",null))
+case 445:case 5007:A.m(s)
+return A.a2(a,new A.b2())}}if(a instanceof TypeError){p=$.fd()
+o=$.fe()
+n=$.ff()
+m=$.fg()
+l=$.fj()
+k=$.fk()
+j=$.fi()
+$.fh()
+i=$.fm()
+h=$.fl()
 g=p.A(s)
-if(g!=null)return A.Y(a,A.dg(A.ap(s),g))
+if(g!=null)return A.a2(a,A.dN(A.az(s),g))
 else{g=o.A(s)
 if(g!=null){g.method="call"
-return A.Y(a,A.dg(A.ap(s),g))}else if(n.A(s)!=null||m.A(s)!=null||l.A(s)!=null||k.A(s)!=null||j.A(s)!=null||m.A(s)!=null||i.A(s)!=null||h.A(s)!=null){A.ap(s)
-return A.Y(a,new A.aS())}}return A.Y(a,new A.bQ(typeof s=="string"?s:""))}if(a instanceof RangeError){if(typeof s=="string"&&s.indexOf("call stack")!==-1)return new A.aV()
+return A.a2(a,A.dN(A.az(s),g))}else if(n.A(s)!=null||m.A(s)!=null||l.A(s)!=null||k.A(s)!=null||j.A(s)!=null||m.A(s)!=null||i.A(s)!=null||h.A(s)!=null){A.az(s)
+return A.a2(a,new A.b2())}}return A.a2(a,new A.c9(typeof s=="string"?s:""))}if(a instanceof RangeError){if(typeof s=="string"&&s.indexOf("call stack")!==-1)return new A.b5()
 s=function(b){try{return String(b)}catch(f){}return null}(a)
-return A.Y(a,new A.N(!1,null,null,typeof s=="string"?s.replace(/^RangeError:\s*/,""):s))}if(typeof InternalError=="function"&&a instanceof InternalError)if(typeof s=="string"&&s==="too much recursion")return new A.aV()
+return A.a2(a,new A.Q(!1,null,null,typeof s=="string"?s.replace(/^RangeError:\s*/,""):s))}if(typeof InternalError=="function"&&a instanceof InternalError)if(typeof s=="string"&&s==="too much recursion")return new A.b5()
 return a},
-at(a){var s
-if(a instanceof A.aC)return a.b
-if(a==null)return new A.b8(a)
+ag(a){var s
+if(a instanceof A.aO)return a.b
+if(a==null)return new A.bm(a)
 s=a.$cachedTrace
 if(s!=null)return s
-s=new A.b8(a)
+s=new A.bm(a)
 if(typeof a==="object")a.$cachedTrace=s
 return s},
-d5(a){if(a==null)return J.M(a)
-if(typeof a=="object")return A.bI(a)
-return J.M(a)},
-hH(a,b){var s,r,q,p=a.length
+dD(a){if(a==null)return J.W(a)
+if(typeof a=="object")return A.c0(a)
+return J.W(a)},
+id(a,b){var s,r,q,p=a.length
 for(s=0;s<p;s=q){r=s+1
 q=r+1
 b.v(0,a[s],a[r])}return b},
-ha(a,b,c,d,e,f){t.Z.a(a)
-switch(A.a7(b)){case 0:return a.$0()
+hH(a,b,c,d,e,f){t.Z.a(a)
+switch(A.a1(b)){case 0:return a.$0()
 case 1:return a.$1(c)
 case 2:return a.$2(c,d)
 case 3:return a.$3(c,d,e)
-case 4:return a.$4(c,d,e,f)}throw A.i(new A.cu("Unsupported number of arguments for wrapped closure"))},
-bi(a,b){var s=a.$identity
+case 4:return a.$4(c,d,e,f)}throw A.e(new A.cV("Unsupported number of arguments for wrapped closure"))},
+aD(a,b){var s=a.$identity
 if(!!s)return s
-s=A.hE(a,b)
+s=A.ia(a,b)
 a.$identity=s
 return s},
-hE(a,b){var s
+ia(a,b){var s
 switch(b){case 0:s=a.$0
 break
 case 1:s=a.$1
@@ -372,10 +369,10 @@ break
 case 4:s=a.$4
 break
 default:s=null}if(s!=null)return s.bind(a)
-return function(c,d,e){return function(f,g,h,i){return e(c,d,f,g,h,i)}}(a,b,A.ha)},
-f3(a2){var s,r,q,p,o,n,m,l,k,j,i=a2.co,h=a2.iS,g=a2.iI,f=a2.nDA,e=a2.aI,d=a2.fs,c=a2.cs,b=d[0],a=c[0],a0=i[b],a1=a2.fT
+return function(c,d,e){return function(f,g,h,i){return e(c,d,f,g,h,i)}}(a,b,A.hH)},
+fx(a2){var s,r,q,p,o,n,m,l,k,j,i=a2.co,h=a2.iS,g=a2.iI,f=a2.nDA,e=a2.aI,d=a2.fs,c=a2.cs,b=d[0],a=c[0],a0=i[b],a1=a2.fT
 a1.toString
-s=h?Object.create(new A.bM().constructor.prototype):Object.create(new A.ae(null,null).constructor.prototype)
+s=h?Object.create(new A.c4().constructor.prototype):Object.create(new A.al(null,null).constructor.prototype)
 s.$initialize=s.constructor
 r=h?function static_tear_off(){this.$initialize()}:function tear_off(a3,a4){this.$initialize(a3,a4)}
 s.constructor=r
@@ -383,24 +380,24 @@ r.prototype=s
 s.$_name=b
 s.$_target=a0
 q=!h
-if(q)p=A.dU(b,a0,g,f)
+if(q)p=A.em(b,a0,g,f)
 else{s.$static_name=b
-p=a0}s.$S=A.f_(a1,h,g)
+p=a0}s.$S=A.ft(a1,h,g)
 s[a]=p
 for(o=p,n=1;n<d.length;++n){m=d[n]
 if(typeof m=="string"){l=i[m]
 k=m
 m=l}else k=""
 j=c[n]
-if(j!=null){if(q)m=A.dU(k,m,g,f)
+if(j!=null){if(q)m=A.em(k,m,g,f)
 s[j]=m}if(n===e)o=m}s.$C=o
 s.$R=a2.rC
 s.$D=a2.dV
 return r},
-f_(a,b,c){if(typeof a=="number")return a
-if(typeof a=="string"){if(b)throw A.i("Cannot compute signature for static tearoff.")
-return function(d,e){return function(){return e(this,d)}}(a,A.eX)}throw A.i("Error in functionType of tearoff")},
-f0(a,b,c,d){var s=A.dT
+ft(a,b,c){if(typeof a=="number")return a
+if(typeof a=="string"){if(b)throw A.e("Cannot compute signature for static tearoff.")
+return function(d,e){return function(){return e(this,d)}}(a,A.fq)}throw A.e("Error in functionType of tearoff")},
+fu(a,b,c,d){var s=A.el
 switch(b?-1:a){case 0:return function(e,f){return function(){return f(this)[e]()}}(c,s)
 case 1:return function(e,f){return function(g){return f(this)[e](g)}}(c,s)
 case 2:return function(e,f){return function(g,h){return f(this)[e](g,h)}}(c,s)
@@ -408,10 +405,10 @@ case 3:return function(e,f){return function(g,h,i){return f(this)[e](g,h,i)}}(c,
 case 4:return function(e,f){return function(g,h,i,j){return f(this)[e](g,h,i,j)}}(c,s)
 case 5:return function(e,f){return function(g,h,i,j,k){return f(this)[e](g,h,i,j,k)}}(c,s)
 default:return function(e,f){return function(){return e.apply(f(this),arguments)}}(d,s)}},
-dU(a,b,c,d){if(c)return A.f2(a,b,d)
-return A.f0(b.length,d,a,b)},
-f1(a,b,c,d){var s=A.dT,r=A.eY
-switch(b?-1:a){case 0:throw A.i(new A.bK("Intercepted function with no arguments."))
+em(a,b,c,d){if(c)return A.fw(a,b,d)
+return A.fu(b.length,d,a,b)},
+fv(a,b,c,d){var s=A.el,r=A.fr
+switch(b?-1:a){case 0:throw A.e(new A.c2("Intercepted function with no arguments."))
 case 1:return function(e,f,g){return function(){return f(this)[e](g(this))}}(c,r,s)
 case 2:return function(e,f,g){return function(h){return f(this)[e](g(this),h)}}(c,r,s)
 case 3:return function(e,f,g){return function(h,i){return f(this)[e](g(this),h,i)}}(c,r,s)
@@ -421,68 +418,68 @@ case 6:return function(e,f,g){return function(h,i,j,k,l){return f(this)[e](g(thi
 default:return function(e,f,g){return function(){var q=[g(this)]
 Array.prototype.push.apply(q,arguments)
 return e.apply(f(this),q)}}(d,r,s)}},
-f2(a,b,c){var s,r
-if($.dR==null)$.dR=A.dQ("interceptor")
-if($.dS==null)$.dS=A.dQ("receiver")
+fw(a,b,c){var s,r
+if($.ej==null)$.ej=A.ei("interceptor")
+if($.ek==null)$.ek=A.ei("receiver")
 s=b.length
-r=A.f1(s,c,a,b)
+r=A.fv(s,c,a,b)
 return r},
-dz(a){return A.f3(a)},
-eX(a,b){return A.bd(v.typeUniverse,A.au(a.a),b)},
-dT(a){return a.a},
-eY(a){return a.b},
-dQ(a){var s,r,q,p=new A.ae("receiver","interceptor"),o=Object.getOwnPropertyNames(p)
+e5(a){return A.fx(a)},
+fq(a,b){return A.bt(v.typeUniverse,A.aE(a.a),b)},
+el(a){return a.a},
+fr(a){return a.b},
+ei(a){var s,r,q,p=new A.al("receiver","interceptor"),o=Object.getOwnPropertyNames(p)
 o.$flags=1
 s=o
 for(o=s.length,r=0;r<o;++r){q=s[r]
-if(p[q]===a)return q}throw A.i(A.ay("Field name "+a+" not found.",null))},
-hI(a){return v.getIsolateTag(a)},
-hR(a){var s,r,q,p,o,n=A.ap($.eF.$1(a)),m=$.cZ[n]
+if(p[q]===a)return q}throw A.e(A.ak("Field name "+a+" not found.",null))},
+ie(a){return v.getIsolateTag(a)},
+iq(a){var s,r,q,p,o,n=A.az($.f7.$1(a)),m=$.du[n]
 if(m!=null){Object.defineProperty(a,v.dispatchPropertyName,{value:m,enumerable:false,writable:true,configurable:true})
-return m.i}s=$.d2[n]
+return m.i}s=$.dA[n]
 if(s!=null)return s
 r=v.interceptorsByTag[n]
-if(r==null){q=A.ep($.eA.$2(a,n))
-if(q!=null){m=$.cZ[q]
+if(r==null){q=A.cl($.f3.$2(a,n))
+if(q!=null){m=$.du[q]
 if(m!=null){Object.defineProperty(a,v.dispatchPropertyName,{value:m,enumerable:false,writable:true,configurable:true})
-return m.i}s=$.d2[q]
+return m.i}s=$.dA[q]
 if(s!=null)return s
 r=v.interceptorsByTag[q]
 n=q}}if(r==null)return null
 s=r.prototype
 p=n[0]
-if(p==="!"){m=A.d4(s)
-$.cZ[n]=m
+if(p==="!"){m=A.dC(s)
+$.du[n]=m
 Object.defineProperty(a,v.dispatchPropertyName,{value:m,enumerable:false,writable:true,configurable:true})
-return m.i}if(p==="~"){$.d2[n]=s
-return s}if(p==="-"){o=A.d4(s)
+return m.i}if(p==="~"){$.dA[n]=s
+return s}if(p==="-"){o=A.dC(s)
 Object.defineProperty(Object.getPrototypeOf(a),v.dispatchPropertyName,{value:o,enumerable:false,writable:true,configurable:true})
-return o.i}if(p==="+")return A.eG(a,s)
-if(p==="*")throw A.i(A.e6(n))
-if(v.leafTags[n]===true){o=A.d4(s)
+return o.i}if(p==="+")return A.f8(a,s)
+if(p==="*")throw A.e(A.eA(n))
+if(v.leafTags[n]===true){o=A.dC(s)
 Object.defineProperty(Object.getPrototypeOf(a),v.dispatchPropertyName,{value:o,enumerable:false,writable:true,configurable:true})
-return o.i}else return A.eG(a,s)},
-eG(a,b){var s=Object.getPrototypeOf(a)
-Object.defineProperty(s,v.dispatchPropertyName,{value:J.dI(b,s,null,null),enumerable:false,writable:true,configurable:true})
+return o.i}else return A.f8(a,s)},
+f8(a,b){var s=Object.getPrototypeOf(a)
+Object.defineProperty(s,v.dispatchPropertyName,{value:J.eb(b,s,null,null),enumerable:false,writable:true,configurable:true})
 return b},
-d4(a){return J.dI(a,!1,null,!!a.$iz)},
-hT(a,b,c){var s=b.prototype
-if(v.leafTags[a]===true)return A.d4(s)
-else return J.dI(s,c,null,null)},
-hN(){if(!0===$.dF)return
-$.dF=!0
-A.hO()},
-hO(){var s,r,q,p,o,n,m,l
-$.cZ=Object.create(null)
-$.d2=Object.create(null)
-A.hM()
+dC(a){return J.eb(a,!1,null,!!a.$iB)},
+is(a,b,c){var s=b.prototype
+if(v.leafTags[a]===true)return A.dC(s)
+else return J.eb(s,c,null,null)},
+il(){if(!0===$.e9)return
+$.e9=!0
+A.im()},
+im(){var s,r,q,p,o,n,m,l
+$.du=Object.create(null)
+$.dA=Object.create(null)
+A.ik()
 s=v.interceptorsByTag
 r=Object.getOwnPropertyNames(s)
 if(typeof window!="undefined"){window
 q=function(){}
 for(p=0;p<r.length;++p){o=r[p]
-n=$.eH.$1(o)
-if(n!=null){m=A.hT(o,s[o],n)
+n=$.fa.$1(o)
+if(n!=null){m=A.is(o,s[o],n)
 if(m!=null){Object.defineProperty(n,v.dispatchPropertyName,{value:m,enumerable:false,writable:true,configurable:true})
 q.prototype=n}}}}for(p=0;p<r.length;++p){o=r[p]
 if(/^[A-Za-z_]/.test(o)){l=s[o]
@@ -491,362 +488,375 @@ s["~"+o]=l
 s["-"+o]=l
 s["+"+o]=l
 s["*"+o]=l}}},
-hM(){var s,r,q,p,o,n,m=B.k()
-m=A.as(B.l,A.as(B.m,A.as(B.i,A.as(B.i,A.as(B.n,A.as(B.o,A.as(B.p(B.h),m)))))))
+ik(){var s,r,q,p,o,n,m=B.k()
+m=A.aC(B.l,A.aC(B.m,A.aC(B.i,A.aC(B.i,A.aC(B.n,A.aC(B.o,A.aC(B.p(B.h),m)))))))
 if(typeof dartNativeDispatchHooksTransformer!="undefined"){s=dartNativeDispatchHooksTransformer
 if(typeof s=="function")s=[s]
 if(Array.isArray(s))for(r=0;r<s.length;++r){q=s[r]
 if(typeof q=="function")m=q(m)||m}}p=m.getTag
 o=m.getUnknownTag
 n=m.prototypeForTag
-$.eF=new A.d_(p)
-$.eA=new A.d0(o)
-$.eH=new A.d1(n)},
-as(a,b){return a(b)||b},
-hF(a,b){var s=b.length,r=v.rttc[""+s+";"+a]
+$.f7=new A.dx(p)
+$.f3=new A.dy(o)
+$.fa=new A.dz(n)},
+aC(a,b){return a(b)||b},
+ib(a,b){var s=b.length,r=v.rttc[""+s+";"+a]
 if(r==null)return null
 if(s===0)return r
 if(s===r.length)return r.apply(null,b)
 return r(b)},
-hV(a){if(/[[\]{}()*+?.\\^$|]/.test(a))return a.replace(/[[\]{}()*+?.\\^$|]/g,"\\$&")
+it(a){if(/[[\]{}()*+?.\\^$|]/.test(a))return a.replace(/[[\]{}()*+?.\\^$|]/g,"\\$&")
 return a},
-b6:function b6(a,b){this.a=a
+bk:function bk(a,b){this.a=a
 this.b=b},
-b7:function b7(a,b,c){this.a=a
+bl:function bl(a,b,c){this.a=a
 this.b=b
 this.c=c},
-aU:function aU(){},
-ch:function ch(a,b,c,d,e,f){var _=this
+aL:function aL(){},
+aM:function aM(a,b,c){this.a=a
+this.b=b
+this.$ti=c},
+be:function be(a,b){this.a=a
+this.$ti=b},
+bf:function bf(a,b,c){var _=this
+_.a=a
+_.b=b
+_.c=0
+_.d=null
+_.$ti=c},
+b4:function b4(){},
+cE:function cE(a,b,c,d,e,f){var _=this
 _.a=a
 _.b=b
 _.c=c
 _.d=d
 _.e=e
 _.f=f},
-aS:function aS(){},
-bw:function bw(a,b,c){this.a=a
+b2:function b2(){},
+bO:function bO(a,b,c){this.a=a
 this.b=b
 this.c=c},
-bQ:function bQ(a){this.a=a},
-cf:function cf(a){this.a=a},
-aC:function aC(a,b){this.a=a
+c9:function c9(a){this.a=a},
+cC:function cC(a){this.a=a},
+aO:function aO(a,b){this.a=a
 this.b=b},
-b8:function b8(a){this.a=a
+bm:function bm(a){this.a=a
 this.b=null},
-T:function T(){},
-bl:function bl(){},
-bm:function bm(){},
-bO:function bO(){},
-bM:function bM(){},
-ae:function ae(a,b){this.a=a
+X:function X(){},
+bB:function bB(){},
+bC:function bC(){},
+c6:function c6(){},
+c4:function c4(){},
+al:function al(a,b){this.a=a
 this.b=b},
-bK:function bK(a){this.a=a},
-a2:function a2(a){var _=this
+c2:function c2(a){this.a=a},
+a6:function a6(a){var _=this
 _.a=0
 _.f=_.e=_.d=_.c=_.b=null
 _.r=0
 _.$ti=a},
-cb:function cb(a,b){this.a=a
+cy:function cy(a,b){this.a=a
 this.b=b
 this.c=null},
-aM:function aM(a,b){this.a=a
+aX:function aX(a,b){this.a=a
 this.$ti=b},
-aL:function aL(a,b,c,d){var _=this
+aW:function aW(a,b,c,d){var _=this
 _.a=a
 _.b=b
 _.c=c
 _.d=null
 _.$ti=d},
-aJ:function aJ(a,b){this.a=a
+aU:function aU(a,b){this.a=a
 this.$ti=b},
-aK:function aK(a,b,c,d){var _=this
+aV:function aV(a,b,c,d){var _=this
 _.a=a
 _.b=b
 _.c=c
 _.d=null
 _.$ti=d},
-d_:function d_(a){this.a=a},
-d0:function d0(a){this.a=a},
-d1:function d1(a){this.a=a},
-S:function S(){},
-am:function am(){},
-an:function an(){},
-ag:function ag(){},
-aQ:function aQ(){},
-by:function by(){},
-ah:function ah(){},
-aO:function aO(){},
-aP:function aP(){},
-bz:function bz(){},
-bA:function bA(){},
-bB:function bB(){},
-bC:function bC(){},
-bD:function bD(){},
-bE:function bE(){},
-bF:function bF(){},
-aR:function aR(){},
-bG:function bG(){},
-b2:function b2(){},
-b3:function b3(){},
-b4:function b4(){},
-b5:function b5(){},
-dl(a,b){var s=b.c
-return s==null?b.c=A.bb(a,"J",[b.x]):s},
-e2(a){var s=a.w
-if(s===6||s===7)return A.e2(a.x)
+dx:function dx(a){this.a=a},
+dy:function dy(a){this.a=a},
+dz:function dz(a){this.a=a},
+V:function V(){},
+au:function au(){},
+av:function av(){},
+aa(a,b,c){if(a>>>0!==a||a>=c)throw A.e(A.dt(b,a))},
+ao:function ao(){},
+b0:function b0(){},
+bQ:function bQ(){},
+ap:function ap(){},
+aZ:function aZ(){},
+b_:function b_(){},
+bR:function bR(){},
+bS:function bS(){},
+bT:function bT(){},
+bU:function bU(){},
+bV:function bV(){},
+bW:function bW(){},
+bX:function bX(){},
+b1:function b1(){},
+bY:function bY(){},
+bg:function bg(){},
+bh:function bh(){},
+bi:function bi(){},
+bj:function bj(){},
+dS(a,b){var s=b.c
+return s==null?b.c=A.br(a,"M",[b.x]):s},
+ew(a){var s=a.w
+if(s===6||s===7)return A.ew(a.x)
 return s===11||s===12},
-fo(a){return a.as},
-dB(a){return A.cL(v.typeUniverse,a,!1)},
-a8(a1,a2,a3,a4){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d,c,b,a,a0=a2.w
+fR(a){return a.as},
+dv(a){return A.dc(v.typeUniverse,a,!1)},
+ac(a1,a2,a3,a4){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d,c,b,a,a0=a2.w
 switch(a0){case 5:case 1:case 2:case 3:case 4:return a2
 case 6:s=a2.x
-r=A.a8(a1,s,a3,a4)
+r=A.ac(a1,s,a3,a4)
 if(r===s)return a2
-return A.ei(a1,r,!0)
+return A.eN(a1,r,!0)
 case 7:s=a2.x
-r=A.a8(a1,s,a3,a4)
+r=A.ac(a1,s,a3,a4)
 if(r===s)return a2
-return A.eh(a1,r,!0)
+return A.eM(a1,r,!0)
 case 8:q=a2.y
-p=A.ar(a1,q,a3,a4)
+p=A.aB(a1,q,a3,a4)
 if(p===q)return a2
-return A.bb(a1,a2.x,p)
+return A.br(a1,a2.x,p)
 case 9:o=a2.x
-n=A.a8(a1,o,a3,a4)
+n=A.ac(a1,o,a3,a4)
 m=a2.y
-l=A.ar(a1,m,a3,a4)
+l=A.aB(a1,m,a3,a4)
 if(n===o&&l===m)return a2
-return A.dr(a1,n,l)
+return A.dY(a1,n,l)
 case 10:k=a2.x
 j=a2.y
-i=A.ar(a1,j,a3,a4)
+i=A.aB(a1,j,a3,a4)
 if(i===j)return a2
-return A.ej(a1,k,i)
+return A.eO(a1,k,i)
 case 11:h=a2.x
-g=A.a8(a1,h,a3,a4)
+g=A.ac(a1,h,a3,a4)
 f=a2.y
-e=A.hv(a1,f,a3,a4)
+e=A.i0(a1,f,a3,a4)
 if(g===h&&e===f)return a2
-return A.eg(a1,g,e)
+return A.eL(a1,g,e)
 case 12:d=a2.y
 a4+=d.length
-c=A.ar(a1,d,a3,a4)
+c=A.aB(a1,d,a3,a4)
 o=a2.x
-n=A.a8(a1,o,a3,a4)
+n=A.ac(a1,o,a3,a4)
 if(c===d&&n===o)return a2
-return A.ds(a1,n,c,!0)
+return A.dZ(a1,n,c,!0)
 case 13:b=a2.x
 if(b<a4)return a2
 a=a3[b-a4]
 if(a==null)return a2
 return a
-default:throw A.i(A.bk("Attempted to substitute unexpected RTI kind "+a0))}},
-ar(a,b,c,d){var s,r,q,p,o=b.length,n=A.cM(o)
+default:throw A.e(A.bA("Attempted to substitute unexpected RTI kind "+a0))}},
+aB(a,b,c,d){var s,r,q,p,o=b.length,n=A.dd(o)
 for(s=!1,r=0;r<o;++r){q=b[r]
-p=A.a8(a,q,c,d)
+p=A.ac(a,q,c,d)
 if(p!==q)s=!0
 n[r]=p}return s?n:b},
-hw(a,b,c,d){var s,r,q,p,o,n,m=b.length,l=A.cM(m)
+i1(a,b,c,d){var s,r,q,p,o,n,m=b.length,l=A.dd(m)
 for(s=!1,r=0;r<m;r+=3){q=b[r]
 p=b[r+1]
 o=b[r+2]
-n=A.a8(a,o,c,d)
+n=A.ac(a,o,c,d)
 if(n!==o)s=!0
 l.splice(r,3,q,p,n)}return s?l:b},
-hv(a,b,c,d){var s,r=b.a,q=A.ar(a,r,c,d),p=b.b,o=A.ar(a,p,c,d),n=b.c,m=A.hw(a,n,c,d)
+i0(a,b,c,d){var s,r=b.a,q=A.aB(a,r,c,d),p=b.b,o=A.aB(a,p,c,d),n=b.c,m=A.i1(a,n,c,d)
 if(q===r&&o===p&&m===n)return b
-s=new A.bX()
+s=new A.cg()
 s.a=q
 s.b=o
 s.c=m
 return s},
-H(a,b){a[v.arrayRti]=b
+K(a,b){a[v.arrayRti]=b
 return a},
-eC(a){var s=a.$S
-if(s!=null){if(typeof s=="number")return A.hK(s)
+f5(a){var s=a.$S
+if(s!=null){if(typeof s=="number")return A.ih(s)
 return a.$S()}return null},
-hP(a,b){var s
-if(A.e2(b))if(a instanceof A.T){s=A.eC(a)
-if(s!=null)return s}return A.au(a)},
-au(a){if(a instanceof A.d)return A.G(a)
-if(Array.isArray(a))return A.ao(a)
-return A.du(J.ab(a))},
-ao(a){var s=a[v.arrayRti],r=t.b
+io(a,b){var s
+if(A.ew(b))if(a instanceof A.X){s=A.f5(a)
+if(s!=null)return s}return A.aE(a)},
+aE(a){if(a instanceof A.d)return A.r(a)
+if(Array.isArray(a))return A.ax(a)
+return A.e0(J.af(a))},
+ax(a){var s=a[v.arrayRti],r=t.b
 if(s==null)return r
 if(s.constructor!==r.constructor)return r
 return s},
-G(a){var s=a.$ti
-return s!=null?s:A.du(a)},
-du(a){var s=a.constructor,r=s.$ccache
+r(a){var s=a.$ti
+return s!=null?s:A.e0(a)},
+e0(a){var s=a.constructor,r=s.$ccache
 if(r!=null)return r
-return A.h7(a,s)},
-h7(a,b){var s=a instanceof A.T?Object.getPrototypeOf(Object.getPrototypeOf(a)).constructor:b,r=A.fO(v.typeUniverse,s.name)
+return A.hE(a,s)},
+hE(a,b){var s=a instanceof A.X?Object.getPrototypeOf(Object.getPrototypeOf(a)).constructor:b,r=A.hj(v.typeUniverse,s.name)
 b.$ccache=r
 return r},
-hK(a){var s,r=v.types,q=r[a]
-if(typeof q=="string"){s=A.cL(v.typeUniverse,q,!1)
+ih(a){var s,r=v.types,q=r[a]
+if(typeof q=="string"){s=A.dc(v.typeUniverse,q,!1)
 r[a]=s
 return s}return q},
-hJ(a){return A.aa(A.G(a))},
-dy(a){var s
-if(a instanceof A.S)return A.hG(a.$r,a.T())
-s=a instanceof A.T?A.eC(a):null
+ig(a){return A.ae(A.r(a))},
+e4(a){var s
+if(a instanceof A.V)return A.ic(a.$r,a.U())
+s=a instanceof A.X?A.f5(a):null
 if(s!=null)return s
-if(t.t.b(a))return J.eW(a).a
-if(Array.isArray(a))return A.ao(a)
-return A.au(a)},
-aa(a){var s=a.r
-return s==null?a.r=new A.cK(a):s},
-hG(a,b){var s,r,q=b,p=q.length
-if(p===0)return t.e
-if(0>=p)return A.x(q,0)
-s=A.bd(v.typeUniverse,A.dy(q[0]),"@<0>")
-for(r=1;r<p;++r){if(!(r<q.length))return A.x(q,r)
-s=A.ek(v.typeUniverse,s,A.dy(q[r]))}return A.bd(v.typeUniverse,s,a)},
-I(a){return A.aa(A.cL(v.typeUniverse,a,!1))},
-h6(a){var s=this
-s.b=A.ht(s)
+if(t.w.b(a))return J.fp(a).a
+if(Array.isArray(a))return A.ax(a)
+return A.aE(a)},
+ae(a){var s=a.r
+return s==null?a.r=new A.db(a):s},
+ic(a,b){var s,r,q=b,p=q.length
+if(p===0)return t.r
+if(0>=p)return A.y(q,0)
+s=A.bt(v.typeUniverse,A.e4(q[0]),"@<0>")
+for(r=1;r<p;++r){if(!(r<q.length))return A.y(q,r)
+s=A.eP(v.typeUniverse,s,A.e4(q[r]))}return A.bt(v.typeUniverse,s,a)},
+L(a){return A.ae(A.dc(v.typeUniverse,a,!1))},
+hD(a){var s=this
+s.b=A.hZ(s)
 return s.b(a)},
-ht(a){var s,r,q,p,o
-if(a===t.K)return A.hg
-if(A.ac(a))return A.hk
+hZ(a){var s,r,q,p,o
+if(a===t.K)return A.hN
+if(A.ah(a))return A.hR
 s=a.w
-if(s===6)return A.h4
-if(s===1)return A.eu
-if(s===7)return A.hb
-r=A.hs(a)
+if(s===6)return A.hA
+if(s===1)return A.eW
+if(s===7)return A.hI
+r=A.hY(a)
 if(r!=null)return r
 if(s===8){q=a.x
-if(a.y.every(A.ac)){a.f="$i"+q
-if(q==="j")return A.he
-if(a===t.m)return A.hd
-return A.hj}}else if(s===10){p=A.hF(a.x,a.y)
-o=p==null?A.eu:p
-return o==null?A.bf(o):o}return A.h2},
-hs(a){if(a.w===8){if(a===t.S)return A.dw
-if(a===t.i||a===t.o)return A.hf
-if(a===t.N)return A.hi
-if(a===t.y)return A.cS}return null},
-h5(a){var s=this,r=A.h1
-if(A.ac(s))r=A.fX
-else if(s===t.K)r=A.bf
-else if(A.av(s)){r=A.h3
-if(s===t.a3)r=A.fU
-else if(s===t.aD)r=A.ep
-else if(s===t.u)r=A.fR
-else if(s===t.ae)r=A.eo
-else if(s===t.I)r=A.fT
-else if(s===t.aQ)r=A.fV}else if(s===t.S)r=A.a7
-else if(s===t.N)r=A.ap
-else if(s===t.y)r=A.fQ
-else if(s===t.o)r=A.fW
-else if(s===t.i)r=A.fS
-else if(s===t.m)r=A.en
+if(a.y.every(A.ah)){a.f="$i"+q
+if(q==="i")return A.hL
+if(a===t.m)return A.hK
+return A.hQ}}else if(s===10){p=A.ib(a.x,a.y)
+o=p==null?A.eW:p
+return o==null?A.ay(o):o}return A.hy},
+hY(a){if(a.w===8){if(a===t.S)return A.e2
+if(a===t.i||a===t.o)return A.hM
+if(a===t.N)return A.hP
+if(a===t.y)return A.dk}return null},
+hC(a){var s=this,r=A.hx
+if(A.ah(s))r=A.hs
+else if(s===t.K)r=A.ay
+else if(A.aF(s)){r=A.hz
+if(s===t.a3)r=A.hp
+else if(s===t.aD)r=A.cl
+else if(s===t.u)r=A.hm
+else if(s===t.ae)r=A.ck
+else if(s===t.I)r=A.ho
+else if(s===t.aQ)r=A.hq}else if(s===t.S)r=A.a1
+else if(s===t.N)r=A.az
+else if(s===t.y)r=A.hl
+else if(s===t.o)r=A.hr
+else if(s===t.i)r=A.hn
+else if(s===t.m)r=A.de
 s.a=r
 return s.a(a)},
-h2(a){var s=this
-if(a==null)return A.av(s)
-return A.hQ(v.typeUniverse,A.hP(a,s),s)},
-h4(a){if(a==null)return!0
+hy(a){var s=this
+if(a==null)return A.aF(s)
+return A.ip(v.typeUniverse,A.io(a,s),s)},
+hA(a){if(a==null)return!0
 return this.x.b(a)},
-hj(a){var s,r=this
-if(a==null)return A.av(r)
+hQ(a){var s,r=this
+if(a==null)return A.aF(r)
 s=r.f
 if(a instanceof A.d)return!!a[s]
-return!!J.ab(a)[s]},
-he(a){var s,r=this
-if(a==null)return A.av(r)
+return!!J.af(a)[s]},
+hL(a){var s,r=this
+if(a==null)return A.aF(r)
 if(typeof a!="object")return!1
 if(Array.isArray(a))return!0
 s=r.f
 if(a instanceof A.d)return!!a[s]
-return!!J.ab(a)[s]},
-hd(a){var s=this
+return!!J.af(a)[s]},
+hK(a){var s=this
 if(a==null)return!1
 if(typeof a=="object"){if(a instanceof A.d)return!!a[s.f]
 return!0}if(typeof a=="function")return!0
 return!1},
-et(a){if(typeof a=="object"){if(a instanceof A.d)return t.m.b(a)
+eV(a){if(typeof a=="object"){if(a instanceof A.d)return t.m.b(a)
 return!0}if(typeof a=="function")return!0
 return!1},
-h1(a){var s=this
-if(a==null){if(A.av(s))return a}else if(s.b(a))return a
-throw A.r(A.eq(a,s),new Error())},
-h3(a){var s=this
+hx(a){var s=this
+if(a==null){if(A.aF(s))return a}else if(s.b(a))return a
+throw A.w(A.eS(a,s),new Error())},
+hz(a){var s=this
 if(a==null||s.b(a))return a
-throw A.r(A.eq(a,s),new Error())},
-eq(a,b){return new A.b9("TypeError: "+A.e9(a,A.A(b,null)))},
-e9(a,b){return A.c4(a)+": type '"+A.A(A.dy(a),null)+"' is not a subtype of type '"+b+"'"},
-E(a,b){return new A.b9("TypeError: "+A.e9(a,b))},
-hb(a){var s=this
-return s.x.b(a)||A.dl(v.typeUniverse,s).b(a)},
-hg(a){return a!=null},
-bf(a){if(a!=null)return a
-throw A.r(A.E(a,"Object"),new Error())},
-hk(a){return!0},
-fX(a){return a},
-eu(a){return!1},
-cS(a){return!0===a||!1===a},
-fQ(a){if(!0===a)return!0
+throw A.w(A.eS(a,s),new Error())},
+eS(a,b){return new A.bp("TypeError: "+A.eD(a,A.F(b,null)))},
+eD(a,b){return A.cr(a)+": type '"+A.F(A.e4(a),null)+"' is not a subtype of type '"+b+"'"},
+I(a,b){return new A.bp("TypeError: "+A.eD(a,b))},
+hI(a){var s=this
+return s.x.b(a)||A.dS(v.typeUniverse,s).b(a)},
+hN(a){return a!=null},
+ay(a){if(a!=null)return a
+throw A.w(A.I(a,"Object"),new Error())},
+hR(a){return!0},
+hs(a){return a},
+eW(a){return!1},
+dk(a){return!0===a||!1===a},
+hl(a){if(!0===a)return!0
 if(!1===a)return!1
-throw A.r(A.E(a,"bool"),new Error())},
-fR(a){if(!0===a)return!0
+throw A.w(A.I(a,"bool"),new Error())},
+hm(a){if(!0===a)return!0
 if(!1===a)return!1
 if(a==null)return a
-throw A.r(A.E(a,"bool?"),new Error())},
-fS(a){if(typeof a=="number")return a
-throw A.r(A.E(a,"double"),new Error())},
-fT(a){if(typeof a=="number")return a
+throw A.w(A.I(a,"bool?"),new Error())},
+hn(a){if(typeof a=="number")return a
+throw A.w(A.I(a,"double"),new Error())},
+ho(a){if(typeof a=="number")return a
 if(a==null)return a
-throw A.r(A.E(a,"double?"),new Error())},
-dw(a){return typeof a=="number"&&Math.floor(a)===a},
-a7(a){if(typeof a=="number"&&Math.floor(a)===a)return a
-throw A.r(A.E(a,"int"),new Error())},
-fU(a){if(typeof a=="number"&&Math.floor(a)===a)return a
+throw A.w(A.I(a,"double?"),new Error())},
+e2(a){return typeof a=="number"&&Math.floor(a)===a},
+a1(a){if(typeof a=="number"&&Math.floor(a)===a)return a
+throw A.w(A.I(a,"int"),new Error())},
+hp(a){if(typeof a=="number"&&Math.floor(a)===a)return a
 if(a==null)return a
-throw A.r(A.E(a,"int?"),new Error())},
-hf(a){return typeof a=="number"},
-fW(a){if(typeof a=="number")return a
-throw A.r(A.E(a,"num"),new Error())},
-eo(a){if(typeof a=="number")return a
+throw A.w(A.I(a,"int?"),new Error())},
+hM(a){return typeof a=="number"},
+hr(a){if(typeof a=="number")return a
+throw A.w(A.I(a,"num"),new Error())},
+ck(a){if(typeof a=="number")return a
 if(a==null)return a
-throw A.r(A.E(a,"num?"),new Error())},
-hi(a){return typeof a=="string"},
-ap(a){if(typeof a=="string")return a
-throw A.r(A.E(a,"String"),new Error())},
-ep(a){if(typeof a=="string")return a
+throw A.w(A.I(a,"num?"),new Error())},
+hP(a){return typeof a=="string"},
+az(a){if(typeof a=="string")return a
+throw A.w(A.I(a,"String"),new Error())},
+cl(a){if(typeof a=="string")return a
 if(a==null)return a
-throw A.r(A.E(a,"String?"),new Error())},
-en(a){if(A.et(a))return a
-throw A.r(A.E(a,"JSObject"),new Error())},
-fV(a){if(a==null)return a
-if(A.et(a))return a
-throw A.r(A.E(a,"JSObject?"),new Error())},
-ey(a,b){var s,r,q
-for(s="",r="",q=0;q<a.length;++q,r=", ")s+=r+A.A(a[q],b)
+throw A.w(A.I(a,"String?"),new Error())},
+de(a){if(A.eV(a))return a
+throw A.w(A.I(a,"JSObject"),new Error())},
+hq(a){if(a==null)return a
+if(A.eV(a))return a
+throw A.w(A.I(a,"JSObject?"),new Error())},
+f1(a,b){var s,r,q
+for(s="",r="",q=0;q<a.length;++q,r=", ")s+=r+A.F(a[q],b)
 return s},
-hn(a,b){var s,r,q,p,o,n,m=a.x,l=a.y
-if(""===m)return"("+A.ey(l,b)+")"
+hU(a,b){var s,r,q,p,o,n,m=a.x,l=a.y
+if(""===m)return"("+A.f1(l,b)+")"
 s=l.length
 r=m.split(",")
 q=r.length-s
 for(p="(",o="",n=0;n<s;++n,o=", "){p+=o
 if(q===0)p+="{"
-p+=A.A(l[n],b)
+p+=A.F(l[n],b)
 if(q>=0)p+=" "+r[q];++q}return p+"})"},
-er(a3,a4,a5){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d,c,b,a,a0,a1=", ",a2=null
+eT(a3,a4,a5){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d,c,b,a,a0,a1=", ",a2=null
 if(a5!=null){s=a5.length
-if(a4==null)a4=A.H([],t.s)
+if(a4==null)a4=A.K([],t.s)
 else a2=a4.length
 r=a4.length
 for(q=s;q>0;--q)B.a.u(a4,"T"+(r+q))
 for(p=t.X,o="<",n="",q=0;q<s;++q,n=a1){m=a4.length
 l=m-1-q
-if(!(l>=0))return A.x(a4,l)
+if(!(l>=0))return A.y(a4,l)
 o=o+n+a4[l]
 k=a5[q]
 j=k.w
-if(!(j===2||j===3||j===4||j===5||k===p))o+=" extends "+A.A(k,a4)}o+=">"}else o=""
+if(!(j===2||j===3||j===4||j===5||k===p))o+=" extends "+A.F(k,a4)}o+=">"}else o=""
 p=a3.x
 i=a3.y
 h=i.a
@@ -855,242 +865,242 @@ f=i.b
 e=f.length
 d=i.c
 c=d.length
-b=A.A(p,a4)
-for(a="",a0="",q=0;q<g;++q,a0=a1)a+=a0+A.A(h[q],a4)
+b=A.F(p,a4)
+for(a="",a0="",q=0;q<g;++q,a0=a1)a+=a0+A.F(h[q],a4)
 if(e>0){a+=a0+"["
-for(a0="",q=0;q<e;++q,a0=a1)a+=a0+A.A(f[q],a4)
+for(a0="",q=0;q<e;++q,a0=a1)a+=a0+A.F(f[q],a4)
 a+="]"}if(c>0){a+=a0+"{"
 for(a0="",q=0;q<c;q+=3,a0=a1){a+=a0
 if(d[q+1])a+="required "
-a+=A.A(d[q+2],a4)+" "+d[q]}a+="}"}if(a2!=null){a4.toString
+a+=A.F(d[q+2],a4)+" "+d[q]}a+="}"}if(a2!=null){a4.toString
 a4.length=a2}return o+"("+a+") => "+b},
-A(a,b){var s,r,q,p,o,n,m,l=a.w
+F(a,b){var s,r,q,p,o,n,m,l=a.w
 if(l===5)return"erased"
 if(l===2)return"dynamic"
 if(l===3)return"void"
 if(l===1)return"Never"
 if(l===4)return"any"
 if(l===6){s=a.x
-r=A.A(s,b)
+r=A.F(s,b)
 q=s.w
-return(q===11||q===12?"("+r+")":r)+"?"}if(l===7)return"FutureOr<"+A.A(a.x,b)+">"
-if(l===8){p=A.hx(a.x)
+return(q===11||q===12?"("+r+")":r)+"?"}if(l===7)return"FutureOr<"+A.F(a.x,b)+">"
+if(l===8){p=A.i2(a.x)
 o=a.y
-return o.length>0?p+("<"+A.ey(o,b)+">"):p}if(l===10)return A.hn(a,b)
-if(l===11)return A.er(a,b,null)
-if(l===12)return A.er(a.x,b,a.y)
+return o.length>0?p+("<"+A.f1(o,b)+">"):p}if(l===10)return A.hU(a,b)
+if(l===11)return A.eT(a,b,null)
+if(l===12)return A.eT(a.x,b,a.y)
 if(l===13){n=a.x
 m=b.length
 n=m-1-n
-if(!(n>=0&&n<m))return A.x(b,n)
+if(!(n>=0&&n<m))return A.y(b,n)
 return b[n]}return"?"},
-hx(a){var s=v.mangledGlobalNames[a]
+i2(a){var s=v.mangledGlobalNames[a]
 if(s!=null)return s
 return"minified:"+a},
-fP(a,b){var s=a.tR[b]
+hk(a,b){var s=a.tR[b]
 while(typeof s=="string")s=a.tR[s]
 return s},
-fO(a,b){var s,r,q,p,o,n=a.eT,m=n[b]
-if(m==null)return A.cL(a,b,!1)
+hj(a,b){var s,r,q,p,o,n=a.eT,m=n[b]
+if(m==null)return A.dc(a,b,!1)
 else if(typeof m=="number"){s=m
-r=A.bc(a,5,"#")
-q=A.cM(s)
+r=A.bs(a,5,"#")
+q=A.dd(s)
 for(p=0;p<s;++p)q[p]=r
-o=A.bb(a,b,q)
+o=A.br(a,b,q)
 n[b]=o
 return o}else return m},
-fN(a,b){return A.el(a.tR,b)},
-fM(a,b){return A.el(a.eT,b)},
-cL(a,b,c){var s,r=a.eC,q=r.get(b)
+hi(a,b){return A.eQ(a.tR,b)},
+hh(a,b){return A.eQ(a.eT,b)},
+dc(a,b,c){var s,r=a.eC,q=r.get(b)
 if(q!=null)return q
-s=A.ee(A.ec(a,null,b,!1))
+s=A.eI(A.eG(a,null,b,!1))
 r.set(b,s)
 return s},
-bd(a,b,c){var s,r,q=b.z
+bt(a,b,c){var s,r,q=b.z
 if(q==null)q=b.z=new Map()
 s=q.get(c)
 if(s!=null)return s
-r=A.ee(A.ec(a,b,c,!0))
+r=A.eI(A.eG(a,b,c,!0))
 q.set(c,r)
 return r},
-ek(a,b,c){var s,r,q,p=b.Q
+eP(a,b,c){var s,r,q,p=b.Q
 if(p==null)p=b.Q=new Map()
 s=c.as
 r=p.get(s)
 if(r!=null)return r
-q=A.dr(a,b,c.w===9?c.y:[c])
+q=A.dY(a,b,c.w===9?c.y:[c])
 p.set(s,q)
 return q},
-X(a,b){b.a=A.h5
-b.b=A.h6
+a0(a,b){b.a=A.hC
+b.b=A.hD
 return b},
-bc(a,b,c){var s,r,q=a.eC.get(c)
+bs(a,b,c){var s,r,q=a.eC.get(c)
 if(q!=null)return q
-s=new A.F(null,null)
+s=new A.J(null,null)
 s.w=b
 s.as=c
-r=A.X(a,s)
+r=A.a0(a,s)
 a.eC.set(c,r)
 return r},
-ei(a,b,c){var s,r=b.as+"?",q=a.eC.get(r)
+eN(a,b,c){var s,r=b.as+"?",q=a.eC.get(r)
 if(q!=null)return q
-s=A.fK(a,b,r,c)
+s=A.hf(a,b,r,c)
 a.eC.set(r,s)
 return s},
-fK(a,b,c,d){var s,r,q
+hf(a,b,c,d){var s,r,q
 if(d){s=b.w
 r=!0
-if(!A.ac(b))if(!(b===t.P||b===t.T))if(s!==6)r=s===7&&A.av(b.x)
+if(!A.ah(b))if(!(b===t.P||b===t.T))if(s!==6)r=s===7&&A.aF(b.x)
 if(r)return b
-else if(s===1)return t.P}q=new A.F(null,null)
+else if(s===1)return t.P}q=new A.J(null,null)
 q.w=6
 q.x=b
 q.as=c
-return A.X(a,q)},
-eh(a,b,c){var s,r=b.as+"/",q=a.eC.get(r)
+return A.a0(a,q)},
+eM(a,b,c){var s,r=b.as+"/",q=a.eC.get(r)
 if(q!=null)return q
-s=A.fI(a,b,r,c)
+s=A.hd(a,b,r,c)
 a.eC.set(r,s)
 return s},
-fI(a,b,c,d){var s,r
+hd(a,b,c,d){var s,r
 if(d){s=b.w
-if(A.ac(b)||b===t.K)return b
-else if(s===1)return A.bb(a,"J",[b])
-else if(b===t.P||b===t.T)return t.bc}r=new A.F(null,null)
+if(A.ah(b)||b===t.K)return b
+else if(s===1)return A.br(a,"M",[b])
+else if(b===t.P||b===t.T)return t.bc}r=new A.J(null,null)
 r.w=7
 r.x=b
 r.as=c
-return A.X(a,r)},
-fL(a,b){var s,r,q=""+b+"^",p=a.eC.get(q)
+return A.a0(a,r)},
+hg(a,b){var s,r,q=""+b+"^",p=a.eC.get(q)
 if(p!=null)return p
-s=new A.F(null,null)
+s=new A.J(null,null)
 s.w=13
 s.x=b
 s.as=q
-r=A.X(a,s)
+r=A.a0(a,s)
 a.eC.set(q,r)
 return r},
-ba(a){var s,r,q,p=a.length
+bq(a){var s,r,q,p=a.length
 for(s="",r="",q=0;q<p;++q,r=",")s+=r+a[q].as
 return s},
-fH(a){var s,r,q,p,o,n=a.length
+hc(a){var s,r,q,p,o,n=a.length
 for(s="",r="",q=0;q<n;q+=3,r=","){p=a[q]
 o=a[q+1]?"!":":"
 s+=r+p+o+a[q+2].as}return s},
-bb(a,b,c){var s,r,q,p=b
-if(c.length>0)p+="<"+A.ba(c)+">"
+br(a,b,c){var s,r,q,p=b
+if(c.length>0)p+="<"+A.bq(c)+">"
 s=a.eC.get(p)
 if(s!=null)return s
-r=new A.F(null,null)
+r=new A.J(null,null)
 r.w=8
 r.x=b
 r.y=c
 if(c.length>0)r.c=c[0]
 r.as=p
-q=A.X(a,r)
+q=A.a0(a,r)
 a.eC.set(p,q)
 return q},
-dr(a,b,c){var s,r,q,p,o,n
+dY(a,b,c){var s,r,q,p,o,n
 if(b.w===9){s=b.x
 r=b.y.concat(c)}else{r=c
-s=b}q=s.as+(";<"+A.ba(r)+">")
+s=b}q=s.as+(";<"+A.bq(r)+">")
 p=a.eC.get(q)
 if(p!=null)return p
-o=new A.F(null,null)
+o=new A.J(null,null)
 o.w=9
 o.x=s
 o.y=r
 o.as=q
-n=A.X(a,o)
+n=A.a0(a,o)
 a.eC.set(q,n)
 return n},
-ej(a,b,c){var s,r,q="+"+(b+"("+A.ba(c)+")"),p=a.eC.get(q)
+eO(a,b,c){var s,r,q="+"+(b+"("+A.bq(c)+")"),p=a.eC.get(q)
 if(p!=null)return p
-s=new A.F(null,null)
+s=new A.J(null,null)
 s.w=10
 s.x=b
 s.y=c
 s.as=q
-r=A.X(a,s)
+r=A.a0(a,s)
 a.eC.set(q,r)
 return r},
-eg(a,b,c){var s,r,q,p,o,n=b.as,m=c.a,l=m.length,k=c.b,j=k.length,i=c.c,h=i.length,g="("+A.ba(m)
+eL(a,b,c){var s,r,q,p,o,n=b.as,m=c.a,l=m.length,k=c.b,j=k.length,i=c.c,h=i.length,g="("+A.bq(m)
 if(j>0){s=l>0?",":""
-g+=s+"["+A.ba(k)+"]"}if(h>0){s=l>0?",":""
-g+=s+"{"+A.fH(i)+"}"}r=n+(g+")")
+g+=s+"["+A.bq(k)+"]"}if(h>0){s=l>0?",":""
+g+=s+"{"+A.hc(i)+"}"}r=n+(g+")")
 q=a.eC.get(r)
 if(q!=null)return q
-p=new A.F(null,null)
+p=new A.J(null,null)
 p.w=11
 p.x=b
 p.y=c
 p.as=r
-o=A.X(a,p)
+o=A.a0(a,p)
 a.eC.set(r,o)
 return o},
-ds(a,b,c,d){var s,r=b.as+("<"+A.ba(c)+">"),q=a.eC.get(r)
+dZ(a,b,c,d){var s,r=b.as+("<"+A.bq(c)+">"),q=a.eC.get(r)
 if(q!=null)return q
-s=A.fJ(a,b,c,r,d)
+s=A.he(a,b,c,r,d)
 a.eC.set(r,s)
 return s},
-fJ(a,b,c,d,e){var s,r,q,p,o,n,m,l
+he(a,b,c,d,e){var s,r,q,p,o,n,m,l
 if(e){s=c.length
-r=A.cM(s)
+r=A.dd(s)
 for(q=0,p=0;p<s;++p){o=c[p]
-if(o.w===1){r[p]=o;++q}}if(q>0){n=A.a8(a,b,r,0)
-m=A.ar(a,c,r,0)
-return A.ds(a,n,m,c!==m)}}l=new A.F(null,null)
+if(o.w===1){r[p]=o;++q}}if(q>0){n=A.ac(a,b,r,0)
+m=A.aB(a,c,r,0)
+return A.dZ(a,n,m,c!==m)}}l=new A.J(null,null)
 l.w=12
 l.x=b
 l.y=c
 l.as=d
-return A.X(a,l)},
-ec(a,b,c,d){return{u:a,e:b,r:c,s:[],p:0,n:d}},
-ee(a){var s,r,q,p,o,n,m,l=a.r,k=a.s
+return A.a0(a,l)},
+eG(a,b,c,d){return{u:a,e:b,r:c,s:[],p:0,n:d}},
+eI(a){var s,r,q,p,o,n,m,l=a.r,k=a.s
 for(s=l.length,r=0;r<s;){q=l.charCodeAt(r)
-if(q>=48&&q<=57)r=A.fB(r+1,q,l,k)
-else if((((q|32)>>>0)-97&65535)<26||q===95||q===36||q===124)r=A.ed(a,r,l,k,!1)
-else if(q===46)r=A.ed(a,r,l,k,!0)
+if(q>=48&&q<=57)r=A.h5(r+1,q,l,k)
+else if((((q|32)>>>0)-97&65535)<26||q===95||q===36||q===124)r=A.eH(a,r,l,k,!1)
+else if(q===46)r=A.eH(a,r,l,k,!0)
 else{++r
 switch(q){case 44:break
 case 58:k.push(!1)
 break
 case 33:k.push(!0)
 break
-case 59:k.push(A.a6(a.u,a.e,k.pop()))
+case 59:k.push(A.a9(a.u,a.e,k.pop()))
 break
-case 94:k.push(A.fL(a.u,k.pop()))
+case 94:k.push(A.hg(a.u,k.pop()))
 break
-case 35:k.push(A.bc(a.u,5,"#"))
+case 35:k.push(A.bs(a.u,5,"#"))
 break
-case 64:k.push(A.bc(a.u,2,"@"))
+case 64:k.push(A.bs(a.u,2,"@"))
 break
-case 126:k.push(A.bc(a.u,3,"~"))
+case 126:k.push(A.bs(a.u,3,"~"))
 break
 case 60:k.push(a.p)
 a.p=k.length
 break
-case 62:A.fD(a,k)
+case 62:A.h7(a,k)
 break
-case 38:A.fC(a,k)
+case 38:A.h6(a,k)
 break
 case 63:p=a.u
-k.push(A.ei(p,A.a6(p,a.e,k.pop()),a.n))
+k.push(A.eN(p,A.a9(p,a.e,k.pop()),a.n))
 break
 case 47:p=a.u
-k.push(A.eh(p,A.a6(p,a.e,k.pop()),a.n))
+k.push(A.eM(p,A.a9(p,a.e,k.pop()),a.n))
 break
 case 40:k.push(-3)
 k.push(a.p)
 a.p=k.length
 break
-case 41:A.fA(a,k)
+case 41:A.h4(a,k)
 break
 case 91:k.push(a.p)
 a.p=k.length
 break
 case 93:o=k.splice(a.p)
-A.ef(a.u,a.e,o)
+A.eJ(a.u,a.e,o)
 a.p=k.pop()
 k.push(o)
 k.push(-1)
@@ -1099,7 +1109,7 @@ case 123:k.push(a.p)
 a.p=k.length
 break
 case 125:o=k.splice(a.p)
-A.fF(a.u,a.e,o)
+A.h9(a.u,a.e,o)
 a.p=k.pop()
 k.push(o)
 k.push(-2)
@@ -1112,13 +1122,13 @@ a.p=k.length
 r=n+1
 break
 default:throw"Bad character "+q}}}m=k.pop()
-return A.a6(a.u,a.e,m)},
-fB(a,b,c,d){var s,r,q=b-48
+return A.a9(a.u,a.e,m)},
+h5(a,b,c,d){var s,r,q=b-48
 for(s=c.length;a<s;++a){r=c.charCodeAt(a)
 if(!(r>=48&&r<=57))break
 q=q*10+(r-48)}d.push(q)
 return a},
-ed(a,b,c,d,e){var s,r,q,p,o,n,m=b+1
+eH(a,b,c,d,e){var s,r,q,p,o,n,m=b+1
 for(s=c.length;m<s;++m){r=c.charCodeAt(m)
 if(r===46){if(e)break
 e=!0}else{if(!((((r|32)>>>0)-97&65535)<26||r===95||r===36||r===124))q=r>=48&&r<=57
@@ -1127,55 +1137,55 @@ if(!q)break}}p=c.substring(b,m)
 if(e){s=a.u
 o=a.e
 if(o.w===9)o=o.x
-n=A.fP(s,o.x)[p]
-if(n==null)A.c1('No "'+p+'" in "'+A.fo(o)+'"')
-d.push(A.bd(s,o,n))}else d.push(p)
+n=A.hk(s,o.x)[p]
+if(n==null)A.co('No "'+p+'" in "'+A.fR(o)+'"')
+d.push(A.bt(s,o,n))}else d.push(p)
 return m},
-fD(a,b){var s,r=a.u,q=A.eb(a,b),p=b.pop()
-if(typeof p=="string")b.push(A.bb(r,p,q))
-else{s=A.a6(r,a.e,p)
-switch(s.w){case 11:b.push(A.ds(r,s,q,a.n))
+h7(a,b){var s,r=a.u,q=A.eF(a,b),p=b.pop()
+if(typeof p=="string")b.push(A.br(r,p,q))
+else{s=A.a9(r,a.e,p)
+switch(s.w){case 11:b.push(A.dZ(r,s,q,a.n))
 break
-default:b.push(A.dr(r,s,q))
+default:b.push(A.dY(r,s,q))
 break}}},
-fA(a,b){var s,r,q,p=a.u,o=b.pop(),n=null,m=null
+h4(a,b){var s,r,q,p=a.u,o=b.pop(),n=null,m=null
 if(typeof o=="number")switch(o){case-1:n=b.pop()
 break
 case-2:m=b.pop()
 break
 default:b.push(o)
 break}else b.push(o)
-s=A.eb(a,b)
+s=A.eF(a,b)
 o=b.pop()
 switch(o){case-3:o=b.pop()
 if(n==null)n=p.sEA
 if(m==null)m=p.sEA
-r=A.a6(p,a.e,o)
-q=new A.bX()
+r=A.a9(p,a.e,o)
+q=new A.cg()
 q.a=s
 q.b=n
 q.c=m
-b.push(A.eg(p,r,q))
+b.push(A.eL(p,r,q))
 return
-case-4:b.push(A.ej(p,b.pop(),s))
+case-4:b.push(A.eO(p,b.pop(),s))
 return
-default:throw A.i(A.bk("Unexpected state under `()`: "+A.n(o)))}},
-fC(a,b){var s=b.pop()
-if(0===s){b.push(A.bc(a.u,1,"0&"))
-return}if(1===s){b.push(A.bc(a.u,4,"1&"))
-return}throw A.i(A.bk("Unexpected extended operation "+A.n(s)))},
-eb(a,b){var s=b.splice(a.p)
-A.ef(a.u,a.e,s)
+default:throw A.e(A.bA("Unexpected state under `()`: "+A.m(o)))}},
+h6(a,b){var s=b.pop()
+if(0===s){b.push(A.bs(a.u,1,"0&"))
+return}if(1===s){b.push(A.bs(a.u,4,"1&"))
+return}throw A.e(A.bA("Unexpected extended operation "+A.m(s)))},
+eF(a,b){var s=b.splice(a.p)
+A.eJ(a.u,a.e,s)
 a.p=b.pop()
 return s},
-a6(a,b,c){if(typeof c=="string")return A.bb(a,c,a.sEA)
+a9(a,b,c){if(typeof c=="string")return A.br(a,c,a.sEA)
 else if(typeof c=="number"){b.toString
-return A.fE(a,b,c)}else return c},
-ef(a,b,c){var s,r=c.length
-for(s=0;s<r;++s)c[s]=A.a6(a,b,c[s])},
-fF(a,b,c){var s,r=c.length
-for(s=2;s<r;s+=3)c[s]=A.a6(a,b,c[s])},
-fE(a,b,c){var s,r,q=b.w
+return A.h8(a,b,c)}else return c},
+eJ(a,b,c){var s,r=c.length
+for(s=0;s<r;++s)c[s]=A.a9(a,b,c[s])},
+h9(a,b,c){var s,r=c.length
+for(s=2;s<r;s+=3)c[s]=A.a9(a,b,c[s])},
+h8(a,b,c){var s,r,q=b.w
 if(q===9){if(c===0)return b.x
 s=b.y
 r=s.length
@@ -1183,32 +1193,32 @@ if(c<=r)return s[c-1]
 c-=r
 b=b.x
 q=b.w}else if(c===0)return b
-if(q!==8)throw A.i(A.bk("Indexed base must be an interface type"))
+if(q!==8)throw A.e(A.bA("Indexed base must be an interface type"))
 s=b.y
 if(c<=s.length)return s[c-1]
-throw A.i(A.bk("Bad index "+c+" for "+b.i(0)))},
-hQ(a,b,c){var s,r=b.d
+throw A.e(A.bA("Bad index "+c+" for "+b.i(0)))},
+ip(a,b,c){var s,r=b.d
 if(r==null)r=b.d=new Map()
 s=r.get(c)
-if(s==null){s=A.p(a,b,null,c,null)
+if(s==null){s=A.t(a,b,null,c,null)
 r.set(c,s)}return s},
-p(a,b,c,d,e){var s,r,q,p,o,n,m,l,k,j,i
+t(a,b,c,d,e){var s,r,q,p,o,n,m,l,k,j,i
 if(b===d)return!0
-if(A.ac(d))return!0
+if(A.ah(d))return!0
 s=b.w
 if(s===4)return!0
-if(A.ac(b))return!1
+if(A.ah(b))return!1
 if(b.w===1)return!0
 r=s===13
-if(r)if(A.p(a,c[b.x],c,d,e))return!0
+if(r)if(A.t(a,c[b.x],c,d,e))return!0
 q=d.w
 p=t.P
-if(b===p||b===t.T){if(q===7)return A.p(a,b,c,d.x,e)
-return d===p||d===t.T||q===6}if(d===t.K){if(s===7)return A.p(a,b.x,c,d,e)
-return s!==6}if(s===7){if(!A.p(a,b.x,c,d,e))return!1
-return A.p(a,A.dl(a,b),c,d,e)}if(s===6)return A.p(a,p,c,d,e)&&A.p(a,b.x,c,d,e)
-if(q===7){if(A.p(a,b,c,d.x,e))return!0
-return A.p(a,b,c,A.dl(a,d),e)}if(q===6)return A.p(a,b,c,p,e)||A.p(a,b,c,d.x,e)
+if(b===p||b===t.T){if(q===7)return A.t(a,b,c,d.x,e)
+return d===p||d===t.T||q===6}if(d===t.K){if(s===7)return A.t(a,b.x,c,d,e)
+return s!==6}if(s===7){if(!A.t(a,b.x,c,d,e))return!1
+return A.t(a,A.dS(a,b),c,d,e)}if(s===6)return A.t(a,p,c,d,e)&&A.t(a,b.x,c,d,e)
+if(q===7){if(A.t(a,b,c,d.x,e))return!0
+return A.t(a,b,c,A.dS(a,d),e)}if(q===6)return A.t(a,b,c,p,e)||A.t(a,b,c,d.x,e)
 if(r)return!1
 p=s!==11
 if((!p||s===12)&&d===t.Z)return!0
@@ -1224,13 +1234,13 @@ c=c==null?n:n.concat(c)
 e=e==null?m:m.concat(e)
 for(k=0;k<l;++k){j=n[k]
 i=m[k]
-if(!A.p(a,j,c,i,e)||!A.p(a,i,e,j,c))return!1}return A.es(a,b.x,c,d.x,e)}if(q===11){if(b===t.g)return!0
+if(!A.t(a,j,c,i,e)||!A.t(a,i,e,j,c))return!1}return A.eU(a,b.x,c,d.x,e)}if(q===11){if(b===t.g)return!0
 if(p)return!1
-return A.es(a,b,c,d,e)}if(s===8){if(q!==8)return!1
-return A.hc(a,b,c,d,e)}if(o&&q===10)return A.hh(a,b,c,d,e)
+return A.eU(a,b,c,d,e)}if(s===8){if(q!==8)return!1
+return A.hJ(a,b,c,d,e)}if(o&&q===10)return A.hO(a,b,c,d,e)
 return!1},
-es(a3,a4,a5,a6,a7){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d,c,b,a,a0,a1,a2
-if(!A.p(a3,a4.x,a5,a6.x,a7))return!1
+eU(a3,a4,a5,a6,a7){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d,c,b,a,a0,a1,a2
+if(!A.t(a3,a4.x,a5,a6.x,a7))return!1
 s=a4.y
 r=a6.y
 q=s.a
@@ -1245,9 +1255,9 @@ j=l.length
 i=k.length
 if(o+j<n+i)return!1
 for(h=0;h<o;++h){g=q[h]
-if(!A.p(a3,p[h],a7,g,a5))return!1}for(h=0;h<m;++h){g=l[h]
-if(!A.p(a3,p[o+h],a7,g,a5))return!1}for(h=0;h<i;++h){g=l[m+h]
-if(!A.p(a3,k[h],a7,g,a5))return!1}f=s.c
+if(!A.t(a3,p[h],a7,g,a5))return!1}for(h=0;h<m;++h){g=l[h]
+if(!A.t(a3,p[o+h],a7,g,a5))return!1}for(h=0;h<i;++h){g=l[m+h]
+if(!A.t(a3,k[h],a7,g,a5))return!1}f=s.c
 e=r.c
 d=f.length
 c=e.length
@@ -1261,10 +1271,10 @@ if(a1<a0){if(a2)return!1
 continue}g=e[a+1]
 if(a2&&!g)return!1
 g=f[b-1]
-if(!A.p(a3,e[a+2],a7,g,a5))return!1
+if(!A.t(a3,e[a+2],a7,g,a5))return!1
 break}}while(b<d){if(f[b+1])return!1
 b+=3}return!0},
-hc(a,b,c,d,e){var s,r,q,p,o,n=b.x,m=d.x
+hJ(a,b,c,d,e){var s,r,q,p,o,n=b.x,m=d.x
 while(n!==m){s=a.tR[n]
 if(s==null)return!1
 if(typeof s=="string"){n=s
@@ -1272,109 +1282,114 @@ continue}r=s[m]
 if(r==null)return!1
 q=r.length
 p=q>0?new Array(q):v.typeUniverse.sEA
-for(o=0;o<q;++o)p[o]=A.bd(a,b,r[o])
-return A.em(a,p,null,c,d.y,e)}return A.em(a,b.y,null,c,d.y,e)},
-em(a,b,c,d,e,f){var s,r=b.length
-for(s=0;s<r;++s)if(!A.p(a,b[s],d,e[s],f))return!1
+for(o=0;o<q;++o)p[o]=A.bt(a,b,r[o])
+return A.eR(a,p,null,c,d.y,e)}return A.eR(a,b.y,null,c,d.y,e)},
+eR(a,b,c,d,e,f){var s,r=b.length
+for(s=0;s<r;++s)if(!A.t(a,b[s],d,e[s],f))return!1
 return!0},
-hh(a,b,c,d,e){var s,r=b.y,q=d.y,p=r.length
+hO(a,b,c,d,e){var s,r=b.y,q=d.y,p=r.length
 if(p!==q.length)return!1
 if(b.x!==d.x)return!1
-for(s=0;s<p;++s)if(!A.p(a,r[s],c,q[s],e))return!1
+for(s=0;s<p;++s)if(!A.t(a,r[s],c,q[s],e))return!1
 return!0},
-av(a){var s=a.w,r=!0
-if(!(a===t.P||a===t.T))if(!A.ac(a))if(s!==6)r=s===7&&A.av(a.x)
+aF(a){var s=a.w,r=!0
+if(!(a===t.P||a===t.T))if(!A.ah(a))if(s!==6)r=s===7&&A.aF(a.x)
 return r},
-ac(a){var s=a.w
+ah(a){var s=a.w
 return s===2||s===3||s===4||s===5||a===t.X},
-el(a,b){var s,r,q=Object.keys(b),p=q.length
+eQ(a,b){var s,r,q=Object.keys(b),p=q.length
 for(s=0;s<p;++s){r=q[s]
 a[r]=b[r]}},
-cM(a){return a>0?new Array(a):v.typeUniverse.sEA},
-F:function F(a,b){var _=this
+dd(a){return a>0?new Array(a):v.typeUniverse.sEA},
+J:function J(a,b){var _=this
 _.a=a
 _.b=b
 _.r=_.f=_.d=_.c=null
 _.w=0
 _.as=_.Q=_.z=_.y=_.x=null},
-bX:function bX(){this.c=this.b=this.a=null},
-cK:function cK(a){this.a=a},
-bW:function bW(){},
-b9:function b9(a){this.a=a},
-fw(){var s,r,q
-if(self.scheduleImmediate!=null)return A.hz()
+cg:function cg(){this.c=this.b=this.a=null},
+db:function db(a){this.a=a},
+cf:function cf(){},
+bp:function bp(a){this.a=a},
+h0(){var s,r,q
+if(self.scheduleImmediate!=null)return A.i4()
 if(self.MutationObserver!=null&&self.document!=null){s={}
 r=self.document.createElement("div")
 q=self.document.createElement("span")
 s.a=null
-new self.MutationObserver(A.bi(new A.cr(s),1)).observe(r,{childList:true})
-return new A.cq(s,r,q)}else if(self.setImmediate!=null)return A.hA()
-return A.hB()},
-fx(a){self.scheduleImmediate(A.bi(new A.cs(t.M.a(a)),0))},
-fy(a){self.setImmediate(A.bi(new A.ct(t.M.a(a)),0))},
-fz(a){t.M.a(a)
-A.fG(0,a)},
-fG(a,b){var s=new A.cI()
-s.ag(a,b)
+new self.MutationObserver(A.aD(new A.cS(s),1)).observe(r,{childList:true})
+return new A.cR(s,r,q)}else if(self.setImmediate!=null)return A.i5()
+return A.i6()},
+h1(a){self.scheduleImmediate(A.aD(new A.cT(t.M.a(a)),0))},
+h2(a){self.setImmediate(A.aD(new A.cU(t.M.a(a)),0))},
+h3(a){t.M.a(a)
+A.ha(0,a)},
+ey(a,b){return A.hb(a.a/1000|0,b)},
+ha(a,b){var s=new A.bo(!0)
+s.ap(a,b)
 return s},
-cT(a){return new A.bT(new A.q($.o,a.h("q<0>")),a.h("bT<0>"))},
-cP(a,b){a.$2(0,null)
+hb(a,b){var s=new A.bo(!1)
+s.aq(a,b)
+return s},
+dl(a){return new A.cc(new A.v($.n,a.h("v<0>")),a.h("cc<0>"))},
+dh(a,b){a.$2(0,null)
 b.b=!0
 return b.a},
-dt(a,b){A.fY(a,b)},
-cO(a,b){b.W(a)},
-cN(a,b){b.X(A.aw(a),A.at(a))},
-fY(a,b){var s,r,q=new A.cQ(b),p=new A.cR(b)
-if(a instanceof A.q)a.a7(q,p,t.z)
+e_(a,b){A.ht(a,b)},
+dg(a,b){b.a_(a)},
+df(a,b){b.a0(A.aj(a),A.ag(a))},
+ht(a,b){var s,r,q=new A.di(b),p=new A.dj(b)
+if(a instanceof A.v)a.af(q,p,t.z)
 else{s=t.z
-if(a instanceof A.q)a.ae(q,p,s)
-else{r=new A.q($.o,t._)
+if(a instanceof A.v)a.a3(q,p,s)
+else{r=new A.v($.n,t._)
 r.a=8
 r.c=a
-r.a7(q,p,s)}}},
-cV(a){var s=function(b,c){return function(d,e){while(true){try{b(d,e)
+r.af(q,p,s)}}},
+dp(a){var s=function(b,c){return function(d,e){while(true){try{b(d,e)
 break}catch(r){e=r
 d=c}}}}(a,1)
-return $.o.ad(new A.cW(s),t.H,t.S,t.z)},
-db(a){var s
+return $.n.ak(new A.dq(s),t.H,t.S,t.z)},
+eK(a,b,c){return 0},
+dJ(a){var s
 if(t.C.b(a)){s=a.gF()
-if(s!=null)return s}return B.d},
-h8(a,b){if($.o===B.b)return null
+if(s!=null)return s}return B.e},
+hF(a,b){if($.n===B.b)return null
 return null},
-h9(a,b){if($.o!==B.b)A.h8(a,b)
+hG(a,b){if($.n!==B.b)A.hF(a,b)
 if(b==null)if(t.C.b(a)){b=a.gF()
-if(b==null){A.e0(a,B.d)
-b=B.d}}else b=B.d
-else if(t.C.b(a))A.e0(a,b)
-return new A.C(a,b)},
-dn(a,b,c){var s,r,q,p,o={},n=o.a=a
+if(b==null){A.eu(a,B.e)
+b=B.e}}else b=B.e
+else if(t.C.b(a))A.eu(a,b)
+return new A.H(a,b)},
+dV(a,b,c){var s,r,q,p,o={},n=o.a=a
 for(s=t._;r=n.a,(r&4)!==0;n=a){a=s.a(n.c)
-o.a=a}if(n===b){s=A.fp()
-b.N(new A.C(new A.N(!0,n,null,"Cannot complete a future with itself"),s))
+o.a=a}if(n===b){s=A.fS()
+b.O(new A.H(new A.Q(!0,n,null,"Cannot complete a future with itself"),s))
 return}q=b.a&1
 s=n.a=r|q
 if((s&24)===0){p=t.F.a(b.c)
 b.a=b.a&1|4
 b.c=n
-n.a6(p)
+n.ad(p)
 return}if(!c)if(b.c==null)n=(s&16)===0||q!==0
 else n=!1
 else n=!0
 if(n){p=b.H()
 b.G(o.a)
-A.ak(b,p)
+A.as(b,p)
 return}b.a^=2
-A.c0(null,null,b.b,t.M.a(new A.cy(o,b)))},
-ak(a,b){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d={},c=d.a=a
+A.cm(null,null,b.b,t.M.a(new A.cZ(o,b)))},
+as(a,b){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d={},c=d.a=a
 for(s=t.n,r=t.F;;){q={}
 p=c.a
 o=(p&16)===0
 n=!o
 if(b==null){if(n&&(p&1)===0){m=s.a(c.c)
-A.dx(m.a,m.b)}return}q.a=b
+A.dm(m.a,m.b)}return}q.a=b
 l=b.a
 for(c=b;l!=null;c=l,l=k){c.a=null
-A.ak(d.a,c)
+A.as(d.a,c)
 q.a=l
 k=l.a}p=d.a
 j=p.c
@@ -1386,17 +1401,17 @@ if(i){h=c.b.b
 if(n){p=p.b===h
 p=!(p||p)}else p=!1
 if(p){s.a(j)
-A.dx(j.a,j.b)
-return}g=$.o
-if(g!==h)$.o=h
+A.dm(j.a,j.b)
+return}g=$.n
+if(g!==h)$.n=h
 else g=null
 c=c.c
-if((c&15)===8)new A.cC(q,d,n).$0()
-else if(o){if((c&1)!==0)new A.cB(q,j).$0()}else if((c&2)!==0)new A.cA(d,q).$0()
-if(g!=null)$.o=g
+if((c&15)===8)new A.d2(q,d,n).$0()
+else if(o){if((c&1)!==0)new A.d1(q,j).$0()}else if((c&2)!==0)new A.d0(d,q).$0()
+if(g!=null)$.n=g
 c=q.c
-if(c instanceof A.q){p=q.a.$ti
-p=p.h("J<2>").b(c)||!p.y[1].b(c)}else p=!1
+if(c instanceof A.v){p=q.a.$ti
+p=p.h("M<2>").b(c)||!p.y[1].b(c)}else p=!1
 if(p){f=q.a.b
 if((c.a&24)!==0){e=r.a(f.c)
 f.c=null
@@ -1404,7 +1419,7 @@ b=f.I(e)
 f.a=c.a&30|f.a&1
 f.c=c.c
 d.a=c
-continue}else A.dn(c,f,!0)
+continue}else A.dV(c,f,!0)
 return}}f=q.a.b
 e=r.a(f.c)
 f.c=null
@@ -1417,374 +1432,475 @@ f.c=p}else{s.a(p)
 f.a=f.a&1|16
 f.c=p}d.a=f
 c=f}},
-ho(a,b){var s
-if(t.Q.b(a))return b.ad(a,t.z,t.K,t.l)
+hV(a,b){var s
+if(t.Q.b(a))return b.ak(a,t.z,t.K,t.l)
 s=t.v
 if(s.b(a))return s.a(a)
-throw A.i(A.dP(a,"onError",u.c))},
-hm(){var s,r
-for(s=$.aq;s!=null;s=$.aq){$.bh=null
+throw A.e(A.eh(a,"onError",u.c))},
+hT(){var s,r
+for(s=$.aA;s!=null;s=$.aA){$.bw=null
 r=s.b
-$.aq=r
-if(r==null)$.bg=null
+$.aA=r
+if(r==null)$.bv=null
 s.a.$0()}},
-hu(){$.dv=!0
-try{A.hm()}finally{$.bh=null
-$.dv=!1
-if($.aq!=null)$.dN().$1(A.eB())}},
-ez(a){var s=new A.bU(a),r=$.bg
-if(r==null){$.aq=$.bg=s
-if(!$.dv)$.dN().$1(A.eB())}else $.bg=r.b=s},
-hr(a){var s,r,q,p=$.aq
-if(p==null){A.ez(a)
-$.bh=$.bg
-return}s=new A.bU(a)
-r=$.bh
+i_(){$.e1=!0
+try{A.hT()}finally{$.bw=null
+$.e1=!1
+if($.aA!=null)$.ef().$1(A.f4())}},
+f2(a){var s=new A.cd(a),r=$.bv
+if(r==null){$.aA=$.bv=s
+if(!$.e1)$.ef().$1(A.f4())}else $.bv=r.b=s},
+hX(a){var s,r,q,p=$.aA
+if(p==null){A.f2(a)
+$.bw=$.bv
+return}s=new A.cd(a)
+r=$.bw
 if(r==null){s.b=p
-$.aq=$.bh=s}else{q=r.b
+$.aA=$.bw=s}else{q=r.b
 s.b=q
-$.bh=r.b=s
-if(q==null)$.bg=s}},
-i1(a,b){A.cX(a,"stream",t.K)
-return new A.bZ(b.h("bZ<0>"))},
-dx(a,b){A.hr(new A.cU(a,b))},
-ex(a,b,c,d,e){var s,r=$.o
+$.bw=r.b=s
+if(q==null)$.bv=s}},
+iA(a,b){A.dr(a,"stream",t.K)
+return new A.ci(b.h("ci<0>"))},
+fT(a,b){var s=$.n
+if(s===B.b)return A.ey(a,t.d.a(b))
+return A.ey(a,t.d.a(s.aH(b,t.p)))},
+dm(a,b){A.hX(new A.dn(a,b))},
+f_(a,b,c,d,e){var s,r=$.n
 if(r===c)return d.$0()
-$.o=c
+$.n=c
 s=r
 try{r=d.$0()
-return r}finally{$.o=s}},
-hq(a,b,c,d,e,f,g){var s,r=$.o
+return r}finally{$.n=s}},
+f0(a,b,c,d,e,f,g){var s,r=$.n
 if(r===c)return d.$1(e)
-$.o=c
+$.n=c
 s=r
 try{r=d.$1(e)
-return r}finally{$.o=s}},
-hp(a,b,c,d,e,f,g,h,i){var s,r=$.o
+return r}finally{$.n=s}},
+hW(a,b,c,d,e,f,g,h,i){var s,r=$.n
 if(r===c)return d.$2(e,f)
-$.o=c
+$.n=c
 s=r
 try{r=d.$2(e,f)
-return r}finally{$.o=s}},
-c0(a,b,c,d){t.M.a(d)
-if(B.b!==c){d=c.ar(d)
-d=d}A.ez(d)},
-cr:function cr(a){this.a=a},
-cq:function cq(a,b,c){this.a=a
+return r}finally{$.n=s}},
+cm(a,b,c,d){t.M.a(d)
+if(B.b!==c){d=c.aG(d)
+d=d}A.f2(d)},
+cS:function cS(a){this.a=a},
+cR:function cR(a,b,c){this.a=a
 this.b=b
 this.c=c},
-cs:function cs(a){this.a=a},
-ct:function ct(a){this.a=a},
-cI:function cI(){},
-cJ:function cJ(a,b){this.a=a
+cT:function cT(a){this.a=a},
+cU:function cU(a){this.a=a},
+bo:function bo(a){this.a=a
+this.b=null
+this.c=0},
+da:function da(a,b){this.a=a
 this.b=b},
-bT:function bT(a,b){this.a=a
+d9:function d9(a,b,c,d){var _=this
+_.a=a
+_.b=b
+_.c=c
+_.d=d},
+cc:function cc(a,b){this.a=a
 this.b=!1
 this.$ti=b},
-cQ:function cQ(a){this.a=a},
-cR:function cR(a){this.a=a},
-cW:function cW(a){this.a=a},
-C:function C(a,b){this.a=a
-this.b=b},
-bV:function bV(){},
-aY:function aY(a,b){this.a=a
+di:function di(a){this.a=a},
+dj:function dj(a){this.a=a},
+dq:function dq(a){this.a=a},
+bn:function bn(a,b){var _=this
+_.a=a
+_.e=_.d=_.c=_.b=null
+_.$ti=b},
+aw:function aw(a,b){this.a=a
 this.$ti=b},
-a5:function a5(a,b,c,d,e){var _=this
+H:function H(a,b){this.a=a
+this.b=b},
+ce:function ce(){},
+b9:function b9(a,b){this.a=a
+this.$ti=b},
+a8:function a8(a,b,c,d,e){var _=this
 _.a=null
 _.b=a
 _.c=b
 _.d=c
 _.e=d
 _.$ti=e},
-q:function q(a,b){var _=this
+v:function v(a,b){var _=this
 _.a=0
 _.b=a
 _.c=null
 _.$ti=b},
-cv:function cv(a,b){this.a=a
+cW:function cW(a,b){this.a=a
 this.b=b},
-cz:function cz(a,b){this.a=a
+d_:function d_(a,b){this.a=a
 this.b=b},
-cy:function cy(a,b){this.a=a
+cZ:function cZ(a,b){this.a=a
 this.b=b},
-cx:function cx(a,b){this.a=a
+cY:function cY(a,b){this.a=a
 this.b=b},
-cw:function cw(a,b){this.a=a
+cX:function cX(a,b){this.a=a
 this.b=b},
-cC:function cC(a,b,c){this.a=a
+d2:function d2(a,b,c){this.a=a
 this.b=b
 this.c=c},
-cD:function cD(a,b){this.a=a
+d3:function d3(a,b){this.a=a
 this.b=b},
-cE:function cE(a){this.a=a},
-cB:function cB(a,b){this.a=a
+d4:function d4(a){this.a=a},
+d1:function d1(a,b){this.a=a
 this.b=b},
-cA:function cA(a,b){this.a=a
+d0:function d0(a,b){this.a=a
 this.b=b},
-bU:function bU(a){this.a=a
+cd:function cd(a){this.a=a
 this.b=null},
-bZ:function bZ(a){this.$ti=a},
-be:function be(){},
-cU:function cU(a,b){this.a=a
+ci:function ci(a){this.$ti=a},
+bu:function bu(){},
+dn:function dn(a,b){this.a=a
 this.b=b},
-bY:function bY(){},
-cH:function cH(a,b){this.a=a
+ch:function ch(){},
+d7:function d7(a,b){this.a=a
 this.b=b},
-ea(a,b){var s=a[b]
+d8:function d8(a,b,c){this.a=a
+this.b=b
+this.c=c},
+eE(a,b){var s=a[b]
 return s===a?null:s},
-dq(a,b,c){if(c==null)a[b]=a
+dX(a,b,c){if(c==null)a[b]=a
 else a[b]=c},
-dp(){var s=Object.create(null)
-A.dq(s,"<non-identifier-key>",s)
+dW(){var s=Object.create(null)
+A.dX(s,"<non-identifier-key>",s)
 delete s["<non-identifier-key>"]
 return s},
-di(a,b,c){return b.h("@<0>").j(c).h("dX<1,2>").a(A.hH(a,new A.a2(b.h("@<0>").j(c).h("a2<1,2>"))))},
-dh(a,b){return new A.a2(a.h("@<0>").j(b).h("a2<1,2>"))},
-dY(a){var s,r
-if(A.dG(a))return"{...}"
-s=new A.bN("")
+C(a,b,c){return b.h("@<0>").k(c).h("eq<1,2>").a(A.id(a,new A.a6(b.h("@<0>").k(c).h("a6<1,2>"))))},
+dO(a,b){return new A.a6(a.h("@<0>").k(b).h("a6<1,2>"))},
+dP(a){var s,r
+if(A.ea(a))return"{...}"
+s=new A.c5("")
 try{r={}
-B.a.u($.B,a)
+B.a.u($.G,a)
 s.a+="{"
 r.a=!0
-a.E(0,new A.cd(r,s))
-s.a+="}"}finally{if(0>=$.B.length)return A.x($.B,-1)
-$.B.pop()}r=s.a
+a.E(0,new A.cA(r,s))
+s.a+="}"}finally{if(0>=$.G.length)return A.y($.G,-1)
+$.G.pop()}r=s.a
 return r.charCodeAt(0)==0?r:r},
-b_:function b_(){},
-al:function al(a){var _=this
+bb:function bb(){},
+at:function at(a){var _=this
 _.a=0
 _.e=_.d=_.c=_.b=null
 _.$ti=a},
-b0:function b0(a,b){this.a=a
+bc:function bc(a,b){this.a=a
 this.$ti=b},
-b1:function b1(a,b,c){var _=this
+bd:function bd(a,b,c){var _=this
 _.a=a
 _.b=b
 _.c=0
 _.d=null
 _.$ti=c},
+f:function f(){},
 k:function k(){},
-e:function e(){},
-cc:function cc(a){this.a=a},
-cd:function cd(a,b){this.a=a
+cz:function cz(a){this.a=a},
+cA:function cA(a,b){this.a=a
 this.b=b},
-f5(a,b){a=A.r(a,new Error())
-if(a==null)a=A.bf(a)
+fz(a,b){a=A.w(a,new Error())
+if(a==null)a=A.ay(a)
 a.stack=b.i(0)
 throw a},
-fe(a,b,c,d){var s,r=c?J.fa(a,d):J.f9(a,d)
+fH(a,b,c,d){var s,r=c?J.fE(a,d):J.fD(a,d)
 if(a!==0&&b!=null)for(s=0;s<r.length;++s)r[s]=b
 return r},
-ff(a,b,c){var s,r,q=A.H([],c.h("t<0>"))
-for(s=a.length,r=0;r<a.length;a.length===s||(0,A.dJ)(a),++r)B.a.u(q,c.a(a[r]))
+fI(a,b,c){var s,r,q=A.K([],c.h("x<0>"))
+for(s=a.length,r=0;r<a.length;a.length===s||(0,A.fb)(a),++r)B.a.u(q,c.a(a[r]))
 q.$flags=1
 return q},
-fd(a,b){var s,r=A.H([],b.h("t<0>"))
-for(s=a.gp(a);s.l();)B.a.u(r,s.gm())
+fG(a,b){var s,r=A.K([],b.h("x<0>"))
+for(s=a.gp(a);s.m();)B.a.u(r,s.gn())
 return r},
-e4(a,b,c){var s=J.eV(b)
-if(!s.l())return a
-if(c.length===0){do a+=A.n(s.gm())
-while(s.l())}else{a+=A.n(s.gm())
-while(s.l())a=a+c+A.n(s.gm())}return a},
-fp(){return A.at(new Error())},
-f4(a){var s=Math.abs(a),r=a<0?"-":""
+ex(a,b,c){var s=J.dH(b)
+if(!s.m())return a
+if(c.length===0){do a+=A.m(s.gn())
+while(s.m())}else{a+=A.m(s.gn())
+while(s.m())a=a+c+A.m(s.gn())}return a},
+fS(){return A.ag(new Error())},
+fy(a){var s=Math.abs(a),r=a<0?"-":""
 if(s>=1000)return""+a
 if(s>=100)return r+"0"+s
 if(s>=10)return r+"00"+s
 return r+"000"+s},
-dV(a){if(a>=100)return""+a
+en(a){if(a>=100)return""+a
 if(a>=10)return"0"+a
 return"00"+a},
-bp(a){if(a>=10)return""+a
+bF(a){if(a>=10)return""+a
 return"0"+a},
-c4(a){if(typeof a=="number"||A.cS(a)||a==null)return J.ax(a)
+cr(a){if(typeof a=="number"||A.dk(a)||a==null)return J.aH(a)
 if(typeof a=="string")return JSON.stringify(a)
-return A.e_(a)},
-f6(a,b){A.cX(a,"error",t.K)
-A.cX(b,"stackTrace",t.l)
-A.f5(a,b)},
-bk(a){return new A.bj(a)},
-ay(a,b){return new A.N(!1,null,b,a)},
-dP(a,b,c){return new A.N(!0,a,b,c)},
-e1(a,b,c,d,e){return new A.aT(b,c,!0,a,d,"Invalid value")},
-f7(a,b,c,d){return new A.bq(b,!0,a,d,"Index out of range")},
-fq(a){return new A.aX(a)},
-e6(a){return new A.bP(a)},
-e3(a){return new A.bL(a)},
-af(a){return new A.bn(a)},
-f8(a,b,c){var s,r
-if(A.dG(a)){if(b==="("&&c===")")return"(...)"
-return b+"..."+c}s=A.H([],t.s)
-B.a.u($.B,a)
-try{A.hl(a,s)}finally{if(0>=$.B.length)return A.x($.B,-1)
-$.B.pop()}r=A.e4(b,t.R.a(s),", ")+c
+return A.et(a)},
+fA(a,b){A.dr(a,"error",t.K)
+A.dr(b,"stackTrace",t.l)
+A.fz(a,b)},
+bA(a){return new A.bz(a)},
+ak(a,b){return new A.Q(!1,null,b,a)},
+eh(a,b,c){return new A.Q(!0,a,b,c)},
+ev(a,b,c,d,e){return new A.b3(b,c,!0,a,d,"Invalid value")},
+fB(a,b,c,d){return new A.bH(b,!0,a,d,"Index out of range")},
+cK(a){return new A.b8(a)},
+eA(a){return new A.c8(a)},
+dT(a){return new A.c3(a)},
+am(a){return new A.bD(a)},
+fC(a,b,c){var s,r
+if(A.ea(a)){if(b==="("&&c===")")return"(...)"
+return b+"..."+c}s=A.K([],t.s)
+B.a.u($.G,a)
+try{A.hS(a,s)}finally{if(0>=$.G.length)return A.y($.G,-1)
+$.G.pop()}r=A.ex(b,t.R.a(s),", ")+c
 return r.charCodeAt(0)==0?r:r},
-dW(a,b,c){var s,r
-if(A.dG(a))return b+"..."+c
-s=new A.bN(b)
-B.a.u($.B,a)
+eo(a,b,c){var s,r
+if(A.ea(a))return b+"..."+c
+s=new A.c5(b)
+B.a.u($.G,a)
 try{r=s
-r.a=A.e4(r.a,a,", ")}finally{if(0>=$.B.length)return A.x($.B,-1)
-$.B.pop()}s.a+=c
+r.a=A.ex(r.a,a,", ")}finally{if(0>=$.G.length)return A.y($.G,-1)
+$.G.pop()}s.a+=c
 r=s.a
 return r.charCodeAt(0)==0?r:r},
-hl(a,b){var s,r,q,p,o,n,m,l=a.gp(a),k=0,j=0
+hS(a,b){var s,r,q,p,o,n,m,l=a.gp(a),k=0,j=0
 for(;;){if(!(k<80||j<3))break
-if(!l.l())return
-s=A.n(l.gm())
+if(!l.m())return
+s=A.m(l.gn())
 B.a.u(b,s)
-k+=s.length+2;++j}if(!l.l()){if(j<=5)return
-if(0>=b.length)return A.x(b,-1)
+k+=s.length+2;++j}if(!l.m()){if(j<=5)return
+if(0>=b.length)return A.y(b,-1)
 r=b.pop()
-if(0>=b.length)return A.x(b,-1)
-q=b.pop()}else{p=l.gm();++j
-if(!l.l()){if(j<=4){B.a.u(b,A.n(p))
-return}r=A.n(p)
-if(0>=b.length)return A.x(b,-1)
+if(0>=b.length)return A.y(b,-1)
+q=b.pop()}else{p=l.gn();++j
+if(!l.m()){if(j<=4){B.a.u(b,A.m(p))
+return}r=A.m(p)
+if(0>=b.length)return A.y(b,-1)
 q=b.pop()
-k+=r.length+2}else{o=l.gm();++j
-for(;l.l();p=o,o=n){n=l.gm();++j
+k+=r.length+2}else{o=l.gn();++j
+for(;l.m();p=o,o=n){n=l.gn();++j
 if(j>100){for(;;){if(!(k>75&&j>3))break
-if(0>=b.length)return A.x(b,-1)
+if(0>=b.length)return A.y(b,-1)
 k-=b.pop().length+2;--j}B.a.u(b,"...")
-return}}q=A.n(p)
-r=A.n(o)
+return}}q=A.m(p)
+r=A.m(o)
 k+=r.length+q.length+4}}if(j>b.length+2){k+=5
 m="..."}else m=null
 for(;;){if(!(k>80&&b.length>3))break
-if(0>=b.length)return A.x(b,-1)
+if(0>=b.length)return A.y(b,-1)
 k-=b.pop().length+2
 if(m==null){k+=5
 m="..."}}if(m!=null)B.a.u(b,m)
 B.a.u(b,q)
 B.a.u(b,r)},
-dk(a,b,c,d){var s
-if(B.c===c){s=B.e.gn(a)
-b=J.M(b)
-return A.dm(A.W(A.W($.d9(),s),b))}if(B.c===d){s=B.e.gn(a)
-b=J.M(b)
-c=J.M(c)
-return A.dm(A.W(A.W(A.W($.d9(),s),b),c))}s=B.e.gn(a)
-b=J.M(b)
-c=J.M(c)
-d=J.M(d)
-d=A.dm(A.W(A.W(A.W(A.W($.d9(),s),b),c),d))
+er(a,b,c,d,e){return new A.a4(a,b.h("@<0>").k(c).k(d).k(e).h("a4<1,2,3,4>"))},
+dR(a,b,c,d){var s
+if(B.d===c){s=B.c.gq(a)
+b=J.W(b)
+return A.dU(A.a_(A.a_($.dG(),s),b))}if(B.d===d){s=B.c.gq(a)
+b=J.W(b)
+c=J.W(c)
+return A.dU(A.a_(A.a_(A.a_($.dG(),s),b),c))}s=B.c.gq(a)
+b=J.W(b)
+c=J.W(c)
+d=J.W(d)
+d=A.dU(A.a_(A.a_(A.a_(A.a_($.dG(),s),b),c),d))
 return d},
-bo:function bo(a,b,c){this.a=a
+bE:function bE(a,b,c){this.a=a
 this.b=b
 this.c=c},
+bG:function bG(a){this.a=a},
 l:function l(){},
-bj:function bj(a){this.a=a},
-Q:function Q(){},
-N:function N(a,b,c,d){var _=this
+bz:function bz(a){this.a=a},
+T:function T(){},
+Q:function Q(a,b,c,d){var _=this
 _.a=a
 _.b=b
 _.c=c
 _.d=d},
-aT:function aT(a,b,c,d,e,f){var _=this
+b3:function b3(a,b,c,d,e,f){var _=this
 _.e=a
 _.f=b
 _.a=c
 _.b=d
 _.c=e
 _.d=f},
-bq:function bq(a,b,c,d,e){var _=this
+bH:function bH(a,b,c,d,e){var _=this
 _.f=a
 _.a=b
 _.b=c
 _.c=d
 _.d=e},
-aX:function aX(a){this.a=a},
-bP:function bP(a){this.a=a},
-bL:function bL(a){this.a=a},
-bn:function bn(a){this.a=a},
-aV:function aV(){},
-cu:function cu(a){this.a=a},
+b8:function b8(a){this.a=a},
+c8:function c8(a){this.a=a},
+c3:function c3(a){this.a=a},
+bD:function bD(a){this.a=a},
+bZ:function bZ(){},
+b5:function b5(){},
+cV:function cV(a){this.a=a},
 b:function b(){},
-u:function u(a,b,c){this.a=a
+p:function p(a,b,c){this.a=a
 this.b=b
 this.$ti=c},
-w:function w(){},
+q:function q(){},
 d:function d(){},
-c_:function c_(){},
-bN:function bN(a){this.a=a},
-ce:function ce(a){this.a=a},
-fZ(a,b,c){t.Z.a(a)
-if(A.a7(c)>=1)return a.$1(b)
+cj:function cj(){},
+c5:function c5(a){this.a=a},
+cB:function cB(a){this.a=a},
+hu(a,b,c){t.Z.a(a)
+if(A.a1(c)>=1)return a.$1(b)
 return a.$0()},
-h_(a,b,c,d,e){t.Z.a(a)
-A.a7(e)
+hv(a,b,c,d,e){t.Z.a(a)
+A.a1(e)
 if(e>=3)return a.$3(b,c,d)
 if(e===2)return a.$2(b,c)
 if(e===1)return a.$1(b)
 return a.$0()},
-ew(a){return a==null||A.cS(a)||typeof a=="number"||typeof a=="string"||t.U.b(a)||t.E.b(a)||t.x.b(a)||t.W.b(a)||t.D.b(a)||t.k.b(a)||t.w.b(a)||t.B.b(a)||t.q.b(a)||t.J.b(a)||t.Y.b(a)},
-dH(a){if(A.ew(a))return a
-return new A.d3(new A.al(t.A)).$1(a)},
-hU(a,b){var s=new A.q($.o,b.h("q<0>")),r=new A.aY(s,b.h("aY<0>"))
-a.then(A.bi(new A.d6(r,b),1),A.bi(new A.d7(r),1))
+eY(a){return a==null||A.dk(a)||typeof a=="number"||typeof a=="string"||t.D.b(a)||t.bX.b(a)||t.ca.b(a)||t.W.b(a)||t.a.b(a)||t.k.b(a)||t.x.b(a)||t.B.b(a)||t.q.b(a)||t.J.b(a)||t.Y.b(a)},
+by(a){if(A.eY(a))return a
+return new A.dB(new A.at(t.A)).$1(a)},
+f9(a,b){var s=new A.v($.n,b.h("v<0>")),r=new A.b9(s,b.h("b9<0>"))
+a.then(A.aD(new A.dE(r,b),1),A.aD(new A.dF(r),1))
 return s},
-ev(a){return a==null||typeof a==="boolean"||typeof a==="number"||typeof a==="string"||a instanceof Int8Array||a instanceof Uint8Array||a instanceof Uint8ClampedArray||a instanceof Int16Array||a instanceof Uint16Array||a instanceof Int32Array||a instanceof Uint32Array||a instanceof Float32Array||a instanceof Float64Array||a instanceof ArrayBuffer||a instanceof DataView},
-dA(a){if(A.ev(a))return a
-return new A.cY(new A.al(t.A)).$1(a)},
-d3:function d3(a){this.a=a},
-d6:function d6(a,b){this.a=a
+eX(a){return a==null||typeof a==="boolean"||typeof a==="number"||typeof a==="string"||a instanceof Int8Array||a instanceof Uint8Array||a instanceof Uint8ClampedArray||a instanceof Int16Array||a instanceof Uint16Array||a instanceof Int32Array||a instanceof Uint32Array||a instanceof Float32Array||a instanceof Float64Array||a instanceof ArrayBuffer||a instanceof DataView},
+e6(a){if(A.eX(a))return a
+return new A.ds(new A.at(t.A)).$1(a)},
+dB:function dB(a){this.a=a},
+dE:function dE(a,b){this.a=a
 this.b=b},
-d7:function d7(a){this.a=a},
-cY:function cY(a){this.a=a},
-bR:function bR(){this.a=null},
-fv(a){var s,r,q,p,o="Attempting to rewrap a JS function."
-if($.e7)return
-$.e7=!0
-$.d8()
+dF:function dF(a){this.a=a},
+ds:function ds(a){this.a=a},
+iw(){var s=$.aG()
+s.a=t.e.a(A.i7())
+s.saM(A.i8())},
+ij(a){var s,r,q,p,o,n=null,m="threshold"
+if(!t.f.b(a))return
+switch(a.j(0,"op")){case"watch":s=A.cl(a.j(0,"ticker"))
+r=s==null?n:s.toLowerCase()
+if(r==null)r="btc"
+q=A.ck(a.j(0,m))
+if(q==null)q=n
+s=$.bx
+if(s!=null)s.Y()
+A.ab(A.C(["kind","watching","ticker",r,"threshold",q],t.N,t.X))
+A.eZ(r,q)
+$.bx=A.fT(B.r,new A.dw(r,q))
+break
+case"stop":s=$.bx
+if(s!=null)s.Y()
+$.bx=null
+A.ab(A.C(["kind","stopped"],t.N,t.X))
+break
+case"check":s=A.cl(a.j(0,"ticker"))
+r=s==null?n:s.toLowerCase()
+if(r==null)r="btc"
+q=A.ck(a.j(0,m))
+if(q==null)q=n
+s=t.N
+p=t.X
+A.ab(A.C(["kind","task-start","ticker",r],s,p))
+o=A.e3(r)
+A.ab(A.C(["kind","task-done","ticker",r,"price",o,"below",q!=null&&o<q],s,p))
+break
+case"text":A.ab(A.C(["kind","echo","text",a.j(0,"text")],t.N,t.X))
+break}},
+eZ(a,b){var s,r=A.e3(a),q=b!=null&&r<b
+A.ab(A.C(["kind",q?"alert":"tick","ticker",a,"price",r,"threshold",b],t.N,t.X))
+if(q){s=$.bx
+if(s!=null)s.Y()
+$.bx=null}},
+ab(a){var s=$.aG().c
+if(s!=null)s.$1(a)},
+e3(a){var s=B.x.j(0,a)
+if(s==null)s=100
+return s*(1+(B.c.al(A.hB(a+":"+B.c.X(Date.now(),3e4)),1000)/1000*0.1-0.05))},
+hB(a){var s,r,q,p
+for(s=new A.aK(a),r=t.V,s=new A.R(s,s.gl(0),r.h("R<f.E>")),r=r.h("f.E"),q=0;s.m();){p=s.d
+if(p==null)p=r.a(p)
+q=q*31+p&2147483647}return q},
+e8(a,b){return A.ii(a,t.h.a(b))},
+ii(a,b){var s=0,r=A.dl(t.y),q,p,o,n,m,l,k,j
+var $async$e8=A.dp(function(c,d){if(c===1)return A.df(d,r)
+for(;;)switch(s){case 0:j=b==null
+if(!j&&J.P(b.j(0,"fail"),!0)){q=!1
+s=1
+break}p=A.cl(j?null:b.j(0,"ticker"))
+o=p==null?null:p.toLowerCase()
+if(o==null)o="btc"
+n=A.ck(j?null:b.j(0,"threshold"))
+if(n==null)n=null
+for(m=0,l=0;l<2e6;++l)m+=l
+j=t.N
+p=t.X
+A.ab(A.C(["kind","task-start","ticker",o,"threshold",n],j,p))
+k=A.e3(o)
+A.ab(A.C(["kind","task-done","ticker",o,"price",k,"below",n!=null&&k<n],j,p))
+q=!0
+s=1
+break
+case 1:return A.dg(q,r)}})
+return A.dh($async$e8,r)},
+dw:function dw(a,b){this.a=a
+this.b=b},
+ca:function ca(){this.c=this.b=this.a=null},
+h_(a){var s,r,q,p,o="Attempting to rewrap a JS function."
+if($.eB)return
+$.eB=!0
+$.aG()
 a.$0()
 s=v.G
-if(typeof A.dL()=="function")A.c1(A.ay(o,null))
-r=function(b,c){return function(d,e,f){return b(c,d,e,f,arguments.length)}}(A.h_,A.dL())
-q=$.dM()
-r[q]=A.dL()
+if(typeof A.ed()=="function")A.co(A.ak(o,null))
+r=function(b,c){return function(d,e,f){return b(c,d,e,f,arguments.length)}}(A.hv,A.ed())
+q=$.ee()
+r[q]=A.ed()
 s.__wmTrigger=r
-p=new A.cp()
-if(typeof p=="function")A.c1(A.ay(o,null))
-r=function(b,c){return function(d){return b(c,d,arguments.length)}}(A.fZ,p)
+p=new A.cQ()
+if(typeof p=="function")A.co(A.ak(o,null))
+r=function(b,c){return function(d){return b(c,d,arguments.length)}}(A.hu,p)
 r[q]=p
 q=t.X
-A.de(s,"addEventListener","message",r,q)
-A.de(s,"postMessage",A.dH(A.di(["type","ready"],t.N,q)),null,q)},
-fs(a){var s=A.fr(a)
-if(s==null)return
-A.co(s.b,s.c,s.a)},
-co(a,b,c){var s=0,r=A.cT(t.H),q,p
-var $async$co=A.cV(function(d,e){if(d===1)return A.cN(e,r)
+A.bN(s,"addEventListener","message",r,q)
+A.fZ()
+A.bN(s,"postMessage",A.by(A.C(["type","ready"],t.N,q)),null,q)},
+fZ(){var s=v.G,r=$.aG()
+if("clients" in s)r.sa4(new A.cO(s))
+else r.sa4(new A.cP(s))},
+fW(a){var s,r,q=A.fV(a)
+if(q!=null||J.P(a.$ti.h("4?").a(a.a.j(0,"type")),"message")){s=$.aG().b
+if(s!=null)s.$1(q)
+return}r=A.fU(a)
+if(r==null)return
+A.cM(r.b,r.c,r.a)},
+cM(a,b,c){var s=0,r=A.dl(t.H),q,p
+var $async$cM=A.dp(function(d,e){if(d===1)return A.df(e,r)
 for(;;)switch(s){case 0:s=2
-return A.dt(A.bS(b,c),$async$co)
+return A.e_(A.cb(b,c),$async$cM)
 case 2:q=e
 p=t.X
-A.de(v.G,"postMessage",A.dH(A.di(["type","result","requestId",a,"result",q.a,"error",q.b],t.N,p)),null,p)
-return A.cO(null,r)}})
-return A.cP($async$co,r)},
-fu(a,b,c){A.cn(A.ap(a),b,t.g.a(c))},
-cn(a,b,c){var s=0,r=A.cT(t.H),q,p,o,n,m
-var $async$cn=A.cV(function(d,e){if(d===1)return A.cN(e,r)
+A.bN(v.G,"postMessage",A.by(A.C(["type","result","requestId",a,"result",q.a,"error",q.b],t.N,p)),null,p)
+return A.dg(null,r)}})
+return A.dh($async$cM,r)},
+fY(a,b,c){A.cL(A.az(a),b,t.g.a(c))},
+cL(a,b,c){var s=0,r=A.dl(t.H),q,p,o,n,m
+var $async$cL=A.dp(function(d,e){if(d===1)return A.df(e,r)
 for(;;)switch(s){case 0:s=2
-return A.dt(A.bS(a,b==null?null:A.dA(b)),$async$cn)
+return A.e_(A.cb(a,b==null?null:A.e6(b)),$async$cL)
 case 2:q=e
 p=q.a
 o=q.b
-n=p==null?null:A.dH(p)
+n=p==null?null:A.by(p)
 m=o==null?null:o
 c.call(null,n,m)
-return A.cO(null,r)}})
-return A.cP($async$cn,r)},
-bS(a,b){return A.ft(a,b)},
-ft(a,b){var s=0,r=A.cT(t.r),q,p=2,o=[],n,m,l,k,j,i,h
-var $async$bS=A.cV(function(c,d){if(c===1){o.push(d)
+return A.dg(null,r)}})
+return A.dh($async$cL,r)},
+cb(a,b){return A.fX(a,b)},
+fX(a,b){var s=0,r=A.dl(t.t),q,p=2,o=[],n,m,l,k,j,i,h
+var $async$cb=A.dp(function(c,d){if(c===1){o.push(d)
 s=p}for(;;)switch(s){case 0:j=null
 i=null
 p=4
-l=$.d8()
+l=$.aG()
 n=l.a
 s=n==null?7:9
 break
@@ -1792,242 +1908,317 @@ case 7:j="No background task handler registered. Did the callbackDispatcher call
 s=8
 break
 case 9:s=10
-return A.dt(n.$2(a,l.az(b)),$async$bS)
+return A.e_(n.$2(a,l.aN(b)),$async$cb)
 case 10:i=d
 case 8:p=2
 s=6
 break
 case 4:p=3
 h=o.pop()
-m=A.aw(h)
-j=J.ax(m)
+m=A.aj(h)
+j=J.aH(m)
 s=6
 break
 case 3:s=2
 break
-case 6:q=new A.b6(i,j)
+case 6:q=new A.bk(i,j)
 s=1
 break
-case 1:return A.cO(q,r)
-case 2:return A.cN(o.at(-1),r)}})
-return A.cP($async$bS,r)},
-cp:function cp(){},
-hW(a){throw A.r(new A.bx("Field '"+a+"' has been assigned during initialization."),new Error())},
-fc(a,b,c,d,e,f){var s
+case 1:return A.dg(q,r)
+case 2:return A.df(o.at(-1),r)}})
+return A.dh($async$cb,r)},
+cQ:function cQ(){},
+cO:function cO(a){this.a=a},
+cN:function cN(a){this.a=a},
+cP:function cP(a){this.a=a},
+iu(a){throw A.w(new A.bP("Field '"+a+"' has been assigned during initialization."),new Error())},
+ep(a,b,c,d,e,f){var s
 if(c==null)return a[b]()
 else if(d==null)return a[b](c)
 else{s=a[b](c,d)
 return s}},
-de(a,b,c,d,e){return e.a(A.fc(a,b,c,d,null,null))},
-hY(){$.d8().a=t.d.a(A.hC())},
-dE(a,b){return A.hL(a,t.h.a(b))},
-hL(a,b){var s=0,r=A.cT(t.y),q,p,o,n
-var $async$dE=A.cV(function(c,d){if(c===1)return A.cN(d,r)
-for(;;)switch(s){case 0:for(p=0,o=0;o<2e6;++o)p+=o
-n=b!=null&&J.Z(b.t(0,"fail"),!0)
-q=!n
-s=1
-break
-case 1:return A.cO(q,r)}})
-return A.cP($async$dE,r)},
-fr(a){var s,r,q=a.a,p=a.$ti.h("4?")
-if(!J.Z(p.a(q.t(0,"type")),"executeTask"))return null
-s=p.a(q.t(0,"requestId"))
-r=p.a(q.t(0,"taskName"))
-if(!A.dw(s)||typeof r!="string")return null
-return new A.b7(p.a(q.t(0,"inputData")),s,r)},
-hS(){A.fv(A.hD())}},B={}
+bN(a,b,c,d,e){return e.a(A.ep(a,b,c,d,null,null))},
+fU(a){var s,r,q=a.a,p=a.$ti.h("4?")
+if(!J.P(p.a(q.j(0,"type")),"executeTask"))return null
+s=p.a(q.j(0,"requestId"))
+r=p.a(q.j(0,"taskName"))
+if(!A.e2(s)||typeof r!="string")return null
+return new A.bl(p.a(q.j(0,"inputData")),s,r)},
+fV(a){var s=a.a,r=a.$ti.h("4?")
+if(!J.P(r.a(s.j(0,"type")),"message"))return null
+return r.a(s.j(0,"payload"))},
+ir(){A.h_(A.i9())}},B={}
 var w=[A,J,B]
 var $={}
-A.df.prototype={}
-J.br.prototype={
-B(a,b){return a===b},
-gn(a){return A.bI(a)},
-i(a){return"Instance of '"+A.bJ(a)+"'"},
-gq(a){return A.aa(A.du(this))}}
-J.bt.prototype={
+A.dM.prototype={}
+J.bI.prototype={
+C(a,b){return a===b},
+gq(a){return A.c0(a)},
+i(a){return"Instance of '"+A.c1(a)+"'"},
+gt(a){return A.ae(A.e0(this))}}
+J.bK.prototype={
 i(a){return String(a)},
-gn(a){return a?519018:218159},
-gq(a){return A.aa(t.y)},
-$ih:1,
-$ia9:1}
-J.aE.prototype={
-B(a,b){return null==b},
+gq(a){return a?519018:218159},
+gt(a){return A.ae(t.y)},
+$ij:1,
+$iad:1}
+J.aQ.prototype={
+C(a,b){return null==b},
 i(a){return"null"},
-gn(a){return 0},
-$ih:1}
-J.aH.prototype={$im:1}
-J.U.prototype={
-gn(a){return 0},
+gq(a){return 0},
+$ij:1,
+$iq:1}
+J.aS.prototype={$io:1}
+J.Y.prototype={
+gq(a){return 0},
 i(a){return String(a)}}
-J.bH.prototype={}
-J.aW.prototype={}
-J.K.prototype={
-i(a){var s=a[$.dM()]
-if(s==null)return this.af(a)
-return"JavaScript function for "+J.ax(s)},
-$ia1:1}
-J.aG.prototype={
-gn(a){return 0},
+J.c_.prototype={}
+J.b6.prototype={}
+J.N.prototype={
+i(a){var s=a[$.ee()]
+if(s==null)return this.an(a)
+return"JavaScript function for "+J.aH(s)},
+$ia5:1}
+J.aR.prototype={
+gq(a){return 0},
 i(a){return String(a)}}
-J.aI.prototype={
-gn(a){return 0},
+J.aT.prototype={
+gq(a){return 0},
 i(a){return String(a)}}
-J.t.prototype={
-u(a,b){A.ao(a).c.a(b)
-a.$flags&1&&A.dK(a,29)
+J.x.prototype={
+u(a,b){A.ax(a).c.a(b)
+a.$flags&1&&A.ec(a,29)
 a.push(b)},
-aq(a,b){var s
-A.ao(a).h("b<1>").a(b)
-a.$flags&1&&A.dK(a,"addAll",2)
-for(s=b.gp(b);s.l();)a.push(s.gm())},
-K(a,b,c){var s=A.ao(a)
-return new A.P(a,s.j(c).h("1(2)").a(b),s.h("@<1>").j(c).h("P<1,2>"))},
-J(a,b){if(!(b<a.length))return A.x(a,b)
+aF(a,b){var s
+A.ax(a).h("b<1>").a(b)
+a.$flags&1&&A.ec(a,"addAll",2)
+for(s=b.gp(b);s.m();)a.push(s.gn())},
+L(a,b,c){var s=A.ax(a)
+return new A.S(a,s.k(c).h("1(2)").a(b),s.h("@<1>").k(c).h("S<1,2>"))},
+K(a,b){if(!(b<a.length))return A.y(a,b)
 return a[b]},
-i(a){return A.dW(a,"[","]")},
-gp(a){return new J.az(a,a.length,A.ao(a).h("az<1>"))},
-gn(a){return A.bI(a)},
-gk(a){return a.length},
-v(a,b,c){A.ao(a).c.a(c)
-a.$flags&2&&A.dK(a)
-if(!(b>=0&&b<a.length))throw A.i(A.eD(a,b))
+i(a){return A.eo(a,"[","]")},
+gp(a){return new J.aI(a,a.length,A.ax(a).h("aI<1>"))},
+gq(a){return A.c0(a)},
+gl(a){return a.length},
+j(a,b){if(!(b>=0&&b<a.length))throw A.e(A.dt(a,b))
+return a[b]},
+v(a,b,c){A.ax(a).c.a(c)
+a.$flags&2&&A.ec(a)
+if(!(b>=0&&b<a.length))throw A.e(A.dt(a,b))
 a[b]=c},
 $ic:1,
 $ib:1,
-$ij:1}
-J.bs.prototype={
-aE(a){var s,r,q
+$ii:1}
+J.bJ.prototype={
+aV(a){var s,r,q
 if(!Array.isArray(a))return null
 s=a.$flags|0
 if((s&4)!==0)r="const, "
 else if((s&2)!==0)r="unmodifiable, "
 else r=(s&1)!==0?"fixed, ":""
-q="Instance of '"+A.bJ(a)+"'"
+q="Instance of '"+A.c1(a)+"'"
 if(r==="")return q
 return q+" ("+r+"length: "+a.length+")"}}
-J.ca.prototype={}
-J.az.prototype={
-gm(){var s=this.d
+J.cx.prototype={}
+J.aI.prototype={
+gn(){var s=this.d
 return s==null?this.$ti.c.a(s):s},
-l(){var s,r=this,q=r.a,p=q.length
-if(r.b!==p){q=A.dJ(q)
-throw A.i(q)}s=r.c
+m(){var s,r=this,q=r.a,p=q.length
+if(r.b!==p){q=A.fb(q)
+throw A.e(q)}s=r.c
 if(s>=p){r.d=null
 return!1}r.d=q[s]
 r.c=s+1
 return!0},
-$iD:1}
-J.bv.prototype={
+$iz:1}
+J.bM.prototype={
 i(a){if(a===0&&1/a<0)return"-0.0"
 else return""+a},
-gn(a){var s,r,q,p,o=a|0
+gq(a){var s,r,q,p,o=a|0
 if(a===o)return o&536870911
 s=Math.abs(a)
 r=Math.log(s)/0.6931471805599453|0
 q=Math.pow(2,r)
 p=s<1?s/q:q/s
 return((p*9007199254740992|0)+(p*3542243181176521|0))*599197+r*1259&536870911},
-ap(a,b){var s
-if(a>0)s=this.ao(a,b)
+al(a,b){var s=a%b
+if(s===0)return 0
+if(s>0)return s
+return s+b},
+ao(a,b){if((a|0)===a)if(b>=1)return a/b|0
+return this.ae(a,b)},
+X(a,b){return(a|0)===a?a/b|0:this.ae(a,b)},
+ae(a,b){var s=a/b
+if(s>=-2147483648&&s<=2147483647)return s|0
+if(s>0){if(s!==1/0)return Math.floor(s)}else if(s>-1/0)return Math.ceil(s)
+throw A.e(A.cK("Result of truncating division is "+A.m(s)+": "+A.m(a)+" ~/ "+b))},
+aE(a,b){var s
+if(a>0)s=this.aD(a,b)
 else{s=b>31?31:b
 s=a>>s>>>0}return s},
-ao(a,b){return b>31?0:a>>>b},
-gq(a){return A.aa(t.o)},
-$if:1,
-$iad:1}
-J.aD.prototype={
-gq(a){return A.aa(t.S)},
+aD(a,b){return b>31?0:a>>>b},
+gt(a){return A.ae(t.o)},
 $ih:1,
+$iai:1}
+J.aP.prototype={
+gt(a){return A.ae(t.S)},
+$ij:1,
 $ia:1}
-J.bu.prototype={
-gq(a){return A.aa(t.i)},
-$ih:1}
-J.aF.prototype={
+J.bL.prototype={
+gt(a){return A.ae(t.i)},
+$ij:1}
+J.an.prototype={
+am(a,b){var s,r
+if(0>=b)return""
+if(b===1||a.length===0)return a
+if(b!==b>>>0)throw A.e(B.q)
+for(s=a,r="";;){if((b&1)===1)r=s+r
+b=b>>>1
+if(b===0)break
+s+=s}return r},
+aP(a,b,c){var s=b-a.length
+if(s<=0)return a
+return this.am(c,s)+a},
 i(a){return a},
-gn(a){var s,r,q
+gq(a){var s,r,q
 for(s=a.length,r=0,q=0;q<s;++q){r=r+a.charCodeAt(q)&536870911
 r=r+((r&524287)<<10)&536870911
 r^=r>>6}r=r+((r&67108863)<<3)&536870911
 r^=r>>11
 return r+((r&16383)<<15)&536870911},
-gq(a){return A.aa(t.N)},
-gk(a){return a.length},
-$ih:1,
-$iv:1}
-A.aj.prototype={
+gt(a){return A.ae(t.N)},
+gl(a){return a.length},
+$ij:1,
+$iu:1}
+A.ar.prototype={
 gp(a){var s=this.a
-return new A.aA(s.gp(s),A.G(this).h("aA<1,2>"))},
-gk(a){var s=this.a
-return s.gk(s)},
+return new A.aJ(s.gp(s),A.r(this).h("aJ<1,2>"))},
+gl(a){var s=this.a
+return s.gl(s)},
 i(a){return this.a.i(0)}}
-A.aA.prototype={
-l(){return this.a.l()},
-gm(){return this.$ti.y[1].a(this.a.gm())},
-$iD:1}
-A.a_.prototype={}
-A.aZ.prototype={$ic:1}
-A.a0.prototype={
-a9(a,b,c){return new A.a0(this.a,this.$ti.h("@<1,2>").j(b).j(c).h("a0<1,2,3,4>"))},
-t(a,b){return this.$ti.h("4?").a(this.a.t(0,b))},
-E(a,b){this.a.E(0,new A.c3(this,this.$ti.h("~(3,4)").a(b)))},
-gC(){var s=this.$ti
-return A.eZ(this.a.gC(),s.c,s.y[2])},
-gk(a){var s=this.a
-return s.gk(s)},
-gD(){var s=this.a.gD(),r=this.$ti.h("u<3,4>"),q=A.G(s)
-return A.dj(s,q.j(r).h("1(b.E)").a(new A.c2(this)),q.h("b.E"),r)}}
-A.c3.prototype={
+A.aJ.prototype={
+m(){return this.a.m()},
+gn(){return this.$ti.y[1].a(this.a.gn())},
+$iz:1}
+A.a3.prototype={}
+A.ba.prototype={$ic:1}
+A.a4.prototype={
+Z(a,b,c){return new A.a4(this.a,this.$ti.h("@<1,2>").k(b).k(c).h("a4<1,2,3,4>"))},
+j(a,b){return this.$ti.h("4?").a(this.a.j(0,b))},
+E(a,b){this.a.E(0,new A.cq(this,this.$ti.h("~(3,4)").a(b)))},
+gB(){var s=this.$ti
+return A.fs(this.a.gB(),s.c,s.y[2])},
+gl(a){var s=this.a
+return s.gl(s)},
+gD(){var s=this.a.gD(),r=this.$ti.h("p<3,4>"),q=A.r(s)
+return A.dQ(s,q.k(r).h("1(b.E)").a(new A.cp(this)),q.h("b.E"),r)}}
+A.cq.prototype={
 $2(a,b){var s=this.a.$ti
 s.c.a(a)
 s.y[1].a(b)
 this.b.$2(s.y[2].a(a),s.y[3].a(b))},
 $S(){return this.a.$ti.h("~(1,2)")}}
-A.c2.prototype={
+A.cp.prototype={
 $1(a){var s=this.a.$ti
-s.h("u<1,2>").a(a)
-return new A.u(s.y[2].a(a.a),s.y[3].a(a.b),s.h("u<3,4>"))},
-$S(){return this.a.$ti.h("u<3,4>(u<1,2>)")}}
-A.bx.prototype={
+s.h("p<1,2>").a(a)
+return new A.p(s.y[2].a(a.a),s.y[3].a(a.b),s.h("p<3,4>"))},
+$S(){return this.a.$ti.h("p<3,4>(p<1,2>)")}}
+A.bP.prototype={
 i(a){return"LateInitializationError: "+this.a}}
-A.cg.prototype={}
+A.aK.prototype={
+gl(a){return this.a.length},
+j(a,b){var s=this.a
+if(!(b>=0&&b<s.length))return A.y(s,b)
+return s.charCodeAt(b)}}
+A.cD.prototype={}
 A.c.prototype={}
-A.L.prototype={
-gp(a){return new A.a3(this,this.gk(0),this.$ti.h("a3<L.E>"))},
-K(a,b,c){var s=this.$ti
-return new A.P(this,s.j(c).h("1(L.E)").a(b),s.h("@<L.E>").j(c).h("P<1,2>"))}}
-A.a3.prototype={
-gm(){var s=this.d
+A.O.prototype={
+gp(a){return new A.R(this,this.gl(0),this.$ti.h("R<O.E>"))},
+L(a,b,c){var s=this.$ti
+return new A.S(this,s.k(c).h("1(O.E)").a(b),s.h("@<O.E>").k(c).h("S<1,2>"))}}
+A.R.prototype={
+gn(){var s=this.d
 return s==null?this.$ti.c.a(s):s},
-l(){var s,r=this,q=r.a,p=J.eE(q),o=p.gk(q)
-if(r.b!==o)throw A.i(A.af(q))
+m(){var s,r=this,q=r.a,p=J.f6(q),o=p.gl(q)
+if(r.b!==o)throw A.e(A.am(q))
 s=r.c
 if(s>=o){r.d=null
-return!1}r.d=p.J(q,s);++r.c
+return!1}r.d=p.K(q,s);++r.c
 return!0},
-$iD:1}
-A.a4.prototype={
+$iz:1}
+A.a7.prototype={
 gp(a){var s=this.a
-return new A.aN(s.gp(s),this.b,A.G(this).h("aN<1,2>"))},
-gk(a){var s=this.a
-return s.gk(s)}}
-A.aB.prototype={$ic:1}
-A.aN.prototype={
-l(){var s=this,r=s.b
-if(r.l()){s.a=s.c.$1(r.gm())
+return new A.aY(s.gp(s),this.b,A.r(this).h("aY<1,2>"))},
+gl(a){var s=this.a
+return s.gl(s)}}
+A.aN.prototype={$ic:1}
+A.aY.prototype={
+m(){var s=this,r=s.b
+if(r.m()){s.a=s.c.$1(r.gn())
 return!0}s.a=null
 return!1},
-gm(){var s=this.a
+gn(){var s=this.a
 return s==null?this.$ti.y[1].a(s):s},
+$iz:1}
+A.S.prototype={
+gl(a){return J.dI(this.a)},
+K(a,b){return this.b.$1(J.fo(this.a,b))}}
+A.A.prototype={}
+A.b7.prototype={}
+A.aq.prototype={}
+A.bk.prototype={$r:"+(1,2)",$s:1}
+A.bl.prototype={$r:"+inputData,requestId,taskName(1,2,3)",$s:2}
+A.aL.prototype={
+Z(a,b,c){var s=A.r(this)
+return A.er(this,s.c,s.y[1],b,c)},
+i(a){return A.dP(this)},
+gD(){return new A.aw(this.aI(),A.r(this).h("aw<p<1,2>>"))},
+aI(){var s=this
+return function(){var r=0,q=1,p=[],o,n,m,l,k
+return function $async$gD(a,b,c){if(b===1){p.push(c)
+r=q}for(;;)switch(r){case 0:o=s.gB(),o=o.gp(o),n=A.r(s),m=n.y[1],n=n.h("p<1,2>")
+case 2:if(!o.m()){r=3
+break}l=o.gn()
+k=s.j(0,l)
+r=4
+return a.b=new A.p(l,k==null?m.a(k):k,n),1
+case 4:r=2
+break
+case 3:return 0
+case 1:return a.c=p.at(-1),3}}}},
 $iD:1}
-A.P.prototype={
-gk(a){return J.da(this.a)},
-J(a,b){return this.b.$1(J.eU(this.a,b))}}
-A.y.prototype={}
-A.b6.prototype={$r:"+(1,2)",$s:1}
-A.b7.prototype={$r:"+inputData,requestId,taskName(1,2,3)",$s:2}
-A.aU.prototype={}
-A.ch.prototype={
+A.aM.prototype={
+gl(a){return this.b.length},
+gac(){var s=this.$keys
+if(s==null){s=Object.keys(this.a)
+this.$keys=s}return s},
+J(a){if(typeof a!="string")return!1
+if("__proto__"===a)return!1
+return this.a.hasOwnProperty(a)},
+j(a,b){if(!this.J(b))return null
+return this.b[this.a[b]]},
+E(a,b){var s,r,q,p
+this.$ti.h("~(1,2)").a(b)
+s=this.gac()
+r=this.b
+for(q=s.length,p=0;p<q;++p)b.$2(s[p],r[p])},
+gB(){return new A.be(this.gac(),this.$ti.h("be<1>"))}}
+A.be.prototype={
+gl(a){return this.a.length},
+gp(a){var s=this.a
+return new A.bf(s,s.length,this.$ti.h("bf<1>"))}}
+A.bf.prototype={
+gn(){var s=this.d
+return s==null?this.$ti.c.a(s):s},
+m(){var s=this,r=s.c
+if(r>=s.b){s.d=null
+return!1}s.d=s.a[r]
+s.c=r+1
+return!0},
+$iz:1}
+A.b4.prototype={}
+A.cE.prototype={
 A(a){var s,r,q=this,p=new RegExp(q.a).exec(a)
 if(p==null)return null
 s=Object.create(null)
@@ -2042,56 +2233,56 @@ if(r!==-1)s.method=p[r+1]
 r=q.f
 if(r!==-1)s.receiver=p[r+1]
 return s}}
-A.aS.prototype={
+A.b2.prototype={
 i(a){return"Null check operator used on a null value"}}
-A.bw.prototype={
+A.bO.prototype={
 i(a){var s,r=this,q="NoSuchMethodError: method not found: '",p=r.b
 if(p==null)return"NoSuchMethodError: "+r.a
 s=r.c
 if(s==null)return q+p+"' ("+r.a+")"
 return q+p+"' on '"+s+"' ("+r.a+")"}}
-A.bQ.prototype={
+A.c9.prototype={
 i(a){var s=this.a
 return s.length===0?"Error":"Error: "+s}}
-A.cf.prototype={
+A.cC.prototype={
 i(a){return"Throw of null ('"+(this.a===null?"null":"undefined")+"' from JavaScript)"}}
-A.aC.prototype={}
-A.b8.prototype={
+A.aO.prototype={}
+A.bm.prototype={
 i(a){var s,r=this.b
 if(r!=null)return r
 r=this.a
 s=r!==null&&typeof r==="object"?r.stack:null
 return this.b=s==null?"":s},
-$iV:1}
-A.T.prototype={
+$iZ:1}
+A.X.prototype={
 i(a){var s=this.constructor,r=s==null?null:s.name
-return"Closure '"+A.eI(r==null?"unknown":r)+"'"},
-$ia1:1,
-gaF(){return this},
+return"Closure '"+A.fc(r==null?"unknown":r)+"'"},
+$ia5:1,
+gaW(){return this},
 $C:"$1",
 $R:1,
 $D:null}
-A.bl.prototype={$C:"$0",$R:0}
-A.bm.prototype={$C:"$2",$R:2}
-A.bO.prototype={}
-A.bM.prototype={
+A.bB.prototype={$C:"$0",$R:0}
+A.bC.prototype={$C:"$2",$R:2}
+A.c6.prototype={}
+A.c4.prototype={
 i(a){var s=this.$static_name
 if(s==null)return"Closure of unknown static method"
-return"Closure '"+A.eI(s)+"'"}}
-A.ae.prototype={
-B(a,b){if(b==null)return!1
+return"Closure '"+A.fc(s)+"'"}}
+A.al.prototype={
+C(a,b){if(b==null)return!1
 if(this===b)return!0
-if(!(b instanceof A.ae))return!1
+if(!(b instanceof A.al))return!1
 return this.$_target===b.$_target&&this.a===b.a},
-gn(a){return(A.d5(this.a)^A.bI(this.$_target))>>>0},
-i(a){return"Closure '"+this.$_name+"' of "+("Instance of '"+A.bJ(this.a)+"'")}}
-A.bK.prototype={
+gq(a){return(A.dD(this.a)^A.c0(this.$_target))>>>0},
+i(a){return"Closure '"+this.$_name+"' of "+("Instance of '"+A.c1(this.a)+"'")}}
+A.c2.prototype={
 i(a){return"RuntimeError: "+this.a}}
-A.a2.prototype={
-gk(a){return this.a},
-gC(){return new A.aM(this,this.$ti.h("aM<1>"))},
-gD(){return new A.aJ(this,this.$ti.h("aJ<1,2>"))},
-t(a,b){var s,r,q,p,o=null
+A.a6.prototype={
+gl(a){return this.a},
+gB(){return new A.aX(this,A.r(this).h("aX<1>"))},
+gD(){return new A.aU(this,A.r(this).h("aU<1,2>"))},
+j(a,b){var s,r,q,p,o=null
 if(typeof b=="string"){s=this.b
 if(s==null)return o
 r=s[b]
@@ -2100,286 +2291,372 @@ return q}else if(typeof b=="number"&&(b&0x3fffffff)===b){p=this.c
 if(p==null)return o
 r=p[b]
 q=r==null?o:r.b
-return q}else return this.av(b)},
-av(a){var s,r,q=this.d
+return q}else return this.aK(b)},
+aK(a){var s,r,q=this.d
 if(q==null)return null
-s=q[J.M(a)&1073741823]
-r=this.ac(s,a)
+s=q[this.ai(a)]
+r=this.aj(s,a)
 if(r<0)return null
 return s[r].b},
-v(a,b,c){var s,r,q,p,o,n,m=this,l=m.$ti
+v(a,b,c){var s,r,q,p,o,n,m=this,l=A.r(m)
 l.c.a(b)
 l.y[1].a(c)
 if(typeof b=="string"){s=m.b
-m.a_(s==null?m.b=m.U():s,b,c)}else if(typeof b=="number"&&(b&0x3fffffff)===b){r=m.c
-m.a_(r==null?m.c=m.U():r,b,c)}else{q=m.d
-if(q==null)q=m.d=m.U()
-p=J.M(b)&1073741823
+m.a5(s==null?m.b=m.V():s,b,c)}else if(typeof b=="number"&&(b&0x3fffffff)===b){r=m.c
+m.a5(r==null?m.c=m.V():r,b,c)}else{q=m.d
+if(q==null)q=m.d=m.V()
+p=m.ai(b)
 o=q[p]
-if(o==null)q[p]=[m.V(b,c)]
-else{n=m.ac(o,b)
+if(o==null)q[p]=[m.W(b,c)]
+else{n=m.aj(o,b)
 if(n>=0)o[n].b=c
-else o.push(m.V(b,c))}}},
+else o.push(m.W(b,c))}}},
 E(a,b){var s,r,q=this
-q.$ti.h("~(1,2)").a(b)
+A.r(q).h("~(1,2)").a(b)
 s=q.e
 r=q.r
 while(s!=null){b.$2(s.a,s.b)
-if(r!==q.r)throw A.i(A.af(q))
+if(r!==q.r)throw A.e(A.am(q))
 s=s.c}},
-a_(a,b,c){var s,r=this.$ti
+a5(a,b,c){var s,r=A.r(this)
 r.c.a(b)
 r.y[1].a(c)
 s=a[b]
-if(s==null)a[b]=this.V(b,c)
+if(s==null)a[b]=this.W(b,c)
 else s.b=c},
-V(a,b){var s=this,r=s.$ti,q=new A.cb(r.c.a(a),r.y[1].a(b))
+W(a,b){var s=this,r=A.r(s),q=new A.cy(r.c.a(a),r.y[1].a(b))
 if(s.e==null)s.e=s.f=q
 else s.f=s.f.c=q;++s.a
 s.r=s.r+1&1073741823
 return q},
-ac(a,b){var s,r
+ai(a){return J.W(a)&1073741823},
+aj(a,b){var s,r
 if(a==null)return-1
 s=a.length
-for(r=0;r<s;++r)if(J.Z(a[r].a,b))return r
+for(r=0;r<s;++r)if(J.P(a[r].a,b))return r
 return-1},
-i(a){return A.dY(this)},
-U(){var s=Object.create(null)
+i(a){return A.dP(this)},
+V(){var s=Object.create(null)
 s["<non-identifier-key>"]=s
 delete s["<non-identifier-key>"]
 return s},
-$idX:1}
-A.cb.prototype={}
-A.aM.prototype={
-gk(a){return this.a.a},
+$ieq:1}
+A.cy.prototype={}
+A.aX.prototype={
+gl(a){return this.a.a},
 gp(a){var s=this.a
-return new A.aL(s,s.r,s.e,this.$ti.h("aL<1>"))}}
-A.aL.prototype={
-gm(){return this.d},
-l(){var s,r=this,q=r.a
-if(r.b!==q.r)throw A.i(A.af(q))
+return new A.aW(s,s.r,s.e,this.$ti.h("aW<1>"))}}
+A.aW.prototype={
+gn(){return this.d},
+m(){var s,r=this,q=r.a
+if(r.b!==q.r)throw A.e(A.am(q))
 s=r.c
 if(s==null){r.d=null
 return!1}else{r.d=s.a
 r.c=s.c
 return!0}},
-$iD:1}
-A.aJ.prototype={
-gk(a){return this.a.a},
+$iz:1}
+A.aU.prototype={
+gl(a){return this.a.a},
 gp(a){var s=this.a
-return new A.aK(s,s.r,s.e,this.$ti.h("aK<1,2>"))}}
-A.aK.prototype={
-gm(){var s=this.d
+return new A.aV(s,s.r,s.e,this.$ti.h("aV<1,2>"))}}
+A.aV.prototype={
+gn(){var s=this.d
 s.toString
 return s},
-l(){var s,r=this,q=r.a
-if(r.b!==q.r)throw A.i(A.af(q))
+m(){var s,r=this,q=r.a
+if(r.b!==q.r)throw A.e(A.am(q))
 s=r.c
 if(s==null){r.d=null
-return!1}else{r.d=new A.u(s.a,s.b,r.$ti.h("u<1,2>"))
+return!1}else{r.d=new A.p(s.a,s.b,r.$ti.h("p<1,2>"))
 r.c=s.c
 return!0}},
-$iD:1}
-A.d_.prototype={
+$iz:1}
+A.dx.prototype={
 $1(a){return this.a(a)},
-$S:6}
-A.d0.prototype={
-$2(a,b){return this.a(a,b)},
 $S:7}
-A.d1.prototype={
-$1(a){return this.a(A.ap(a))},
+A.dy.prototype={
+$2(a,b){return this.a(a,b)},
 $S:8}
-A.S.prototype={
-i(a){return this.a8(!1)},
-a8(a){var s,r,q,p,o,n=this.al(),m=this.T(),l=(a?"Record ":"")+"("
+A.dz.prototype={
+$1(a){return this.a(A.az(a))},
+$S:9}
+A.V.prototype={
+i(a){return this.ag(!1)},
+ag(a){var s,r,q,p,o,n=this.az(),m=this.U(),l=(a?"Record ":"")+"("
 for(s=n.length,r="",q=0;q<s;++q,r=", "){l+=r
 p=n[q]
 if(typeof p=="string")l=l+p+": "
-if(!(q<m.length))return A.x(m,q)
+if(!(q<m.length))return A.y(m,q)
 o=m[q]
-l=a?l+A.e_(o):l+A.n(o)}l+=")"
+l=a?l+A.et(o):l+A.m(o)}l+=")"
 return l.charCodeAt(0)==0?l:l},
-al(){var s,r=this.$s
-while($.cG.length<=r)B.a.u($.cG,null)
-s=$.cG[r]
-if(s==null){s=this.aj()
-B.a.v($.cG,r,s)}return s},
-aj(){var s,r,q,p=this.$r,o=p.indexOf("("),n=p.substring(1,o),m=p.substring(o),l=m==="()"?0:m.replace(/[^,]/g,"").length+1,k=A.H(new Array(l),t.f)
+az(){var s,r=this.$s
+while($.d6.length<=r)B.a.u($.d6,null)
+s=$.d6[r]
+if(s==null){s=this.av()
+B.a.v($.d6,r,s)}return s},
+av(){var s,r,q,p=this.$r,o=p.indexOf("("),n=p.substring(1,o),m=p.substring(o),l=m==="()"?0:m.replace(/[^,]/g,"").length+1,k=A.K(new Array(l),t.G)
 for(s=0;s<l;++s)k[s]=s
 if(n!==""){r=n.split(",")
 s=r.length
 for(q=l;s>0;){--q;--s
-B.a.v(k,q,r[s])}}k=A.ff(k,!1,t.K)
+B.a.v(k,q,r[s])}}k=A.fI(k,!1,t.K)
 k.$flags=3
 return k}}
-A.am.prototype={
-T(){return[this.a,this.b]},
-B(a,b){if(b==null)return!1
-return b instanceof A.am&&this.$s===b.$s&&J.Z(this.a,b.a)&&J.Z(this.b,b.b)},
-gn(a){return A.dk(this.$s,this.a,this.b,B.c)}}
-A.an.prototype={
-T(){return[this.a,this.b,this.c]},
-B(a,b){var s=this
+A.au.prototype={
+U(){return[this.a,this.b]},
+C(a,b){if(b==null)return!1
+return b instanceof A.au&&this.$s===b.$s&&J.P(this.a,b.a)&&J.P(this.b,b.b)},
+gq(a){return A.dR(this.$s,this.a,this.b,B.d)}}
+A.av.prototype={
+U(){return[this.a,this.b,this.c]},
+C(a,b){var s=this
 if(b==null)return!1
-return b instanceof A.an&&s.$s===b.$s&&J.Z(s.a,b.a)&&J.Z(s.b,b.b)&&J.Z(s.c,b.c)},
-gn(a){var s=this
-return A.dk(s.$s,s.a,s.b,s.c)}}
-A.ag.prototype={
-gq(a){return B.u},
-$ih:1,
-$idc:1}
-A.aQ.prototype={}
-A.by.prototype={
-gq(a){return B.v},
-$ih:1,
-$idd:1}
-A.ah.prototype={
-gk(a){return a.length},
-$iz:1}
-A.aO.prototype={$ic:1,$ib:1,$ij:1}
-A.aP.prototype={$ic:1,$ib:1,$ij:1}
-A.bz.prototype={
-gq(a){return B.w},
-$ih:1,
-$ic5:1}
-A.bA.prototype={
-gq(a){return B.x},
-$ih:1,
-$ic6:1}
-A.bB.prototype={
-gq(a){return B.y},
-$ih:1,
-$ic7:1}
-A.bC.prototype={
-gq(a){return B.z},
-$ih:1,
-$ic8:1}
-A.bD.prototype={
-gq(a){return B.A},
-$ih:1,
-$ic9:1}
-A.bE.prototype={
-gq(a){return B.C},
-$ih:1,
-$icj:1}
-A.bF.prototype={
-gq(a){return B.D},
-$ih:1,
-$ick:1}
-A.aR.prototype={
-gq(a){return B.E},
-gk(a){return a.length},
-$ih:1,
-$icl:1}
-A.bG.prototype={
-gq(a){return B.F},
-gk(a){return a.length},
-$ih:1,
-$icm:1}
-A.b2.prototype={}
-A.b3.prototype={}
-A.b4.prototype={}
-A.b5.prototype={}
-A.F.prototype={
-h(a){return A.bd(v.typeUniverse,this,a)},
-j(a){return A.ek(v.typeUniverse,this,a)}}
-A.bX.prototype={}
-A.cK.prototype={
-i(a){return A.A(this.a,null)}}
+return b instanceof A.av&&s.$s===b.$s&&J.P(s.a,b.a)&&J.P(s.b,b.b)&&J.P(s.c,b.c)},
+gq(a){var s=this
+return A.dR(s.$s,s.a,s.b,s.c)}}
+A.ao.prototype={
+gt(a){return B.z},
+$ij:1,
+$idK:1}
+A.b0.prototype={}
+A.bQ.prototype={
+gt(a){return B.A},
+$ij:1,
+$idL:1}
+A.ap.prototype={
+gl(a){return a.length},
+$iB:1}
+A.aZ.prototype={
+j(a,b){A.aa(b,a,a.length)
+return a[b]},
+$ic:1,
+$ib:1,
+$ii:1}
+A.b_.prototype={$ic:1,$ib:1,$ii:1}
+A.bR.prototype={
+gt(a){return B.B},
+$ij:1,
+$ics:1}
+A.bS.prototype={
+gt(a){return B.C},
+$ij:1,
+$ict:1}
+A.bT.prototype={
+gt(a){return B.D},
+j(a,b){A.aa(b,a,a.length)
+return a[b]},
+$ij:1,
+$icu:1}
+A.bU.prototype={
+gt(a){return B.E},
+j(a,b){A.aa(b,a,a.length)
+return a[b]},
+$ij:1,
+$icv:1}
+A.bV.prototype={
+gt(a){return B.F},
+j(a,b){A.aa(b,a,a.length)
+return a[b]},
+$ij:1,
+$icw:1}
 A.bW.prototype={
+gt(a){return B.H},
+j(a,b){A.aa(b,a,a.length)
+return a[b]},
+$ij:1,
+$icG:1}
+A.bX.prototype={
+gt(a){return B.I},
+j(a,b){A.aa(b,a,a.length)
+return a[b]},
+$ij:1,
+$icH:1}
+A.b1.prototype={
+gt(a){return B.J},
+gl(a){return a.length},
+j(a,b){A.aa(b,a,a.length)
+return a[b]},
+$ij:1,
+$icI:1}
+A.bY.prototype={
+gt(a){return B.K},
+gl(a){return a.length},
+j(a,b){A.aa(b,a,a.length)
+return a[b]},
+$ij:1,
+$icJ:1}
+A.bg.prototype={}
+A.bh.prototype={}
+A.bi.prototype={}
+A.bj.prototype={}
+A.J.prototype={
+h(a){return A.bt(v.typeUniverse,this,a)},
+k(a){return A.eP(v.typeUniverse,this,a)}}
+A.cg.prototype={}
+A.db.prototype={
+i(a){return A.F(this.a,null)}}
+A.cf.prototype={
 i(a){return this.a}}
-A.b9.prototype={$iQ:1}
-A.cr.prototype={
+A.bp.prototype={$iT:1}
+A.cS.prototype={
 $1(a){var s=this.a,r=s.a
 s.a=null
 r.$0()},
-$S:4}
-A.cq.prototype={
+$S:6}
+A.cR.prototype={
 $1(a){var s,r
 this.a.a=t.M.a(a)
 s=this.b
 r=this.c
 s.firstChild?s.removeChild(r):s.appendChild(r)},
-$S:9}
-A.cs.prototype={
+$S:10}
+A.cT.prototype={
 $0(){this.a.$0()},
-$S:5}
-A.ct.prototype={
+$S:1}
+A.cU.prototype={
 $0(){this.a.$0()},
-$S:5}
-A.cI.prototype={
-ag(a,b){if(self.setTimeout!=null)self.setTimeout(A.bi(new A.cJ(this,b),0),a)
-else throw A.i(A.fq("`setTimeout()` not found."))}}
-A.cJ.prototype={
-$0(){this.b.$0()},
+$S:1}
+A.bo.prototype={
+ap(a,b){if(self.setTimeout!=null)this.b=self.setTimeout(A.aD(new A.da(this,b),0),a)
+else throw A.e(A.cK("`setTimeout()` not found."))},
+aq(a,b){if(self.setTimeout!=null)this.b=self.setInterval(A.aD(new A.d9(this,a,Date.now(),b),0),a)
+else throw A.e(A.cK("Periodic timer."))},
+Y(){if(self.setTimeout!=null){var s=this.b
+if(s==null)return
+if(this.a)self.clearTimeout(s)
+else self.clearInterval(s)
+this.b=null}else throw A.e(A.cK("Canceling a timer."))},
+$ic7:1}
+A.da.prototype={
+$0(){var s=this.a
+s.b=null
+s.c=1
+this.b.$0()},
 $S:0}
-A.bT.prototype={
-W(a){var s,r=this,q=r.$ti
+A.d9.prototype={
+$0(){var s,r=this,q=r.a,p=q.c+1,o=r.b
+if(o>0){s=Date.now()-r.c
+if(s>(p+1)*o)p=B.c.ao(s,o)}q.c=p
+r.d.$1(q)},
+$S:1}
+A.cc.prototype={
+a_(a){var s,r=this,q=r.$ti
 q.h("1/?").a(a)
 if(a==null)a=q.c.a(a)
-if(!r.b)r.a.a0(a)
+if(!r.b)r.a.a6(a)
 else{s=r.a
-if(q.h("J<1>").b(a))s.a1(a)
-else s.a3(a)}},
-X(a,b){var s=this.a
-if(this.b)s.O(new A.C(a,b))
-else s.N(new A.C(a,b))}}
-A.cQ.prototype={
+if(q.h("M<1>").b(a))s.a7(a)
+else s.a9(a)}},
+a0(a,b){var s=this.a
+if(this.b)s.P(new A.H(a,b))
+else s.O(new A.H(a,b))}}
+A.di.prototype={
 $1(a){return this.a.$2(0,a)},
-$S:1}
-A.cR.prototype={
-$2(a,b){this.a.$2(1,new A.aC(a,t.l.a(b)))},
-$S:10}
-A.cW.prototype={
-$2(a,b){this.a(A.a7(a),b)},
+$S:2}
+A.dj.prototype={
+$2(a,b){this.a.$2(1,new A.aO(a,t.l.a(b)))},
 $S:11}
-A.C.prototype={
-i(a){return A.n(this.a)},
+A.dq.prototype={
+$2(a,b){this.a(A.a1(a),b)},
+$S:12}
+A.bn.prototype={
+gn(){var s=this.b
+return s==null?this.$ti.c.a(s):s},
+aB(a,b){var s,r,q
+a=A.a1(a)
+b=b
+s=this.a
+for(;;)try{r=s(this,a,b)
+return r}catch(q){b=q
+a=1}},
+m(){var s,r,q,p,o=this,n=null,m=0
+for(;;){s=o.d
+if(s!=null)try{if(s.m()){o.b=s.gn()
+return!0}else o.d=null}catch(r){n=r
+m=1
+o.d=null}q=o.aB(m,n)
+if(1===q)return!0
+if(0===q){o.b=null
+p=o.e
+if(p==null||p.length===0){o.a=A.eK
+return!1}if(0>=p.length)return A.y(p,-1)
+o.a=p.pop()
+m=0
+n=null
+continue}if(2===q){m=0
+n=null
+continue}if(3===q){n=o.c
+o.c=null
+p=o.e
+if(p==null||p.length===0){o.b=null
+o.a=A.eK
+throw n
+return!1}if(0>=p.length)return A.y(p,-1)
+o.a=p.pop()
+m=1
+continue}throw A.e(A.dT("sync*"))}return!1},
+aX(a){var s,r,q=this
+if(a instanceof A.aw){s=a.a()
+r=q.e
+if(r==null)r=q.e=[]
+B.a.u(r,q.a)
+q.a=s
+return 2}else{q.d=J.dH(a)
+return 2}},
+$iz:1}
+A.aw.prototype={
+gp(a){return new A.bn(this.a(),this.$ti.h("bn<1>"))}}
+A.H.prototype={
+i(a){return A.m(this.a)},
 $il:1,
 gF(){return this.b}}
-A.bV.prototype={
-X(a,b){var s=this.a
-if((s.a&30)!==0)throw A.i(A.e3("Future already completed"))
-s.N(A.h9(a,b))},
-aa(a){return this.X(a,null)}}
-A.aY.prototype={
-W(a){var s,r=this.$ti
+A.ce.prototype={
+a0(a,b){var s=this.a
+if((s.a&30)!==0)throw A.e(A.dT("Future already completed"))
+s.O(A.hG(a,b))},
+ah(a){return this.a0(a,null)}}
+A.b9.prototype={
+a_(a){var s,r=this.$ti
 r.h("1/?").a(a)
 s=this.a
-if((s.a&30)!==0)throw A.i(A.e3("Future already completed"))
-s.a0(r.h("1/").a(a))}}
-A.a5.prototype={
-aw(a){if((this.c&15)!==6)return!0
-return this.b.b.Z(t.V.a(this.d),a.a,t.y,t.K)},
-au(a){var s,r=this,q=r.e,p=null,o=t.z,n=t.K,m=a.a,l=r.b.b
-if(t.Q.b(q))p=l.aC(q,m,a.b,o,n,t.l)
-else p=l.Z(t.v.a(q),m,o,n)
+if((s.a&30)!==0)throw A.e(A.dT("Future already completed"))
+s.a6(r.h("1/").a(a))}}
+A.a8.prototype={
+aL(a){if((this.c&15)!==6)return!0
+return this.b.b.a2(t.bG.a(this.d),a.a,t.y,t.K)},
+aJ(a){var s,r=this,q=r.e,p=null,o=t.z,n=t.K,m=a.a,l=r.b.b
+if(t.Q.b(q))p=l.aR(q,m,a.b,o,n,t.l)
+else p=l.a2(t.v.a(q),m,o,n)
 try{o=r.$ti.h("2/").a(p)
-return o}catch(s){if(t.c.b(A.aw(s))){if((r.c&1)!==0)throw A.i(A.ay("The error handler of Future.then must return a value of the returned future's type","onError"))
-throw A.i(A.ay("The error handler of Future.catchError must return a value of the future's type","onError"))}else throw s}}}
-A.q.prototype={
-ae(a,b,c){var s,r,q=this.$ti
-q.j(c).h("1/(2)").a(a)
-s=$.o
-if(s===B.b){if(!t.Q.b(b)&&!t.v.b(b))throw A.i(A.dP(b,"onError",u.c))}else{c.h("@<0/>").j(q.c).h("1(2)").a(a)
-b=A.ho(b,s)}r=new A.q(s,c.h("q<0>"))
-this.M(new A.a5(r,3,a,b,q.h("@<1>").j(c).h("a5<1,2>")))
+return o}catch(s){if(t.c.b(A.aj(s))){if((r.c&1)!==0)throw A.e(A.ak("The error handler of Future.then must return a value of the returned future's type","onError"))
+throw A.e(A.ak("The error handler of Future.catchError must return a value of the future's type","onError"))}else throw s}}}
+A.v.prototype={
+a3(a,b,c){var s,r,q,p=this.$ti
+p.k(c).h("1/(2)").a(a)
+s=$.n
+if(s===B.b){if(b!=null&&!t.Q.b(b)&&!t.v.b(b))throw A.e(A.eh(b,"onError",u.c))}else{c.h("@<0/>").k(p.c).h("1(2)").a(a)
+if(b!=null)b=A.hV(b,s)}r=new A.v(s,c.h("v<0>"))
+q=b==null?1:3
+this.N(new A.a8(r,q,a,b,p.h("@<1>").k(c).h("a8<1,2>")))
 return r},
-a7(a,b,c){var s,r=this.$ti
-r.j(c).h("1/(2)").a(a)
-s=new A.q($.o,c.h("q<0>"))
-this.M(new A.a5(s,19,a,b,r.h("@<1>").j(c).h("a5<1,2>")))
+aU(a,b){return this.a3(a,null,b)},
+af(a,b,c){var s,r=this.$ti
+r.k(c).h("1/(2)").a(a)
+s=new A.v($.n,c.h("v<0>"))
+this.N(new A.a8(s,19,a,b,r.h("@<1>").k(c).h("a8<1,2>")))
 return s},
-an(a){this.a=this.a&1|16
+aC(a){this.a=this.a&1|16
 this.c=a},
 G(a){this.a=a.a&30|this.a&1
 this.c=a.c},
-M(a){var s,r=this,q=r.a
+N(a){var s,r=this,q=r.a
 if(q<=3){a.a=t.F.a(r.c)
 r.c=a}else{if((q&4)!==0){s=t._.a(r.c)
-if((s.a&24)===0){s.M(a)
-return}r.G(s)}A.c0(null,null,r.b,t.M.a(new A.cv(r,a)))}},
-a6(a){var s,r,q,p,o,n,m=this,l={}
+if((s.a&24)===0){s.N(a)
+return}r.G(s)}A.cm(null,null,r.b,t.M.a(new A.cW(r,a)))}},
+ad(a){var s,r,q,p,o,n,m=this,l={}
 l.a=a
 if(a==null)return
 s=m.a
@@ -2388,197 +2665,209 @@ m.c=a
 if(r!=null){q=a.a
 for(p=a;q!=null;p=q,q=o)o=q.a
 p.a=r}}else{if((s&4)!==0){n=t._.a(m.c)
-if((n.a&24)===0){n.a6(a)
+if((n.a&24)===0){n.ad(a)
 return}m.G(n)}l.a=m.I(a)
-A.c0(null,null,m.b,t.M.a(new A.cz(l,m)))}},
+A.cm(null,null,m.b,t.M.a(new A.d_(l,m)))}},
 H(){var s=t.F.a(this.c)
 this.c=null
 return this.I(s)},
 I(a){var s,r,q
 for(s=a,r=null;s!=null;r=s,s=q){q=s.a
 s.a=r}return r},
-a3(a){var s,r=this
+a9(a){var s,r=this
 r.$ti.c.a(a)
 s=r.H()
 r.a=8
 r.c=a
-A.ak(r,s)},
-ai(a){var s,r,q=this
+A.as(r,s)},
+au(a){var s,r,q=this
 if((a.a&16)!==0){s=q.b===a.b
 s=!(s||s)}else s=!1
 if(s)return
 r=q.H()
 q.G(a)
-A.ak(q,r)},
-O(a){var s=this.H()
-this.an(a)
-A.ak(this,s)},
-a0(a){var s=this.$ti
+A.as(q,r)},
+P(a){var s=this.H()
+this.aC(a)
+A.as(this,s)},
+a6(a){var s=this.$ti
 s.h("1/").a(a)
-if(s.h("J<1>").b(a)){this.a1(a)
-return}this.ah(a)},
-ah(a){var s=this
+if(s.h("M<1>").b(a)){this.a7(a)
+return}this.ar(a)},
+ar(a){var s=this
 s.$ti.c.a(a)
 s.a^=2
-A.c0(null,null,s.b,t.M.a(new A.cx(s,a)))},
-a1(a){A.dn(this.$ti.h("J<1>").a(a),this,!1)
+A.cm(null,null,s.b,t.M.a(new A.cY(s,a)))},
+a7(a){A.dV(this.$ti.h("M<1>").a(a),this,!1)
 return},
-N(a){this.a^=2
-A.c0(null,null,this.b,t.M.a(new A.cw(this,a)))},
-$iJ:1}
-A.cv.prototype={
-$0(){A.ak(this.a,this.b)},
+O(a){this.a^=2
+A.cm(null,null,this.b,t.M.a(new A.cX(this,a)))},
+$iM:1}
+A.cW.prototype={
+$0(){A.as(this.a,this.b)},
 $S:0}
-A.cz.prototype={
-$0(){A.ak(this.b,this.a.a)},
+A.d_.prototype={
+$0(){A.as(this.b,this.a.a)},
 $S:0}
-A.cy.prototype={
-$0(){A.dn(this.a.a,this.b,!0)},
+A.cZ.prototype={
+$0(){A.dV(this.a.a,this.b,!0)},
 $S:0}
-A.cx.prototype={
-$0(){this.a.a3(this.b)},
+A.cY.prototype={
+$0(){this.a.a9(this.b)},
 $S:0}
-A.cw.prototype={
-$0(){this.a.O(this.b)},
+A.cX.prototype={
+$0(){this.a.P(this.b)},
 $S:0}
-A.cC.prototype={
+A.d2.prototype={
 $0(){var s,r,q,p,o,n,m,l,k=this,j=null
 try{q=k.a.a
-j=q.b.b.aB(t.a.a(q.d),t.z)}catch(p){s=A.aw(p)
-r=A.at(p)
+j=q.b.b.aQ(t.bd.a(q.d),t.z)}catch(p){s=A.aj(p)
+r=A.ag(p)
 if(k.c&&t.n.a(k.b.a.c).a===s){q=k.a
 q.c=t.n.a(k.b.a.c)}else{q=s
 o=r
-if(o==null)o=A.db(q)
+if(o==null)o=A.dJ(q)
 n=k.a
-n.c=new A.C(q,o)
+n.c=new A.H(q,o)
 q=n}q.b=!0
-return}if(j instanceof A.q&&(j.a&24)!==0){if((j.a&16)!==0){q=k.a
+return}if(j instanceof A.v&&(j.a&24)!==0){if((j.a&16)!==0){q=k.a
 q.c=t.n.a(j.c)
-q.b=!0}return}if(j instanceof A.q){m=k.b.a
-l=new A.q(m.b,m.$ti)
-j.ae(new A.cD(l,m),new A.cE(l),t.H)
+q.b=!0}return}if(j instanceof A.v){m=k.b.a
+l=new A.v(m.b,m.$ti)
+j.a3(new A.d3(l,m),new A.d4(l),t.H)
 q=k.a
 q.c=l
 q.b=!1}},
 $S:0}
-A.cD.prototype={
-$1(a){this.a.ai(this.b)},
-$S:4}
-A.cE.prototype={
-$2(a,b){A.bf(a)
+A.d3.prototype={
+$1(a){this.a.au(this.b)},
+$S:6}
+A.d4.prototype={
+$2(a,b){A.ay(a)
 t.l.a(b)
-this.a.O(new A.C(a,b))},
-$S:12}
-A.cB.prototype={
+this.a.P(new A.H(a,b))},
+$S:13}
+A.d1.prototype={
 $0(){var s,r,q,p,o,n,m,l
 try{q=this.a
 p=q.a
 o=p.$ti
 n=o.c
 m=n.a(this.b)
-q.c=p.b.b.Z(o.h("2/(1)").a(p.d),m,o.h("2/"),n)}catch(l){s=A.aw(l)
-r=A.at(l)
+q.c=p.b.b.a2(o.h("2/(1)").a(p.d),m,o.h("2/"),n)}catch(l){s=A.aj(l)
+r=A.ag(l)
 q=s
 p=r
-if(p==null)p=A.db(q)
+if(p==null)p=A.dJ(q)
 o=this.a
-o.c=new A.C(q,p)
+o.c=new A.H(q,p)
 o.b=!0}},
 $S:0}
-A.cA.prototype={
+A.d0.prototype={
 $0(){var s,r,q,p,o,n,m,l=this
 try{s=t.n.a(l.a.a.c)
 p=l.b
-if(p.a.aw(s)&&p.a.e!=null){p.c=p.a.au(s)
-p.b=!1}}catch(o){r=A.aw(o)
-q=A.at(o)
+if(p.a.aL(s)&&p.a.e!=null){p.c=p.a.aJ(s)
+p.b=!1}}catch(o){r=A.aj(o)
+q=A.ag(o)
 p=t.n.a(l.a.a.c)
 if(p.a===r){n=l.b
 n.c=p
 p=n}else{p=r
 n=q
-if(n==null)n=A.db(p)
+if(n==null)n=A.dJ(p)
 m=l.b
-m.c=new A.C(p,n)
+m.c=new A.H(p,n)
 p=m}p.b=!0}},
 $S:0}
-A.bU.prototype={}
-A.bZ.prototype={}
-A.be.prototype={$ie8:1}
-A.cU.prototype={
-$0(){A.f6(this.a,this.b)},
+A.cd.prototype={}
+A.ci.prototype={}
+A.bu.prototype={$ieC:1}
+A.dn.prototype={
+$0(){A.fA(this.a,this.b)},
 $S:0}
-A.bY.prototype={
-aD(a){var s,r,q
+A.ch.prototype={
+aS(a){var s,r,q
 t.M.a(a)
-try{if(B.b===$.o){a.$0()
-return}A.ex(null,null,this,a,t.H)}catch(q){s=A.aw(q)
-r=A.at(q)
-A.dx(A.bf(s),t.l.a(r))}},
-ar(a){return new A.cH(this,t.M.a(a))},
-aB(a,b){b.h("0()").a(a)
-if($.o===B.b)return a.$0()
-return A.ex(null,null,this,a,b)},
-Z(a,b,c,d){c.h("@<0>").j(d).h("1(2)").a(a)
+try{if(B.b===$.n){a.$0()
+return}A.f_(null,null,this,a,t.H)}catch(q){s=A.aj(q)
+r=A.ag(q)
+A.dm(A.ay(s),t.l.a(r))}},
+aT(a,b,c){var s,r,q
+c.h("~(0)").a(a)
+c.a(b)
+try{if(B.b===$.n){a.$1(b)
+return}A.f0(null,null,this,a,b,t.H,c)}catch(q){s=A.aj(q)
+r=A.ag(q)
+A.dm(A.ay(s),t.l.a(r))}},
+aG(a){return new A.d7(this,t.M.a(a))},
+aH(a,b){return new A.d8(this,b.h("~(0)").a(a),b)},
+aQ(a,b){b.h("0()").a(a)
+if($.n===B.b)return a.$0()
+return A.f_(null,null,this,a,b)},
+a2(a,b,c,d){c.h("@<0>").k(d).h("1(2)").a(a)
 d.a(b)
-if($.o===B.b)return a.$1(b)
-return A.hq(null,null,this,a,b,c,d)},
-aC(a,b,c,d,e,f){d.h("@<0>").j(e).j(f).h("1(2,3)").a(a)
+if($.n===B.b)return a.$1(b)
+return A.f0(null,null,this,a,b,c,d)},
+aR(a,b,c,d,e,f){d.h("@<0>").k(e).k(f).h("1(2,3)").a(a)
 e.a(b)
 f.a(c)
-if($.o===B.b)return a.$2(b,c)
-return A.hp(null,null,this,a,b,c,d,e,f)},
-ad(a,b,c,d){return b.h("@<0>").j(c).j(d).h("1(2,3)").a(a)}}
-A.cH.prototype={
-$0(){return this.a.aD(this.b)},
+if($.n===B.b)return a.$2(b,c)
+return A.hW(null,null,this,a,b,c,d,e,f)},
+ak(a,b,c,d){return b.h("@<0>").k(c).k(d).h("1(2,3)").a(a)}}
+A.d7.prototype={
+$0(){return this.a.aS(this.b)},
 $S:0}
-A.b_.prototype={
-gk(a){return this.a},
-gC(){return new A.b0(this,this.$ti.h("b0<1>"))},
-ab(a){var s,r
+A.d8.prototype={
+$1(a){var s=this.c
+return this.a.aT(this.b,s.a(a),s)},
+$S(){return this.c.h("~(0)")}}
+A.bb.prototype={
+gl(a){return this.a},
+gB(){return new A.bc(this,this.$ti.h("bc<1>"))},
+J(a){var s,r
 if(typeof a=="string"&&a!=="__proto__"){s=this.b
 return s==null?!1:s[a]!=null}else if(typeof a=="number"&&(a&1073741823)===a){r=this.c
-return r==null?!1:r[a]!=null}else return this.ak(a)},
-ak(a){var s=this.d
+return r==null?!1:r[a]!=null}else return this.aw(a)},
+aw(a){var s=this.d
 if(s==null)return!1
-return this.S(this.a5(s,a),a)>=0},
-t(a,b){var s,r,q
+return this.T(this.ab(s,a),a)>=0},
+j(a,b){var s,r,q
 if(typeof b=="string"&&b!=="__proto__"){s=this.b
-r=s==null?null:A.ea(s,b)
+r=s==null?null:A.eE(s,b)
 return r}else if(typeof b=="number"&&(b&1073741823)===b){q=this.c
-r=q==null?null:A.ea(q,b)
-return r}else return this.am(b)},
-am(a){var s,r,q=this.d
+r=q==null?null:A.eE(q,b)
+return r}else return this.aA(b)},
+aA(a){var s,r,q=this.d
 if(q==null)return null
-s=this.a5(q,a)
-r=this.S(s,a)
+s=this.ab(q,a)
+r=this.T(s,a)
 return r<0?null:s[r+1]},
 v(a,b,c){var s,r,q,p,o,n,m=this,l=m.$ti
 l.c.a(b)
 l.y[1].a(c)
 if(typeof b=="string"&&b!=="__proto__"){s=m.b
-m.a2(s==null?m.b=A.dp():s,b,c)}else if(typeof b=="number"&&(b&1073741823)===b){r=m.c
-m.a2(r==null?m.c=A.dp():r,b,c)}else{q=m.d
-if(q==null)q=m.d=A.dp()
-p=A.d5(b)&1073741823
+m.a8(s==null?m.b=A.dW():s,b,c)}else if(typeof b=="number"&&(b&1073741823)===b){r=m.c
+m.a8(r==null?m.c=A.dW():r,b,c)}else{q=m.d
+if(q==null)q=m.d=A.dW()
+p=A.dD(b)&1073741823
 o=q[p]
-if(o==null){A.dq(q,p,[b,c]);++m.a
-m.e=null}else{n=m.S(o,b)
+if(o==null){A.dX(q,p,[b,c]);++m.a
+m.e=null}else{n=m.T(o,b)
 if(n>=0)o[n+1]=c
 else{o.push(b,c);++m.a
 m.e=null}}}},
 E(a,b){var s,r,q,p,o,n,m=this,l=m.$ti
 l.h("~(1,2)").a(b)
-s=m.a4()
+s=m.aa()
 for(r=s.length,q=l.c,l=l.y[1],p=0;p<r;++p){o=s[p]
 q.a(o)
-n=m.t(0,o)
+n=m.j(0,o)
 b.$2(o,n==null?l.a(n):n)
-if(s!==m.e)throw A.i(A.af(m))}},
-a4(){var s,r,q,p,o,n,m,l,k,j,i=this,h=i.e
+if(s!==m.e)throw A.e(A.am(m))}},
+aa(){var s,r,q,p,o,n,m,l,k,j,i=this,h=i.e
 if(h!=null)return h
-h=A.fe(i.a,null,!1,t.z)
+h=A.fH(i.a,null,!1,t.z)
 s=i.b
 r=0
 if(s!=null){q=Object.getOwnPropertyNames(s)
@@ -2592,281 +2881,323 @@ p=q.length
 for(o=0;o<p;++o){l=m[q[o]]
 k=l.length
 for(j=0;j<k;j+=2){h[r]=l[j];++r}}}return i.e=h},
-a2(a,b,c){var s=this.$ti
+a8(a,b,c){var s=this.$ti
 s.c.a(b)
 s.y[1].a(c)
 if(a[b]==null){++this.a
-this.e=null}A.dq(a,b,c)},
-a5(a,b){return a[A.d5(b)&1073741823]}}
-A.al.prototype={
-S(a,b){var s,r,q
+this.e=null}A.dX(a,b,c)},
+ab(a,b){return a[A.dD(b)&1073741823]}}
+A.at.prototype={
+T(a,b){var s,r,q
 if(a==null)return-1
 s=a.length
 for(r=0;r<s;r+=2){q=a[r]
 if(q==null?b==null:q===b)return r}return-1}}
-A.b0.prototype={
-gk(a){return this.a.a},
+A.bc.prototype={
+gl(a){return this.a.a},
 gp(a){var s=this.a
-return new A.b1(s,s.a4(),this.$ti.h("b1<1>"))}}
-A.b1.prototype={
-gm(){var s=this.d
+return new A.bd(s,s.aa(),this.$ti.h("bd<1>"))}}
+A.bd.prototype={
+gn(){var s=this.d
 return s==null?this.$ti.c.a(s):s},
-l(){var s=this,r=s.b,q=s.c,p=s.a
-if(r!==p.e)throw A.i(A.af(p))
+m(){var s=this,r=s.b,q=s.c,p=s.a
+if(r!==p.e)throw A.e(A.am(p))
 else if(q>=r.length){s.d=null
 return!1}else{s.d=r[q]
 s.c=q+1
 return!0}},
-$iD:1}
+$iz:1}
+A.f.prototype={
+gp(a){return new A.R(a,this.gl(a),A.aE(a).h("R<f.E>"))},
+K(a,b){return this.j(a,b)},
+L(a,b,c){var s=A.aE(a)
+return new A.S(a,s.k(c).h("1(f.E)").a(b),s.h("@<f.E>").k(c).h("S<1,2>"))},
+i(a){return A.eo(a,"[","]")},
+$ic:1,
+$ib:1,
+$ii:1}
 A.k.prototype={
-gp(a){return new A.a3(a,a.length,A.au(a).h("a3<k.E>"))},
-J(a,b){if(!(b<a.length))return A.x(a,b)
-return a[b]},
-K(a,b,c){var s=A.au(a)
-return new A.P(a,s.j(c).h("1(k.E)").a(b),s.h("@<k.E>").j(c).h("P<1,2>"))},
-i(a){return A.dW(a,"[","]")}}
-A.e.prototype={
-a9(a,b,c){return new A.a0(this,A.G(this).h("@<e.K,e.V>").j(b).j(c).h("a0<1,2,3,4>"))},
-E(a,b){var s,r,q,p=A.G(this)
-p.h("~(e.K,e.V)").a(b)
-for(s=this.gC(),s=s.gp(s),p=p.h("e.V");s.l();){r=s.gm()
-q=this.t(0,r)
+Z(a,b,c){var s=A.r(this)
+return A.er(this,s.h("k.K"),s.h("k.V"),b,c)},
+E(a,b){var s,r,q,p=A.r(this)
+p.h("~(k.K,k.V)").a(b)
+for(s=this.gB(),s=s.gp(s),p=p.h("k.V");s.m();){r=s.gn()
+q=this.j(0,r)
 b.$2(r,q==null?p.a(q):q)}},
-gD(){var s=this.gC(),r=A.G(this).h("u<e.K,e.V>"),q=A.G(s)
-return A.dj(s,q.j(r).h("1(b.E)").a(new A.cc(this)),q.h("b.E"),r)},
-gk(a){var s=this.gC()
-return s.gk(s)},
-i(a){return A.dY(this)},
-$iO:1}
-A.cc.prototype={
-$1(a){var s=this.a,r=A.G(s)
-r.h("e.K").a(a)
-s=s.t(0,a)
-if(s==null)s=r.h("e.V").a(s)
-return new A.u(a,s,r.h("u<e.K,e.V>"))},
-$S(){return A.G(this.a).h("u<e.K,e.V>(e.K)")}}
-A.cd.prototype={
+gD(){var s=this.gB(),r=A.r(this).h("p<k.K,k.V>"),q=A.r(s)
+return A.dQ(s,q.k(r).h("1(b.E)").a(new A.cz(this)),q.h("b.E"),r)},
+gl(a){var s=this.gB()
+return s.gl(s)},
+i(a){return A.dP(this)},
+$iD:1}
+A.cz.prototype={
+$1(a){var s=this.a,r=A.r(s)
+r.h("k.K").a(a)
+s=s.j(0,a)
+if(s==null)s=r.h("k.V").a(s)
+return new A.p(a,s,r.h("p<k.K,k.V>"))},
+$S(){return A.r(this.a).h("p<k.K,k.V>(k.K)")}}
+A.cA.prototype={
 $2(a,b){var s,r=this.a
 if(!r.a)this.b.a+=", "
 r.a=!1
 r=this.b
-s=A.n(a)
+s=A.m(a)
 r.a=(r.a+=s)+": "
-s=A.n(b)
+s=A.m(b)
 r.a+=s},
-$S:13}
-A.bo.prototype={
-B(a,b){var s
-if(b==null)return!1
-s=!1
-if(b instanceof A.bo)if(this.a===b.a)s=this.b===b.b
-return s},
-gn(a){return A.dk(this.a,this.b,B.c,B.c)},
-i(a){var s=this,r=A.f4(A.fn(s)),q=A.bp(A.fl(s)),p=A.bp(A.fh(s)),o=A.bp(A.fi(s)),n=A.bp(A.fk(s)),m=A.bp(A.fm(s)),l=A.dV(A.fj(s)),k=s.b,j=k===0?"":A.dV(k)
-return r+"-"+q+"-"+p+" "+o+":"+n+":"+m+"."+l+j+"Z"}}
+$S:14}
+A.bE.prototype={
+C(a,b){if(b==null)return!1
+return b instanceof A.bE&&this.a===b.a&&this.b===b.b&&this.c===b.c},
+gq(a){return A.dR(this.a,this.b,B.d,B.d)},
+i(a){var s=this,r=A.fy(A.fQ(s)),q=A.bF(A.fO(s)),p=A.bF(A.fK(s)),o=A.bF(A.fL(s)),n=A.bF(A.fN(s)),m=A.bF(A.fP(s)),l=A.en(A.fM(s)),k=s.b,j=k===0?"":A.en(k)
+k=r+"-"+q
+if(s.c)return k+"-"+p+" "+o+":"+n+":"+m+"."+l+j+"Z"
+else return k+"-"+p+" "+o+":"+n+":"+m+"."+l+j}}
+A.bG.prototype={
+C(a,b){if(b==null)return!1
+return b instanceof A.bG&&this.a===b.a},
+gq(a){return B.c.gq(this.a)},
+i(a){var s,r,q,p=this.a,o=p%36e8,n=B.c.X(o,6e7)
+o%=6e7
+s=n<10?"0":""
+r=B.c.X(o,1e6)
+q=r<10?"0":""
+return""+(p/36e8|0)+":"+s+n+":"+q+r+"."+B.u.aP(B.c.i(o%1e6),6,"0")}}
 A.l.prototype={
-gF(){return A.fg(this)}}
-A.bj.prototype={
+gF(){return A.fJ(this)}}
+A.bz.prototype={
 i(a){var s=this.a
-if(s!=null)return"Assertion failed: "+A.c4(s)
+if(s!=null)return"Assertion failed: "+A.cr(s)
 return"Assertion failed"}}
-A.Q.prototype={}
-A.N.prototype={
-gR(){return"Invalid argument"+(!this.a?"(s)":"")},
-gP(){return""},
-i(a){var s=this,r=s.c,q=r==null?"":" ("+r+")",p=s.d,o=p==null?"":": "+p,n=s.gR()+q+o
+A.T.prototype={}
+A.Q.prototype={
+gS(){return"Invalid argument"+(!this.a?"(s)":"")},
+gR(){return""},
+i(a){var s=this,r=s.c,q=r==null?"":" ("+r+")",p=s.d,o=p==null?"":": "+p,n=s.gS()+q+o
 if(!s.a)return n
-return n+s.gP()+": "+A.c4(s.gY())},
-gY(){return this.b}}
-A.aT.prototype={
-gY(){return A.eo(this.b)},
-gR(){return"RangeError"},
-gP(){var s,r=this.e,q=this.f
-if(r==null)s=q!=null?": Not less than or equal to "+A.n(q):""
-else if(q==null)s=": Not greater than or equal to "+A.n(r)
-else if(q>r)s=": Not in inclusive range "+A.n(r)+".."+A.n(q)
-else s=q<r?": Valid value range is empty":": Only valid value is "+A.n(r)
+return n+s.gR()+": "+A.cr(s.ga1())},
+ga1(){return this.b}}
+A.b3.prototype={
+ga1(){return A.ck(this.b)},
+gS(){return"RangeError"},
+gR(){var s,r=this.e,q=this.f
+if(r==null)s=q!=null?": Not less than or equal to "+A.m(q):""
+else if(q==null)s=": Not greater than or equal to "+A.m(r)
+else if(q>r)s=": Not in inclusive range "+A.m(r)+".."+A.m(q)
+else s=q<r?": Valid value range is empty":": Only valid value is "+A.m(r)
 return s}}
-A.bq.prototype={
-gY(){return A.a7(this.b)},
-gR(){return"RangeError"},
-gP(){if(A.a7(this.b)<0)return": index must not be negative"
+A.bH.prototype={
+ga1(){return A.a1(this.b)},
+gS(){return"RangeError"},
+gR(){if(A.a1(this.b)<0)return": index must not be negative"
 var s=this.f
 if(s===0)return": no indices are valid"
 return": index should be less than "+s},
-gk(a){return this.f}}
-A.aX.prototype={
+gl(a){return this.f}}
+A.b8.prototype={
 i(a){return"Unsupported operation: "+this.a}}
-A.bP.prototype={
+A.c8.prototype={
 i(a){return"UnimplementedError: "+this.a}}
-A.bL.prototype={
+A.c3.prototype={
 i(a){return"Bad state: "+this.a}}
-A.bn.prototype={
+A.bD.prototype={
 i(a){var s=this.a
 if(s==null)return"Concurrent modification during iteration."
-return"Concurrent modification during iteration: "+A.c4(s)+"."}}
-A.aV.prototype={
+return"Concurrent modification during iteration: "+A.cr(s)+"."}}
+A.bZ.prototype={
+i(a){return"Out of Memory"},
+gF(){return null},
+$il:1}
+A.b5.prototype={
 i(a){return"Stack Overflow"},
 gF(){return null},
 $il:1}
-A.cu.prototype={
+A.cV.prototype={
 i(a){return"Exception: "+this.a}}
 A.b.prototype={
-K(a,b,c){var s=A.G(this)
-return A.dj(this,s.j(c).h("1(b.E)").a(b),s.h("b.E"),c)},
-gk(a){var s,r=this.gp(this)
-for(s=0;r.l();)++s
+L(a,b,c){var s=A.r(this)
+return A.dQ(this,s.k(c).h("1(b.E)").a(b),s.h("b.E"),c)},
+gl(a){var s,r=this.gp(this)
+for(s=0;r.m();)++s
 return s},
-i(a){return A.f8(this,"(",")")}}
-A.u.prototype={
-i(a){return"MapEntry("+A.n(this.a)+": "+A.n(this.b)+")"}}
-A.w.prototype={
-gn(a){return A.d.prototype.gn.call(this,0)},
+i(a){return A.fC(this,"(",")")}}
+A.p.prototype={
+i(a){return"MapEntry("+A.m(this.a)+": "+A.m(this.b)+")"}}
+A.q.prototype={
+gq(a){return A.d.prototype.gq.call(this,0)},
 i(a){return"null"}}
 A.d.prototype={$id:1,
-B(a,b){return this===b},
-gn(a){return A.bI(this)},
-i(a){return"Instance of '"+A.bJ(this)+"'"},
-gq(a){return A.hJ(this)},
+C(a,b){return this===b},
+gq(a){return A.c0(this)},
+i(a){return"Instance of '"+A.c1(this)+"'"},
+gt(a){return A.ig(this)},
 toString(){return this.i(this)}}
-A.c_.prototype={
+A.cj.prototype={
 i(a){return""},
-$iV:1}
-A.bN.prototype={
-gk(a){return this.a.length},
+$iZ:1}
+A.c5.prototype={
+gl(a){return this.a.length},
 i(a){var s=this.a
 return s.charCodeAt(0)==0?s:s}}
-A.ce.prototype={
+A.cB.prototype={
 i(a){return"Promise was rejected with a value of `"+(this.a?"undefined":"null")+"`."}}
-A.d3.prototype={
+A.dB.prototype={
 $1(a){var s,r,q,p
-if(A.ew(a))return a
+if(A.eY(a))return a
 s=this.a
-if(s.ab(a))return s.t(0,a)
-if(a instanceof A.e){r={}
+if(s.J(a))return s.j(0,a)
+if(t.f.b(a)){r={}
 s.v(0,a,r)
-for(s=a.gC(),s=s.gp(s);s.l();){q=s.gm()
-r[q]=this.$1(a.t(0,q))}return r}else if(t.R.b(a)){p=[]
+for(s=a.gB(),s=s.gp(s);s.m();){q=s.gn()
+r[q]=this.$1(a.j(0,q))}return r}else if(t.R.b(a)){p=[]
 s.v(0,a,p)
-B.a.aq(p,J.dO(a,this,t.z))
+B.a.aF(p,J.eg(a,this,t.z))
 return p}else return a},
+$S:3}
+A.dE.prototype={
+$1(a){return this.a.a_(this.b.h("0/?").a(a))},
 $S:2}
-A.d6.prototype={
-$1(a){return this.a.W(this.b.h("0/?").a(a))},
-$S:1}
-A.d7.prototype={
-$1(a){if(a==null)return this.a.aa(new A.ce(a===undefined))
-return this.a.aa(a)},
-$S:1}
-A.cY.prototype={
-$1(a){var s,r,q,p,o,n,m,l,k,j,i,h,g
-if(A.ev(a))return a
+A.dF.prototype={
+$1(a){if(a==null)return this.a.ah(new A.cB(a===undefined))
+return this.a.ah(a)},
+$S:2}
+A.ds.prototype={
+$1(a){var s,r,q,p,o,n,m,l,k,j,i,h
+if(A.eX(a))return a
 s=this.a
 a.toString
-if(s.ab(a))return s.t(0,a)
+if(s.J(a))return s.j(0,a)
 if(a instanceof Date){r=a.getTime()
-if(r<-864e13||r>864e13)A.c1(A.e1(r,-864e13,864e13,"millisecondsSinceEpoch",null))
-A.cX(!0,"isUtc",t.y)
-return new A.bo(r,0,!0)}if(a instanceof RegExp)throw A.i(A.ay("structured clone of RegExp",null))
-if(a instanceof Promise)return A.hU(a,t.X)
+if(r<-864e13||r>864e13)A.co(A.ev(r,-864e13,864e13,"millisecondsSinceEpoch",null))
+A.dr(!0,"isUtc",t.y)
+return new A.bE(r,0,!0)}if(a instanceof RegExp)throw A.e(A.ak("structured clone of RegExp",null))
+if(a instanceof Promise)return A.f9(a,t.X)
 q=Object.getPrototypeOf(a)
 if(q===Object.prototype||q===null){p=t.X
-o=A.dh(p,p)
+o=A.dO(p,p)
 s.v(0,a,o)
 n=Object.keys(a)
 m=[]
-for(s=n.length,l=0;l<n.length;n.length===s||(0,A.dJ)(n),++l)m.push(A.dA(n[l]))
-for(k=0;k<n.length;++k){j=n[k]
-if(!(k<m.length))return A.x(m,k)
-i=m[k]
-if(j!=null)o.v(0,i,this.$1(a[j]))}return o}if(a instanceof Array){h=a
+for(s=J.cn(n),p=s.gp(n);p.m();)m.push(A.e6(p.gn()))
+for(l=0;l<s.gl(n);++l){k=s.j(n,l)
+if(!(l<m.length))return A.y(m,l)
+j=m[l]
+if(k!=null)o.v(0,j,this.$1(a[k]))}return o}if(a instanceof Array){i=a
 o=[]
 s.v(0,a,o)
-g=A.a7(a.length)
-for(k=0;k<g;++k){if(!(k<h.length))return A.x(h,k)
-o.push(this.$1(h[k]))}return o}return a},
-$S:2}
-A.bR.prototype={
-az(a){var s,r,q,p
+h=A.a1(a.length)
+for(s=J.cn(i),l=0;l<h;++l)o.push(this.$1(s.j(i,l)))
+return o}return a},
+$S:3}
+A.dw.prototype={
+$1(a){t.p.a(a)
+return A.eZ(this.a,this.b)},
+$S:15}
+A.ca.prototype={
+aN(a){var s,r,q,p
 if(a==null)return null
-if(a instanceof A.e){s=A.dh(t.N,t.z)
-for(r=a.gD(),r=r.gp(r);r.l();){q=r.gm()
+if(t.f.b(a)){s=A.dO(t.N,t.z)
+for(r=a.gD(),r=r.gp(r);r.m();){q=r.gn()
 p=q.a
-if(typeof p=="string")s.v(0,p,this.L(q.b))}return s}return A.di(["value",this.L(a)],t.N,t.z)},
-L(a){var s,r,q,p
-if(a instanceof A.e){s=A.dh(t.N,t.z)
-for(r=a.gD(),r=r.gp(r);r.l();){q=r.gm()
+if(typeof p=="string")s.v(0,p,this.M(q.b))}return s}return A.C(["value",this.M(a)],t.N,t.z)},
+M(a){var s,r,q,p
+if(t.f.b(a)){s=A.dO(t.N,t.z)
+for(r=a.gD(),r=r.gp(r);r.m();){q=r.gn()
 p=q.a
-if(typeof p=="string")s.v(0,p,this.L(q.b))}return s}if(t.j.b(a)){r=J.dO(a,this.gaA(),t.X)
-r=A.fd(r,r.$ti.h("L.E"))
-return r}return a}}
-A.cp.prototype={
-$1(a){var s=A.en(a).data,r=s==null?null:A.dA(s)
-if(r instanceof A.e){s=t.X
-A.fs(r.a9(0,s,s))}},
-$S:14};(function aliases(){var s=J.U.prototype
-s.af=s.i})();(function installTearOffs(){var s=hunkHelpers._static_1,r=hunkHelpers._static_0,q=hunkHelpers._instance_1u,p=hunkHelpers.installStaticTearOff,o=hunkHelpers._static_2
-s(A,"hz","fx",3)
-s(A,"hA","fy",3)
-s(A,"hB","fz",3)
-r(A,"eB","hu",0)
-q(A.bR.prototype,"gaA","L",2)
-p(A,"dL",3,null,["$3"],["fu"],15,0)
-r(A,"hD","hY",0)
-o(A,"hC","dE",16)})();(function inheritance(){var s=hunkHelpers.mixin,r=hunkHelpers.inherit,q=hunkHelpers.inheritMany
+if(typeof p=="string")s.v(0,p,this.M(q.b))}return s}if(t.j.b(a)){r=J.eg(a,this.gaO(),t.X)
+r=A.fG(r,r.$ti.h("O.E"))
+return r}return a},
+saM(a){this.b=t.U.a(a)},
+sa4(a){this.c=t.U.a(a)}}
+A.cQ.prototype={
+$1(a){var s=A.de(a).data,r=s==null?null:A.e6(s)
+if(t.f.b(r)){s=t.X
+A.fW(r.Z(0,s,s))}},
+$S:16}
+A.cO.prototype={
+$1(a){var s=t.N,r=t.X,q=A.by(A.C(["type","workerMessage","payload",a],s,r))
+A.f9(A.de(A.bN(A.de(this.a.clients),"matchAll",A.by(A.C(["type","window","includeUncontrolled",!0],s,r)),null,r)),r).aU(new A.cN(q),t.P)},
+$S:4}
+A.cN.prototype={
+$1(a){var s,r,q,p
+if(!t.j.b(a))return
+for(s=J.dH(a),r=t.m,q=this.a;s.m();){p=s.gn()
+if(r.b(p))A.ep(p,"postMessage",q,null,null,null)}},
+$S:17}
+A.cP.prototype={
+$1(a){var s=t.X
+A.bN(this.a,"postMessage",A.by(A.C(["type","workerMessage","payload",a],t.N,s)),null,s)},
+$S:4};(function aliases(){var s=J.Y.prototype
+s.an=s.i})();(function installTearOffs(){var s=hunkHelpers._static_1,r=hunkHelpers._static_0,q=hunkHelpers._static_2,p=hunkHelpers._instance_1u,o=hunkHelpers.installStaticTearOff
+s(A,"i4","h1",5)
+s(A,"i5","h2",5)
+s(A,"i6","h3",5)
+r(A,"f4","i_",0)
+r(A,"i9","iw",0)
+s(A,"i8","ij",4)
+q(A,"i7","e8",18)
+p(A.ca.prototype,"gaO","M",3)
+o(A,"ed",3,null,["$3"],["fY"],19,0)})();(function inheritance(){var s=hunkHelpers.mixin,r=hunkHelpers.inherit,q=hunkHelpers.inheritMany
 r(A.d,null)
-q(A.d,[A.df,J.br,A.aU,J.az,A.b,A.aA,A.e,A.T,A.l,A.cg,A.a3,A.aN,A.y,A.S,A.ch,A.cf,A.aC,A.b8,A.cb,A.aL,A.aK,A.F,A.bX,A.cK,A.cI,A.bT,A.C,A.bV,A.a5,A.q,A.bU,A.bZ,A.be,A.b1,A.k,A.bo,A.aV,A.cu,A.u,A.w,A.c_,A.bN,A.ce,A.bR])
-q(J.br,[J.bt,J.aE,J.aH,J.aG,J.aI,J.bv,J.aF])
-q(J.aH,[J.U,J.t,A.ag,A.aQ])
-q(J.U,[J.bH,J.aW,J.K])
-r(J.bs,A.aU)
-r(J.ca,J.t)
-q(J.bv,[J.aD,J.bu])
-q(A.b,[A.aj,A.c,A.a4])
-r(A.a_,A.aj)
-r(A.aZ,A.a_)
-q(A.e,[A.a0,A.a2,A.b_])
-q(A.T,[A.bm,A.c2,A.bl,A.bO,A.d_,A.d1,A.cr,A.cq,A.cQ,A.cD,A.cc,A.d3,A.d6,A.d7,A.cY,A.cp])
-q(A.bm,[A.c3,A.d0,A.cR,A.cW,A.cE,A.cd])
-q(A.l,[A.bx,A.Q,A.bw,A.bQ,A.bK,A.bW,A.bj,A.N,A.aX,A.bP,A.bL,A.bn])
-q(A.c,[A.L,A.aM,A.aJ,A.b0])
-r(A.aB,A.a4)
-r(A.P,A.L)
-q(A.S,[A.am,A.an])
-r(A.b6,A.am)
-r(A.b7,A.an)
-r(A.aS,A.Q)
-q(A.bO,[A.bM,A.ae])
-q(A.aQ,[A.by,A.ah])
-q(A.ah,[A.b2,A.b4])
-r(A.b3,A.b2)
-r(A.aO,A.b3)
-r(A.b5,A.b4)
-r(A.aP,A.b5)
-q(A.aO,[A.bz,A.bA])
-q(A.aP,[A.bB,A.bC,A.bD,A.bE,A.bF,A.aR,A.bG])
-r(A.b9,A.bW)
-q(A.bl,[A.cs,A.ct,A.cJ,A.cv,A.cz,A.cy,A.cx,A.cw,A.cC,A.cB,A.cA,A.cU,A.cH])
-r(A.aY,A.bV)
-r(A.bY,A.be)
-r(A.al,A.b_)
-q(A.N,[A.aT,A.bq])
-s(A.b2,A.k)
-s(A.b3,A.y)
-s(A.b4,A.k)
-s(A.b5,A.y)})()
-var v={G:typeof self!="undefined"?self:globalThis,typeUniverse:{eC:new Map(),tR:{},eT:{},tPV:{},sEA:[]},mangledGlobalNames:{a:"int",f:"double",ad:"num",v:"String",a9:"bool",w:"Null",j:"List",d:"Object",O:"Map",m:"JSObject"},mangledNames:{},types:["~()","~(@)","d?(d?)","~(~())","w(@)","w()","@(@)","@(@,v)","@(v)","w(~())","w(@,V)","~(a,@)","w(d,V)","~(d?,d?)","w(m)","~(v,d?,K)","J<a9>(v,O<v,@>?)"],interceptorsByTag:null,leafTags:null,arrayRti:Symbol("$ti"),rttc:{"2;":(a,b)=>c=>c instanceof A.b6&&a.b(c.a)&&b.b(c.b),"3;inputData,requestId,taskName":(a,b,c)=>d=>d instanceof A.b7&&a.b(d.a)&&b.b(d.b)&&c.b(d.c)}}
-A.fN(v.typeUniverse,JSON.parse('{"K":"U","bH":"U","aW":"U","i_":"ag","bt":{"a9":[],"h":[]},"aE":{"h":[]},"aH":{"m":[]},"U":{"m":[]},"t":{"j":["1"],"c":["1"],"m":[],"b":["1"]},"bs":{"aU":[]},"ca":{"t":["1"],"j":["1"],"c":["1"],"m":[],"b":["1"]},"az":{"D":["1"]},"bv":{"f":[],"ad":[]},"aD":{"f":[],"a":[],"ad":[],"h":[]},"bu":{"f":[],"ad":[],"h":[]},"aF":{"v":[],"h":[]},"aj":{"b":["2"]},"aA":{"D":["2"]},"a_":{"aj":["1","2"],"b":["2"],"b.E":"2"},"aZ":{"a_":["1","2"],"aj":["1","2"],"c":["2"],"b":["2"],"b.E":"2"},"a0":{"e":["3","4"],"O":["3","4"],"e.K":"3","e.V":"4"},"bx":{"l":[]},"c":{"b":["1"]},"L":{"c":["1"],"b":["1"]},"a3":{"D":["1"]},"a4":{"b":["2"],"b.E":"2"},"aB":{"a4":["1","2"],"c":["2"],"b":["2"],"b.E":"2"},"aN":{"D":["2"]},"P":{"L":["2"],"c":["2"],"b":["2"],"L.E":"2","b.E":"2"},"b6":{"am":[],"S":[]},"b7":{"an":[],"S":[]},"aS":{"Q":[],"l":[]},"bw":{"l":[]},"bQ":{"l":[]},"b8":{"V":[]},"T":{"a1":[]},"bl":{"a1":[]},"bm":{"a1":[]},"bO":{"a1":[]},"bM":{"a1":[]},"ae":{"a1":[]},"bK":{"l":[]},"a2":{"e":["1","2"],"dX":["1","2"],"O":["1","2"],"e.K":"1","e.V":"2"},"aM":{"c":["1"],"b":["1"],"b.E":"1"},"aL":{"D":["1"]},"aJ":{"c":["u<1,2>"],"b":["u<1,2>"],"b.E":"u<1,2>"},"aK":{"D":["u<1,2>"]},"am":{"S":[]},"an":{"S":[]},"ag":{"m":[],"dc":[],"h":[]},"aQ":{"m":[]},"by":{"dd":[],"m":[],"h":[]},"ah":{"z":["1"],"m":[]},"aO":{"k":["f"],"j":["f"],"z":["f"],"c":["f"],"m":[],"b":["f"],"y":["f"]},"aP":{"k":["a"],"j":["a"],"z":["a"],"c":["a"],"m":[],"b":["a"],"y":["a"]},"bz":{"c5":[],"k":["f"],"j":["f"],"z":["f"],"c":["f"],"m":[],"b":["f"],"y":["f"],"h":[],"k.E":"f"},"bA":{"c6":[],"k":["f"],"j":["f"],"z":["f"],"c":["f"],"m":[],"b":["f"],"y":["f"],"h":[],"k.E":"f"},"bB":{"c7":[],"k":["a"],"j":["a"],"z":["a"],"c":["a"],"m":[],"b":["a"],"y":["a"],"h":[],"k.E":"a"},"bC":{"c8":[],"k":["a"],"j":["a"],"z":["a"],"c":["a"],"m":[],"b":["a"],"y":["a"],"h":[],"k.E":"a"},"bD":{"c9":[],"k":["a"],"j":["a"],"z":["a"],"c":["a"],"m":[],"b":["a"],"y":["a"],"h":[],"k.E":"a"},"bE":{"cj":[],"k":["a"],"j":["a"],"z":["a"],"c":["a"],"m":[],"b":["a"],"y":["a"],"h":[],"k.E":"a"},"bF":{"ck":[],"k":["a"],"j":["a"],"z":["a"],"c":["a"],"m":[],"b":["a"],"y":["a"],"h":[],"k.E":"a"},"aR":{"cl":[],"k":["a"],"j":["a"],"z":["a"],"c":["a"],"m":[],"b":["a"],"y":["a"],"h":[],"k.E":"a"},"bG":{"cm":[],"k":["a"],"j":["a"],"z":["a"],"c":["a"],"m":[],"b":["a"],"y":["a"],"h":[],"k.E":"a"},"bW":{"l":[]},"b9":{"Q":[],"l":[]},"C":{"l":[]},"aY":{"bV":["1"]},"q":{"J":["1"]},"be":{"e8":[]},"bY":{"be":[],"e8":[]},"b_":{"e":["1","2"],"O":["1","2"]},"al":{"b_":["1","2"],"e":["1","2"],"O":["1","2"],"e.K":"1","e.V":"2"},"b0":{"c":["1"],"b":["1"],"b.E":"1"},"b1":{"D":["1"]},"e":{"O":["1","2"]},"f":{"ad":[]},"a":{"ad":[]},"j":{"c":["1"],"b":["1"]},"bj":{"l":[]},"Q":{"l":[]},"N":{"l":[]},"aT":{"l":[]},"bq":{"l":[]},"aX":{"l":[]},"bP":{"l":[]},"bL":{"l":[]},"bn":{"l":[]},"aV":{"l":[]},"c_":{"V":[]},"c9":{"j":["a"],"c":["a"],"b":["a"]},"cm":{"j":["a"],"c":["a"],"b":["a"]},"cl":{"j":["a"],"c":["a"],"b":["a"]},"c7":{"j":["a"],"c":["a"],"b":["a"]},"cj":{"j":["a"],"c":["a"],"b":["a"]},"c8":{"j":["a"],"c":["a"],"b":["a"]},"ck":{"j":["a"],"c":["a"],"b":["a"]},"c5":{"j":["f"],"c":["f"],"b":["f"]},"c6":{"j":["f"],"c":["f"],"b":["f"]}}'))
-A.fM(v.typeUniverse,JSON.parse('{"ah":1}'))
+q(A.d,[A.dM,J.bI,A.b4,J.aI,A.b,A.aJ,A.k,A.X,A.l,A.f,A.cD,A.R,A.aY,A.A,A.b7,A.V,A.aL,A.bf,A.cE,A.cC,A.aO,A.bm,A.cy,A.aW,A.aV,A.J,A.cg,A.db,A.bo,A.cc,A.bn,A.H,A.ce,A.a8,A.v,A.cd,A.ci,A.bu,A.bd,A.bE,A.bG,A.bZ,A.b5,A.cV,A.p,A.q,A.cj,A.c5,A.cB,A.ca])
+q(J.bI,[J.bK,J.aQ,J.aS,J.aR,J.aT,J.bM,J.an])
+q(J.aS,[J.Y,J.x,A.ao,A.b0])
+q(J.Y,[J.c_,J.b6,J.N])
+r(J.bJ,A.b4)
+r(J.cx,J.x)
+q(J.bM,[J.aP,J.bL])
+q(A.b,[A.ar,A.c,A.a7,A.be,A.aw])
+r(A.a3,A.ar)
+r(A.ba,A.a3)
+q(A.k,[A.a4,A.a6,A.bb])
+q(A.X,[A.bC,A.cp,A.bB,A.c6,A.dx,A.dz,A.cS,A.cR,A.di,A.d3,A.d8,A.cz,A.dB,A.dE,A.dF,A.ds,A.dw,A.cQ,A.cO,A.cN,A.cP])
+q(A.bC,[A.cq,A.dy,A.dj,A.dq,A.d4,A.cA])
+q(A.l,[A.bP,A.T,A.bO,A.c9,A.c2,A.cf,A.bz,A.Q,A.b8,A.c8,A.c3,A.bD])
+r(A.aq,A.f)
+r(A.aK,A.aq)
+q(A.c,[A.O,A.aX,A.aU,A.bc])
+r(A.aN,A.a7)
+r(A.S,A.O)
+q(A.V,[A.au,A.av])
+r(A.bk,A.au)
+r(A.bl,A.av)
+r(A.aM,A.aL)
+r(A.b2,A.T)
+q(A.c6,[A.c4,A.al])
+q(A.b0,[A.bQ,A.ap])
+q(A.ap,[A.bg,A.bi])
+r(A.bh,A.bg)
+r(A.aZ,A.bh)
+r(A.bj,A.bi)
+r(A.b_,A.bj)
+q(A.aZ,[A.bR,A.bS])
+q(A.b_,[A.bT,A.bU,A.bV,A.bW,A.bX,A.b1,A.bY])
+r(A.bp,A.cf)
+q(A.bB,[A.cT,A.cU,A.da,A.d9,A.cW,A.d_,A.cZ,A.cY,A.cX,A.d2,A.d1,A.d0,A.dn,A.d7])
+r(A.b9,A.ce)
+r(A.ch,A.bu)
+r(A.at,A.bb)
+q(A.Q,[A.b3,A.bH])
+s(A.aq,A.b7)
+s(A.bg,A.f)
+s(A.bh,A.A)
+s(A.bi,A.f)
+s(A.bj,A.A)})()
+var v={G:typeof self!="undefined"?self:globalThis,typeUniverse:{eC:new Map(),tR:{},eT:{},tPV:{},sEA:[]},mangledGlobalNames:{a:"int",h:"double",ai:"num",u:"String",ad:"bool",q:"Null",i:"List",d:"Object",D:"Map",o:"JSObject"},mangledNames:{},types:["~()","q()","~(@)","d?(d?)","~(d?)","~(~())","q(@)","@(@)","@(@,u)","@(u)","q(~())","q(@,Z)","~(a,@)","q(d,Z)","~(d?,d?)","~(c7)","q(o)","q(d?)","M<ad>(u,D<u,@>?)","~(u,d?,N)"],interceptorsByTag:null,leafTags:null,arrayRti:Symbol("$ti"),rttc:{"2;":(a,b)=>c=>c instanceof A.bk&&a.b(c.a)&&b.b(c.b),"3;inputData,requestId,taskName":(a,b,c)=>d=>d instanceof A.bl&&a.b(d.a)&&b.b(d.b)&&c.b(d.c)}}
+A.hi(v.typeUniverse,JSON.parse('{"N":"Y","c_":"Y","b6":"Y","iy":"ao","bK":{"ad":[],"j":[]},"aQ":{"q":[],"j":[]},"aS":{"o":[]},"Y":{"o":[]},"x":{"i":["1"],"c":["1"],"o":[],"b":["1"]},"bJ":{"b4":[]},"cx":{"x":["1"],"i":["1"],"c":["1"],"o":[],"b":["1"]},"aI":{"z":["1"]},"bM":{"h":[],"ai":[]},"aP":{"h":[],"a":[],"ai":[],"j":[]},"bL":{"h":[],"ai":[],"j":[]},"an":{"u":[],"j":[]},"ar":{"b":["2"]},"aJ":{"z":["2"]},"a3":{"ar":["1","2"],"b":["2"],"b.E":"2"},"ba":{"a3":["1","2"],"ar":["1","2"],"c":["2"],"b":["2"],"b.E":"2"},"a4":{"k":["3","4"],"D":["3","4"],"k.K":"3","k.V":"4"},"bP":{"l":[]},"aK":{"f":["a"],"b7":["a"],"i":["a"],"c":["a"],"b":["a"],"f.E":"a"},"c":{"b":["1"]},"O":{"c":["1"],"b":["1"]},"R":{"z":["1"]},"a7":{"b":["2"],"b.E":"2"},"aN":{"a7":["1","2"],"c":["2"],"b":["2"],"b.E":"2"},"aY":{"z":["2"]},"S":{"O":["2"],"c":["2"],"b":["2"],"b.E":"2","O.E":"2"},"aq":{"f":["1"],"b7":["1"],"i":["1"],"c":["1"],"b":["1"]},"bk":{"au":[],"V":[]},"bl":{"av":[],"V":[]},"aL":{"D":["1","2"]},"aM":{"aL":["1","2"],"D":["1","2"]},"be":{"b":["1"],"b.E":"1"},"bf":{"z":["1"]},"b2":{"T":[],"l":[]},"bO":{"l":[]},"c9":{"l":[]},"bm":{"Z":[]},"X":{"a5":[]},"bB":{"a5":[]},"bC":{"a5":[]},"c6":{"a5":[]},"c4":{"a5":[]},"al":{"a5":[]},"c2":{"l":[]},"a6":{"k":["1","2"],"eq":["1","2"],"D":["1","2"],"k.K":"1","k.V":"2"},"aX":{"c":["1"],"b":["1"],"b.E":"1"},"aW":{"z":["1"]},"aU":{"c":["p<1,2>"],"b":["p<1,2>"],"b.E":"p<1,2>"},"aV":{"z":["p<1,2>"]},"au":{"V":[]},"av":{"V":[]},"ao":{"o":[],"dK":[],"j":[]},"b0":{"o":[]},"bQ":{"dL":[],"o":[],"j":[]},"ap":{"B":["1"],"o":[]},"aZ":{"f":["h"],"i":["h"],"B":["h"],"c":["h"],"o":[],"b":["h"],"A":["h"]},"b_":{"f":["a"],"i":["a"],"B":["a"],"c":["a"],"o":[],"b":["a"],"A":["a"]},"bR":{"cs":[],"f":["h"],"i":["h"],"B":["h"],"c":["h"],"o":[],"b":["h"],"A":["h"],"j":[],"f.E":"h"},"bS":{"ct":[],"f":["h"],"i":["h"],"B":["h"],"c":["h"],"o":[],"b":["h"],"A":["h"],"j":[],"f.E":"h"},"bT":{"cu":[],"f":["a"],"i":["a"],"B":["a"],"c":["a"],"o":[],"b":["a"],"A":["a"],"j":[],"f.E":"a"},"bU":{"cv":[],"f":["a"],"i":["a"],"B":["a"],"c":["a"],"o":[],"b":["a"],"A":["a"],"j":[],"f.E":"a"},"bV":{"cw":[],"f":["a"],"i":["a"],"B":["a"],"c":["a"],"o":[],"b":["a"],"A":["a"],"j":[],"f.E":"a"},"bW":{"cG":[],"f":["a"],"i":["a"],"B":["a"],"c":["a"],"o":[],"b":["a"],"A":["a"],"j":[],"f.E":"a"},"bX":{"cH":[],"f":["a"],"i":["a"],"B":["a"],"c":["a"],"o":[],"b":["a"],"A":["a"],"j":[],"f.E":"a"},"b1":{"cI":[],"f":["a"],"i":["a"],"B":["a"],"c":["a"],"o":[],"b":["a"],"A":["a"],"j":[],"f.E":"a"},"bY":{"cJ":[],"f":["a"],"i":["a"],"B":["a"],"c":["a"],"o":[],"b":["a"],"A":["a"],"j":[],"f.E":"a"},"cf":{"l":[]},"bp":{"T":[],"l":[]},"bo":{"c7":[]},"bn":{"z":["1"]},"aw":{"b":["1"],"b.E":"1"},"H":{"l":[]},"b9":{"ce":["1"]},"v":{"M":["1"]},"bu":{"eC":[]},"ch":{"bu":[],"eC":[]},"bb":{"k":["1","2"],"D":["1","2"]},"at":{"bb":["1","2"],"k":["1","2"],"D":["1","2"],"k.K":"1","k.V":"2"},"bc":{"c":["1"],"b":["1"],"b.E":"1"},"bd":{"z":["1"]},"f":{"i":["1"],"c":["1"],"b":["1"]},"k":{"D":["1","2"]},"h":{"ai":[]},"a":{"ai":[]},"i":{"c":["1"],"b":["1"]},"bz":{"l":[]},"T":{"l":[]},"Q":{"l":[]},"b3":{"l":[]},"bH":{"l":[]},"b8":{"l":[]},"c8":{"l":[]},"c3":{"l":[]},"bD":{"l":[]},"bZ":{"l":[]},"b5":{"l":[]},"cj":{"Z":[]},"cw":{"i":["a"],"c":["a"],"b":["a"]},"cJ":{"i":["a"],"c":["a"],"b":["a"]},"cI":{"i":["a"],"c":["a"],"b":["a"]},"cu":{"i":["a"],"c":["a"],"b":["a"]},"cG":{"i":["a"],"c":["a"],"b":["a"]},"cv":{"i":["a"],"c":["a"],"b":["a"]},"cH":{"i":["a"],"c":["a"],"b":["a"]},"cs":{"i":["h"],"c":["h"],"b":["h"]},"ct":{"i":["h"],"c":["h"],"b":["h"]}}'))
+A.hh(v.typeUniverse,JSON.parse('{"aq":1,"ap":1}'))
 var u={c:"Error handler must accept one Object or one Object and a StackTrace as arguments, and return a value of the returned future's type"}
-var t=(function rtii(){var s=A.dB
-return{n:s("C"),J:s("dc"),Y:s("dd"),O:s("c<@>"),C:s("l"),B:s("c5"),q:s("c6"),Z:s("a1"),d:s("J<a9>(v,O<v,@>?)"),W:s("c7"),k:s("c8"),U:s("c9"),R:s("b<@>"),f:s("t<d>"),s:s("t<v>"),b:s("t<@>"),T:s("aE"),m:s("m"),g:s("K"),p:s("z<@>"),j:s("j<@>"),P:s("w"),K:s("d"),L:s("i0"),e:s("+()"),r:s("+(d?,v?)"),l:s("V"),N:s("v"),t:s("h"),c:s("Q"),D:s("cj"),w:s("ck"),x:s("cl"),E:s("cm"),G:s("aW"),_:s("q<@>"),A:s("al<d?,d?>"),y:s("a9"),V:s("a9(d)"),i:s("f"),z:s("@"),a:s("@()"),v:s("@(d)"),Q:s("@(d,V)"),S:s("a"),bc:s("J<w>?"),aQ:s("m?"),h:s("O<v,@>?"),X:s("d?"),aD:s("v?"),F:s("a5<@,@>?"),u:s("a9?"),I:s("f?"),a3:s("a?"),ae:s("ad?"),o:s("ad"),H:s("~"),M:s("~()")}})();(function constants(){B.q=J.br.prototype
-B.a=J.t.prototype
-B.e=J.aD.prototype
-B.r=J.K.prototype
-B.t=J.aH.prototype
-B.j=J.bH.prototype
-B.f=J.aW.prototype
+var t=(function rtii(){var s=A.dv
+return{n:s("H"),J:s("dK"),Y:s("dL"),V:s("aK"),O:s("c<@>"),C:s("l"),B:s("cs"),q:s("ct"),Z:s("a5"),e:s("M<ad>(u,D<u,@>?)"),W:s("cu"),k:s("cv"),D:s("cw"),R:s("b<@>"),G:s("x<d>"),s:s("x<u>"),b:s("x<@>"),T:s("aQ"),m:s("o"),g:s("N"),E:s("B<@>"),j:s("i<@>"),f:s("D<@,@>"),P:s("q"),K:s("d"),L:s("iz"),r:s("+()"),t:s("+(d?,u?)"),l:s("Z"),N:s("u"),p:s("c7"),w:s("j"),c:s("T"),a:s("cG"),x:s("cH"),ca:s("cI"),bX:s("cJ"),cr:s("b6"),_:s("v<@>"),A:s("at<d?,d?>"),y:s("ad"),bG:s("ad(d)"),i:s("h"),z:s("@"),bd:s("@()"),v:s("@(d)"),Q:s("@(d,Z)"),S:s("a"),bc:s("M<q>?"),aQ:s("o?"),h:s("D<u,@>?"),X:s("d?"),aD:s("u?"),F:s("a8<@,@>?"),u:s("ad?"),I:s("h?"),a3:s("a?"),ae:s("ai?"),U:s("~(d?)?"),o:s("ai"),H:s("~"),M:s("~()"),d:s("~(c7)")}})();(function constants(){B.t=J.bI.prototype
+B.a=J.x.prototype
+B.c=J.aP.prototype
+B.u=J.an.prototype
+B.v=J.N.prototype
+B.w=J.aS.prototype
+B.j=J.c_.prototype
+B.f=J.b6.prototype
 B.h=function getTagFallback(o) {
   var s = Object.prototype.toString.call(o);
   return s.substring(8, s.length - 1);
@@ -2992,57 +3323,62 @@ B.m=function(hooks) {
 }
 B.i=function(hooks) { return hooks; }
 
-B.c=new A.cg()
-B.b=new A.bY()
-B.d=new A.c_()
-B.u=A.I("dc")
-B.v=A.I("dd")
-B.w=A.I("c5")
-B.x=A.I("c6")
-B.y=A.I("c7")
-B.z=A.I("c8")
-B.A=A.I("c9")
-B.B=A.I("d")
-B.C=A.I("cj")
-B.D=A.I("ck")
-B.E=A.I("cl")
-B.F=A.I("cm")})();(function staticFields(){$.cF=null
-$.B=A.H([],t.f)
-$.dZ=null
-$.dS=null
-$.dR=null
-$.eF=null
-$.eA=null
-$.eH=null
-$.cZ=null
-$.d2=null
-$.dF=null
-$.cG=A.H([],A.dB("t<j<d>?>"))
-$.aq=null
-$.bg=null
-$.bh=null
-$.dv=!1
-$.o=B.b
-$.e7=!1})();(function lazyInitializers(){var s=hunkHelpers.lazyFinal
-s($,"hZ","dM",()=>A.hI("_$dart_dartClosure"))
-s($,"ig","eT",()=>A.H([new J.bs()],A.dB("t<aU>")))
-s($,"i2","eJ",()=>A.R(A.ci({
+B.q=new A.bZ()
+B.d=new A.cD()
+B.b=new A.ch()
+B.e=new A.cj()
+B.r=new A.bG(3e6)
+B.y={btc:0,eth:1,ada:2}
+B.x=new A.aM(B.y,[6e4,2500,0.6],A.dv("aM<u,h>"))
+B.z=A.L("dK")
+B.A=A.L("dL")
+B.B=A.L("cs")
+B.C=A.L("ct")
+B.D=A.L("cu")
+B.E=A.L("cv")
+B.F=A.L("cw")
+B.G=A.L("d")
+B.H=A.L("cG")
+B.I=A.L("cH")
+B.J=A.L("cI")
+B.K=A.L("cJ")})();(function staticFields(){$.d5=null
+$.G=A.K([],t.G)
+$.es=null
+$.ek=null
+$.ej=null
+$.f7=null
+$.f3=null
+$.fa=null
+$.du=null
+$.dA=null
+$.e9=null
+$.d6=A.K([],A.dv("x<i<d>?>"))
+$.aA=null
+$.bv=null
+$.bw=null
+$.e1=!1
+$.n=B.b
+$.bx=null
+$.eB=!1})();(function lazyInitializers(){var s=hunkHelpers.lazyFinal
+s($,"ix","ee",()=>A.ie("_$dart_dartClosure"))
+s($,"iO","fn",()=>A.K([new J.bJ()],A.dv("x<b4>")))
+s($,"iB","fd",()=>A.U(A.cF({
 toString:function(){return"$receiver$"}})))
-s($,"i3","eK",()=>A.R(A.ci({$method$:null,
+s($,"iC","fe",()=>A.U(A.cF({$method$:null,
 toString:function(){return"$receiver$"}})))
-s($,"i4","eL",()=>A.R(A.ci(null)))
-s($,"i5","eM",()=>A.R(function(){var $argumentsExpr$="$arguments$"
+s($,"iD","ff",()=>A.U(A.cF(null)))
+s($,"iE","fg",()=>A.U(function(){var $argumentsExpr$="$arguments$"
 try{null.$method$($argumentsExpr$)}catch(r){return r.message}}()))
-s($,"i8","eP",()=>A.R(A.ci(void 0)))
-s($,"i9","eQ",()=>A.R(function(){var $argumentsExpr$="$arguments$"
+s($,"iH","fj",()=>A.U(A.cF(void 0)))
+s($,"iI","fk",()=>A.U(function(){var $argumentsExpr$="$arguments$"
 try{(void 0).$method$($argumentsExpr$)}catch(r){return r.message}}()))
-s($,"i7","eO",()=>A.R(A.e5(null)))
-s($,"i6","eN",()=>A.R(function(){try{null.$method$}catch(r){return r.message}}()))
-s($,"ib","eS",()=>A.R(A.e5(void 0)))
-s($,"ia","eR",()=>A.R(function(){try{(void 0).$method$}catch(r){return r.message}}()))
-s($,"id","dN",()=>A.fw())
-s($,"ie","d9",()=>A.d5(B.B))
-s($,"ic","d8",()=>new A.bR())})();(function nativeSupport(){!function(){var s=function(a){var m={}
+s($,"iG","fi",()=>A.U(A.ez(null)))
+s($,"iF","fh",()=>A.U(function(){try{null.$method$}catch(r){return r.message}}()))
+s($,"iK","fm",()=>A.U(A.ez(void 0)))
+s($,"iJ","fl",()=>A.U(function(){try{(void 0).$method$}catch(r){return r.message}}()))
+s($,"iM","ef",()=>A.h0())
+s($,"iN","dG",()=>A.dD(B.G))
+s($,"iL","aG",()=>new A.ca())})();(function nativeSupport(){!function(){var s=function(a){var m={}
 m[a]=1
 return Object.keys(hunkHelpers.convertToFastObject(m))[0]}
 v.getIsolateTag=function(a){return s("___dart_"+a+v.isolateTag)}
@@ -3053,15 +3389,15 @@ for(var o=0;;o++){var n=s(p+"_"+o+"_")
 if(!(n in q)){q[n]=1
 v.isolateTag=n
 break}}v.dispatchPropertyName=v.getIsolateTag("dispatch_record")}()
-hunkHelpers.setOrUpdateInterceptorsByTag({ArrayBuffer:A.ag,SharedArrayBuffer:A.ag,ArrayBufferView:A.aQ,DataView:A.by,Float32Array:A.bz,Float64Array:A.bA,Int16Array:A.bB,Int32Array:A.bC,Int8Array:A.bD,Uint16Array:A.bE,Uint32Array:A.bF,Uint8ClampedArray:A.aR,CanvasPixelArray:A.aR,Uint8Array:A.bG})
+hunkHelpers.setOrUpdateInterceptorsByTag({ArrayBuffer:A.ao,SharedArrayBuffer:A.ao,ArrayBufferView:A.b0,DataView:A.bQ,Float32Array:A.bR,Float64Array:A.bS,Int16Array:A.bT,Int32Array:A.bU,Int8Array:A.bV,Uint16Array:A.bW,Uint32Array:A.bX,Uint8ClampedArray:A.b1,CanvasPixelArray:A.b1,Uint8Array:A.bY})
 hunkHelpers.setOrUpdateLeafTags({ArrayBuffer:true,SharedArrayBuffer:true,ArrayBufferView:false,DataView:true,Float32Array:true,Float64Array:true,Int16Array:true,Int32Array:true,Int8Array:true,Uint16Array:true,Uint32Array:true,Uint8ClampedArray:true,CanvasPixelArray:true,Uint8Array:false})
-A.ah.$nativeSuperclassTag="ArrayBufferView"
-A.b2.$nativeSuperclassTag="ArrayBufferView"
-A.b3.$nativeSuperclassTag="ArrayBufferView"
-A.aO.$nativeSuperclassTag="ArrayBufferView"
-A.b4.$nativeSuperclassTag="ArrayBufferView"
-A.b5.$nativeSuperclassTag="ArrayBufferView"
-A.aP.$nativeSuperclassTag="ArrayBufferView"})()
+A.ap.$nativeSuperclassTag="ArrayBufferView"
+A.bg.$nativeSuperclassTag="ArrayBufferView"
+A.bh.$nativeSuperclassTag="ArrayBufferView"
+A.aZ.$nativeSuperclassTag="ArrayBufferView"
+A.bi.$nativeSuperclassTag="ArrayBufferView"
+A.bj.$nativeSuperclassTag="ArrayBufferView"
+A.b_.$nativeSuperclassTag="ArrayBufferView"})()
 Function.prototype.$1=function(a){return this(a)}
 Function.prototype.$2=function(a,b){return this(a,b)}
 Function.prototype.$0=function(){return this()}
@@ -3074,5 +3410,5 @@ convertToFastObject($);(function(a){if(typeof document==="undefined"){a(null)
 return}if(typeof document.currentScript!="undefined"){a(document.currentScript)
 return}var s=document.scripts
 function onLoad(b){for(var q=0;q<s.length;++q){s[q].removeEventListener("load",onLoad,false)}a(b.target)}for(var r=0;r<s.length;++r){s[r].addEventListener("load",onLoad,false)}})(function(a){v.currentScript=a
-var s=A.hS
+var s=A.ir
 if(typeof dartMainRunner==="function"){dartMainRunner(s,[])}else{s([])}})})()

--- a/example/web/background.dart.js
+++ b/example/web/background.dart.js
@@ -1776,14 +1776,14 @@ s.a=t.e.a(A.i7())
 s.saM(A.i8())},
 ij(a){var s,r,q,p,o,n=null,m="threshold"
 if(!t.f.b(a))return
-switch(a.j(0,"op")){case"watch":s=A.cl(a.j(0,"ticker"))
+switch(a.j(0,"op")){case"watch":s=A.cl(a.j(0,"city"))
 r=s==null?n:s.toLowerCase()
-if(r==null)r="btc"
+if(r==null)r="cardiff"
 q=A.ck(a.j(0,m))
 if(q==null)q=n
 s=$.bx
 if(s!=null)s.Y()
-A.ab(A.C(["kind","watching","ticker",r,"threshold",q],t.N,t.X))
+A.ab(A.C(["kind","watching","city",r,"threshold",q],t.N,t.X))
 A.eZ(r,q)
 $.bx=A.fT(B.r,new A.dw(r,q))
 break
@@ -1792,28 +1792,28 @@ if(s!=null)s.Y()
 $.bx=null
 A.ab(A.C(["kind","stopped"],t.N,t.X))
 break
-case"check":s=A.cl(a.j(0,"ticker"))
+case"check":s=A.cl(a.j(0,"city"))
 r=s==null?n:s.toLowerCase()
-if(r==null)r="btc"
+if(r==null)r="cardiff"
 q=A.ck(a.j(0,m))
 if(q==null)q=n
 s=t.N
 p=t.X
-A.ab(A.C(["kind","task-start","ticker",r],s,p))
+A.ab(A.C(["kind","task-start","city",r],s,p))
 o=A.e3(r)
-A.ab(A.C(["kind","task-done","ticker",r,"price",o,"below",q!=null&&o<q],s,p))
+A.ab(A.C(["kind","task-done","city",r,"tempC",o,"below",q!=null&&o<q],s,p))
 break
 case"text":A.ab(A.C(["kind","echo","text",a.j(0,"text")],t.N,t.X))
 break}},
 eZ(a,b){var s,r=A.e3(a),q=b!=null&&r<b
-A.ab(A.C(["kind",q?"alert":"tick","ticker",a,"price",r,"threshold",b],t.N,t.X))
+A.ab(A.C(["kind",q?"alert":"tick","city",a,"tempC",r,"threshold",b],t.N,t.X))
 if(q){s=$.bx
 if(s!=null)s.Y()
 $.bx=null}},
 ab(a){var s=$.aG().c
 if(s!=null)s.$1(a)},
 e3(a){var s=B.x.j(0,a)
-if(s==null)s=100
+if(s==null)s=15
 return s*(1+(B.c.al(A.hB(a+":"+B.c.X(Date.now(),3e4)),1000)/1000*0.1-0.05))},
 hB(a){var s,r,q,p
 for(s=new A.aK(a),r=t.V,s=new A.R(s,s.gl(0),r.h("R<f.E>")),r=r.h("f.E"),q=0;s.m();){p=s.d
@@ -1825,17 +1825,17 @@ var $async$e8=A.dp(function(c,d){if(c===1)return A.df(d,r)
 for(;;)switch(s){case 0:j=b==null
 if(!j&&J.P(b.j(0,"fail"),!0)){q=!1
 s=1
-break}p=A.cl(j?null:b.j(0,"ticker"))
+break}p=A.cl(j?null:b.j(0,"city"))
 o=p==null?null:p.toLowerCase()
-if(o==null)o="btc"
+if(o==null)o="cardiff"
 n=A.ck(j?null:b.j(0,"threshold"))
 if(n==null)n=null
 for(m=0,l=0;l<2e6;++l)m+=l
 j=t.N
 p=t.X
-A.ab(A.C(["kind","task-start","ticker",o,"threshold",n],j,p))
+A.ab(A.C(["kind","task-start","city",o,"threshold",n],j,p))
 k=A.e3(o)
-A.ab(A.C(["kind","task-done","ticker",o,"price",k,"below",n!=null&&k<n],j,p))
+A.ab(A.C(["kind","task-done","city",o,"tempC",k,"below",n!=null&&k<n],j,p))
 q=!0
 s=1
 break
@@ -3328,8 +3328,8 @@ B.d=new A.cD()
 B.b=new A.ch()
 B.e=new A.cj()
 B.r=new A.bG(3e6)
-B.y={btc:0,eth:1,ada:2}
-B.x=new A.aM(B.y,[6e4,2500,0.6],A.dv("aM<u,h>"))
+B.y={cardiff:0,taipei:1}
+B.x=new A.aM(B.y,[11,26],A.dv("aM<u,h>"))
 B.z=A.L("dK")
 B.A=A.L("dL")
 B.B=A.L("cs")

--- a/example/web/background.dart.js
+++ b/example/web/background.dart.js
@@ -54,7 +54,7 @@ function initializeDeferredHunk(a){x=v.types.length
 a(hunkHelpers,v,w,$)}var J={
 ee(a,b,c,d){return{i:a,p:b,e:c,x:d}},
 ea(a){var s,r,q,p,o,n=a[v.dispatchPropertyName]
-if(n==null)if($.ec==null){A.iq()
+if(n==null)if($.ec==null){A.ip()
 n=a[v.dispatchPropertyName]}if(n!=null){s=n.p
 if(!1===s)return n.i
 if(!0===s)return a
@@ -65,7 +65,7 @@ if(q==null)p=null
 else{o=$.d6
 if(o==null)o=$.d6=v.getIsolateTag("_$dart_js")
 p=q[o]}if(p!=null)return p
-p=A.iu(a)
+p=A.it(a)
 if(p!=null)return p
 if(typeof a=="function")return B.w
 s=Object.getPrototypeOf(a)
@@ -100,7 +100,7 @@ if(typeof a=="symbol")return J.aW.prototype
 if(typeof a=="bigint")return J.aU.prototype
 return a}if(a instanceof A.c)return a
 return J.ea(a)},
-dx(a){if(a==null)return a
+dw(a){if(a==null)return a
 if(Array.isArray(a))return J.x.prototype
 if(typeof a!="object"){if(typeof a=="function")return J.N.prototype
 if(typeof a=="symbol")return J.aW.prototype
@@ -110,12 +110,12 @@ return J.ea(a)},
 P(a,b){if(a==null)return b==null
 if(typeof a!="object")return b!=null&&a===b
 return J.ag(a).C(a,b)},
-fq(a,b){return J.dx(a).L(a,b)},
+fq(a,b){return J.dw(a).L(a,b)},
 X(a){return J.ag(a).gq(a)},
-dJ(a){return J.dx(a).gp(a)},
+dJ(a){return J.dw(a).gp(a)},
 dK(a){return J.e9(a).gl(a)},
 fr(a){return J.ag(a).gt(a)},
-ek(a,b,c){return J.dx(a).M(a,b,c)},
+ek(a,b,c){return J.dw(a).M(a,b,c)},
 aI(a){return J.ag(a).i(a)},
 bL:function bL(){},
 bN:function bN(){},
@@ -148,7 +148,7 @@ return a^a>>>6},
 dW(a){a=a+((a&67108863)<<3)&536870911
 a^=a>>>11
 return a+((a&16383)<<15)&536870911},
-ds(a,b,c){return a},
+dr(a,b,c){return a},
 ed(a){var s,r
 for(s=$.G.length,r=0;r<s;++r)if(a===$.G[r])return!0
 return!1},
@@ -246,8 +246,8 @@ A.w(a,s)
 a.$thrownJsError=s
 s.stack=b.i(0)}},
 y(a,b){if(a==null)J.dK(a)
-throw A.e(A.du(a,b))},
-du(a,b){var s,r="index"
+throw A.e(A.dt(a,b))},
+dt(a,b){var s,r="index"
 if(!A.e4(b))return new A.Q(!0,b,r,null)
 s=J.dK(a)
 if(b<0||b>=s)return A.fD(b,s,a,r)
@@ -283,7 +283,7 @@ l="an "}else k=(m&1)!==0?"fixed-length ":""
 return new A.bb("'"+s+"': Cannot "+o+" "+l+k+n)},
 fd(a){throw A.e(A.an(a))},
 U(a){var s,r,q,p,o,n
-a=A.ix(a.replace(String({}),"$receiver$"))
+a=A.iw(a.replace(String({}),"$receiver$"))
 s=a.match(/\\\$[a-zA-Z]+\\\$/g)
 if(s==null)s=A.K([],t.s)
 r=s.indexOf("\\$arguments\\$")
@@ -302,10 +302,10 @@ if(a==null)return new A.cD(a)
 if(a instanceof A.aP){s=a.a
 return A.a3(a,s==null?A.aa(s):s)}if(typeof a!=="object")return a
 if("dartException" in a)return A.a3(a,a.dartException)
-return A.i7(a)},
+return A.i6(a)},
 a3(a,b){if(t.C.b(b))if(b.$thrownJsError==null)b.$thrownJsError=a
 return b},
-i7(a){var s,r,q,p,o,n,m,l,k,j,i,h,g
+i6(a){var s,r,q,p,o,n,m,l,k,j,i,h,g
 if(!("message" in a))return a
 s=a.message
 if("number" in a&&typeof a.number=="number"){r=a.number
@@ -339,10 +339,10 @@ if(s!=null)return s
 s=new A.bp(a)
 if(typeof a==="object")a.$cachedTrace=s
 return s},
-dF(a){if(a==null)return J.X(a)
+dE(a){if(a==null)return J.X(a)
 if(typeof a=="object")return A.c1(a)
 return J.X(a)},
-ii(a,b){var s,r,q,p=a.length
+ih(a,b){var s,r,q,p=a.length
 for(s=0;s<p;s=q){r=s+1
 q=r+1
 b.v(0,a[s],a[r])}return b},
@@ -354,10 +354,10 @@ case 3:return a.$3(c,d,e)
 case 4:return a.$4(c,d,e,f)}throw A.e(new A.cW("Unsupported number of arguments for wrapped closure"))},
 aD(a,b){var s=a.$identity
 if(!!s)return s
-s=A.ie(a,b)
+s=A.id(a,b)
 a.$identity=s
 return s},
-ie(a,b){var s
+id(a,b){var s
 switch(b){case 0:s=a.$0
 break
 case 1:s=a.$1
@@ -433,53 +433,53 @@ o.$flags=1
 s=o
 for(o=s.length,r=0;r<o;++r){q=s[r]
 if(p[q]===a)return q}throw A.e(A.al("Field name "+a+" not found.",null))},
-ij(a){return v.getIsolateTag(a)},
-iu(a){var s,r,q,p,o,n=A.az($.fa.$1(a)),m=$.dv[n]
+ii(a){return v.getIsolateTag(a)},
+it(a){var s,r,q,p,o,n=A.az($.fa.$1(a)),m=$.du[n]
 if(m!=null){Object.defineProperty(a,v.dispatchPropertyName,{value:m,enumerable:false,writable:true,configurable:true})
-return m.i}s=$.dC[n]
+return m.i}s=$.dB[n]
 if(s!=null)return s
 r=v.interceptorsByTag[n]
 if(r==null){q=A.cn($.f7.$2(a,n))
-if(q!=null){m=$.dv[q]
+if(q!=null){m=$.du[q]
 if(m!=null){Object.defineProperty(a,v.dispatchPropertyName,{value:m,enumerable:false,writable:true,configurable:true})
-return m.i}s=$.dC[q]
+return m.i}s=$.dB[q]
 if(s!=null)return s
 r=v.interceptorsByTag[q]
 n=q}}if(r==null)return null
 s=r.prototype
 p=n[0]
-if(p==="!"){m=A.dE(s)
-$.dv[n]=m
+if(p==="!"){m=A.dD(s)
+$.du[n]=m
 Object.defineProperty(a,v.dispatchPropertyName,{value:m,enumerable:false,writable:true,configurable:true})
-return m.i}if(p==="~"){$.dC[n]=s
-return s}if(p==="-"){o=A.dE(s)
+return m.i}if(p==="~"){$.dB[n]=s
+return s}if(p==="-"){o=A.dD(s)
 Object.defineProperty(Object.getPrototypeOf(a),v.dispatchPropertyName,{value:o,enumerable:false,writable:true,configurable:true})
 return o.i}if(p==="+")return A.fb(a,s)
 if(p==="*")throw A.e(A.eD(n))
-if(v.leafTags[n]===true){o=A.dE(s)
+if(v.leafTags[n]===true){o=A.dD(s)
 Object.defineProperty(Object.getPrototypeOf(a),v.dispatchPropertyName,{value:o,enumerable:false,writable:true,configurable:true})
 return o.i}else return A.fb(a,s)},
 fb(a,b){var s=Object.getPrototypeOf(a)
 Object.defineProperty(s,v.dispatchPropertyName,{value:J.ee(b,s,null,null),enumerable:false,writable:true,configurable:true})
 return b},
-dE(a){return J.ee(a,!1,null,!!a.$iC)},
-iw(a,b,c){var s=b.prototype
-if(v.leafTags[a]===true)return A.dE(s)
+dD(a){return J.ee(a,!1,null,!!a.$iC)},
+iv(a,b,c){var s=b.prototype
+if(v.leafTags[a]===true)return A.dD(s)
 else return J.ee(s,c,null,null)},
-iq(){if(!0===$.ec)return
+ip(){if(!0===$.ec)return
 $.ec=!0
-A.ir()},
-ir(){var s,r,q,p,o,n,m,l
-$.dv=Object.create(null)
-$.dC=Object.create(null)
-A.ip()
+A.iq()},
+iq(){var s,r,q,p,o,n,m,l
+$.du=Object.create(null)
+$.dB=Object.create(null)
+A.io()
 s=v.interceptorsByTag
 r=Object.getOwnPropertyNames(s)
 if(typeof window!="undefined"){window
 q=function(){}
 for(p=0;p<r.length;++p){o=r[p]
 n=$.fc.$1(o)
-if(n!=null){m=A.iw(o,s[o],n)
+if(n!=null){m=A.iv(o,s[o],n)
 if(m!=null){Object.defineProperty(n,v.dispatchPropertyName,{value:m,enumerable:false,writable:true,configurable:true})
 q.prototype=n}}}}for(p=0;p<r.length;++p){o=r[p]
 if(/^[A-Za-z_]/.test(o)){l=s[o]
@@ -488,7 +488,7 @@ s["~"+o]=l
 s["-"+o]=l
 s["+"+o]=l
 s["*"+o]=l}}},
-ip(){var s,r,q,p,o,n,m=B.l()
+io(){var s,r,q,p,o,n,m=B.l()
 m=A.aC(B.m,A.aC(B.n,A.aC(B.i,A.aC(B.i,A.aC(B.o,A.aC(B.p,A.aC(B.q(B.h),m)))))))
 if(typeof dartNativeDispatchHooksTransformer!="undefined"){s=dartNativeDispatchHooksTransformer
 if(typeof s=="function")s=[s]
@@ -496,16 +496,16 @@ if(Array.isArray(s))for(r=0;r<s.length;++r){q=s[r]
 if(typeof q=="function")m=q(m)||m}}p=m.getTag
 o=m.getUnknownTag
 n=m.prototypeForTag
-$.fa=new A.dz(p)
-$.f7=new A.dA(o)
-$.fc=new A.dB(n)},
+$.fa=new A.dy(p)
+$.f7=new A.dz(o)
+$.fc=new A.dA(n)},
 aC(a,b){return a(b)||b},
-ig(a,b){var s=b.length,r=v.rttc[""+s+";"+a]
+ie(a,b){var s=b.length,r=v.rttc[""+s+";"+a]
 if(r==null)return null
 if(s===0)return r
 if(s===r.length)return r.apply(null,b)
 return r(b)},
-ix(a){if(/[[\]{}()*+?.\\^$|]/.test(a))return a.replace(/[[\]{}()*+?.\\^$|]/g,"\\$&")
+iw(a){if(/[[\]{}()*+?.\\^$|]/.test(a))return a.replace(/[[\]{}()*+?.\\^$|]/g,"\\$&")
 return a},
 bn:function bn(a,b){this.a=a
 this.b=b},
@@ -574,13 +574,13 @@ _.b=b
 _.c=c
 _.d=null
 _.$ti=d},
+dy:function dy(a){this.a=a},
 dz:function dz(a){this.a=a},
 dA:function dA(a){this.a=a},
-dB:function dB(a){this.a=a},
 W:function W(){},
 av:function av(){},
 aw:function aw(){},
-ab(a,b,c){if(a>>>0!==a||a>=c)throw A.e(A.du(b,a))},
+ab(a,b,c){if(a>>>0!==a||a>=c)throw A.e(A.dt(b,a))},
 ap:function ap(){},
 b3:function b3(){},
 bR:function bR(){},
@@ -606,7 +606,7 @@ ez(a){var s=a.w
 if(s===6||s===7)return A.ez(a.x)
 return s===11||s===12},
 fU(a){return a.as},
-dw(a){return A.dd(v.typeUniverse,a,!1)},
+dv(a){return A.dd(v.typeUniverse,a,!1)},
 ad(a1,a2,a3,a4){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d,c,b,a,a0=a2.w
 switch(a0){case 5:case 1:case 2:case 3:case 4:return a2
 case 6:s=a2.x
@@ -635,7 +635,7 @@ return A.eR(a1,k,i)
 case 11:h=a2.x
 g=A.ad(a1,h,a3,a4)
 f=a2.y
-e=A.i4(a1,f,a3,a4)
+e=A.i3(a1,f,a3,a4)
 if(g===h&&e===f)return a2
 return A.eO(a1,g,e)
 case 12:d=a2.y
@@ -656,14 +656,14 @@ for(s=!1,r=0;r<o;++r){q=b[r]
 p=A.ad(a,q,c,d)
 if(p!==q)s=!0
 n[r]=p}return s?n:b},
-i5(a,b,c,d){var s,r,q,p,o,n,m=b.length,l=A.de(m)
+i4(a,b,c,d){var s,r,q,p,o,n,m=b.length,l=A.de(m)
 for(s=!1,r=0;r<m;r+=3){q=b[r]
 p=b[r+1]
 o=b[r+2]
 n=A.ad(a,o,c,d)
 if(n!==o)s=!0
 l.splice(r,3,q,p,n)}return s?l:b},
-i4(a,b,c,d){var s,r=b.a,q=A.aB(a,r,c,d),p=b.b,o=A.aB(a,p,c,d),n=b.c,m=A.i5(a,n,c,d)
+i3(a,b,c,d){var s,r=b.a,q=A.aB(a,r,c,d),p=b.b,o=A.aB(a,p,c,d),n=b.c,m=A.i4(a,n,c,d)
 if(q===r&&o===p&&m===n)return b
 s=new A.ci()
 s.a=q
@@ -673,9 +673,9 @@ return s},
 K(a,b){a[v.arrayRti]=b
 return a},
 f9(a){var s=a.$S
-if(s!=null){if(typeof s=="number")return A.il(s)
+if(s!=null){if(typeof s=="number")return A.ik(s)
 return a.$S()}return null},
-is(a,b){var s
+ir(a,b){var s
 if(A.ez(b))if(a instanceof A.Y){s=A.f9(a)
 if(s!=null)return s}return A.aE(a)},
 aE(a){if(a instanceof A.c)return A.t(a)
@@ -693,13 +693,13 @@ return A.hI(a,s)},
 hI(a,b){var s=a instanceof A.Y?Object.getPrototypeOf(Object.getPrototypeOf(a)).constructor:b,r=A.hm(v.typeUniverse,s.name)
 b.$ccache=r
 return r},
-il(a){var s,r=v.types,q=r[a]
+ik(a){var s,r=v.types,q=r[a]
 if(typeof q=="string"){s=A.dd(v.typeUniverse,q,!1)
 r[a]=s
 return s}return q},
-ik(a){return A.af(A.t(a))},
+ij(a){return A.af(A.t(a))},
 e6(a){var s
-if(a instanceof A.W)return A.ih(a.$r,a.U())
+if(a instanceof A.W)return A.ig(a.$r,a.U())
 s=a instanceof A.Y?A.f9(a):null
 if(s!=null)return s
 if(t.w.b(a))return J.fr(a).a
@@ -707,7 +707,7 @@ if(Array.isArray(a))return A.ay(a)
 return A.aE(a)},
 af(a){var s=a.r
 return s==null?a.r=new A.dc(a):s},
-ih(a,b){var s,r,q=b,p=q.length
+ig(a,b){var s,r,q=b,p=q.length
 if(p===0)return t.r
 if(0>=p)return A.y(q,0)
 s=A.bw(v.typeUniverse,A.e6(q[0]),"@<0>")
@@ -715,25 +715,25 @@ for(r=1;r<p;++r){if(!(r<q.length))return A.y(q,r)
 s=A.eS(v.typeUniverse,s,A.e6(q[r]))}return A.bw(v.typeUniverse,s,a)},
 L(a){return A.af(A.dd(v.typeUniverse,a,!1))},
 hH(a){var s=this
-s.b=A.i2(s)
+s.b=A.i1(s)
 return s.b(a)},
-i2(a){var s,r,q,p,o
+i1(a){var s,r,q,p,o
 if(a===t.K)return A.hR
 if(A.ai(a))return A.hV
 s=a.w
 if(s===6)return A.hE
 if(s===1)return A.eZ
 if(s===7)return A.hM
-r=A.i1(a)
+r=A.i0(a)
 if(r!=null)return r
 if(s===8){q=a.x
 if(a.y.every(A.ai)){a.f="$i"+q
 if(q==="i")return A.hP
 if(a===t.m)return A.hO
-return A.hU}}else if(s===10){p=A.ig(a.x,a.y)
+return A.hU}}else if(s===10){p=A.ie(a.x,a.y)
 o=p==null?A.eZ:p
 return o==null?A.aa(o):o}return A.hC},
-i1(a){if(a.w===8){if(a===t.S)return A.e4
+i0(a){if(a.w===8){if(a===t.S)return A.e4
 if(a===t.i||a===t.o)return A.hQ
 if(a===t.N)return A.hT
 if(a===t.y)return A.dk}return null},
@@ -756,7 +756,7 @@ s.a=r
 return s.a(a)},
 hC(a){var s=this
 if(a==null)return A.aF(s)
-return A.it(v.typeUniverse,A.is(a,s),s)},
+return A.is(v.typeUniverse,A.ir(a,s),s)},
 hE(a){if(a==null)return!0
 return this.x.b(a)},
 hU(a){var s,r=this
@@ -835,7 +835,7 @@ throw A.w(A.I(a,"JSObject?"),new Error())},
 f5(a,b){var s,r,q
 for(s="",r="",q=0;q<a.length;++q,r=", ")s+=r+A.F(a[q],b)
 return s},
-hZ(a,b){var s,r,q,p,o,n,m=a.x,l=a.y
+hY(a,b){var s,r,q,p,o,n,m=a.x,l=a.y
 if(""===m)return"("+A.f5(l,b)+")"
 s=l.length
 r=m.split(",")
@@ -884,9 +884,9 @@ if(l===6){s=a.x
 r=A.F(s,b)
 q=s.w
 return(q===11||q===12?"("+r+")":r)+"?"}if(l===7)return"FutureOr<"+A.F(a.x,b)+">"
-if(l===8){p=A.i6(a.x)
+if(l===8){p=A.i5(a.x)
 o=a.y
-return o.length>0?p+("<"+A.f5(o,b)+">"):p}if(l===10)return A.hZ(a,b)
+return o.length>0?p+("<"+A.f5(o,b)+">"):p}if(l===10)return A.hY(a,b)
 if(l===11)return A.eW(a,b,null)
 if(l===12)return A.eW(a.x,b,a.y)
 if(l===13){n=a.x
@@ -894,7 +894,7 @@ m=b.length
 n=m-1-n
 if(!(n>=0&&n<m))return A.y(b,n)
 return b[n]}return"?"},
-i6(a){var s=v.mangledGlobalNames[a]
+i5(a){var s=v.mangledGlobalNames[a]
 if(s!=null)return s
 return"minified:"+a},
 hn(a,b){var s=a.tR[b]
@@ -1197,7 +1197,7 @@ if(q!==8)throw A.e(A.bD("Indexed base must be an interface type"))
 s=b.y
 if(c<=s.length)return s[c-1]
 throw A.e(A.bD("Bad index "+c+" for "+b.i(0)))},
-it(a,b,c){var s,r=b.d
+is(a,b,c){var s,r=b.d
 if(r==null)r=b.d=new Map()
 s=r.get(c)
 if(s==null){s=A.u(a,b,null,c,null)
@@ -1312,14 +1312,14 @@ dc:function dc(a){this.a=a},
 ch:function ch(){},
 bs:function bs(a){this.a=a},
 h3(){var s,r,q
-if(self.scheduleImmediate!=null)return A.i8()
+if(self.scheduleImmediate!=null)return A.i7()
 if(self.MutationObserver!=null&&self.document!=null){s={}
 r=self.document.createElement("div")
 q=self.document.createElement("span")
 s.a=null
 new self.MutationObserver(A.aD(new A.cT(s),1)).observe(r,{childList:true})
-return new A.cS(s,r,q)}else if(self.setImmediate!=null)return A.i9()
-return A.ia()},
+return new A.cS(s,r,q)}else if(self.setImmediate!=null)return A.i8()
+return A.i9()},
 h4(a){self.scheduleImmediate(A.aD(new A.cU(t.M.a(a)),0))},
 h5(a){self.setImmediate(A.aD(new A.cV(t.M.a(a)),0))},
 h6(a){t.M.a(a)
@@ -1346,10 +1346,10 @@ else{r=new A.r($.m,t._)
 r.a=8
 r.c=a
 r.af(q,p,s)}}},
-dq(a){var s=function(b,c){return function(d,e){while(true){try{b(d,e)
+dp(a){var s=function(b,c){return function(d,e){while(true){try{b(d,e)
 break}catch(r){e=r
 d=c}}}}(a,1)
-return $.m.ak(new A.dr(s),t.H,t.S,t.z)},
+return $.m.ak(new A.dq(s),t.H,t.S,t.z)},
 eN(a,b,c){return 0},
 dL(a){var s
 if(t.C.b(a)){s=a.gF()
@@ -1386,7 +1386,7 @@ p=c.a
 o=(p&16)===0
 n=!o
 if(b==null){if(n&&(p&1)===0){m=s.a(c.c)
-A.dn(m.a,m.b)}return}q.a=b
+A.dm(m.a,m.b)}return}q.a=b
 l=b.a
 for(c=b;l!=null;c=l,l=k){c.a=null
 A.at(d.a,c)
@@ -1401,7 +1401,7 @@ if(i){h=c.b.b
 if(n){p=p.b===h
 p=!(p||p)}else p=!1
 if(p){s.a(j)
-A.dn(j.a,j.b)
+A.dm(j.a,j.b)
 return}g=$.m
 if(g!==h)$.m=h
 else g=null
@@ -1443,14 +1443,14 @@ r=s.b
 $.aA=r
 if(r==null)$.bz=null
 s.a.$0()}},
-i3(){$.e3=!0
+i2(){$.e3=!0
 try{A.hX()}finally{$.bA=null
 $.e3=!1
 if($.aA!=null)$.ej().$1(A.f8())}},
 f6(a){var s=new A.cf(a),r=$.bz
 if(r==null){$.aA=$.bz=s
 if(!$.e3)$.ej().$1(A.f8())}else $.bz=r.b=s},
-i0(a){var s,r,q,p=$.aA
+i_(a){var s,r,q,p=$.aA
 if(p==null){A.f6(a)
 $.bA=$.bz
 return}s=new A.cf(a)
@@ -1460,12 +1460,12 @@ $.aA=$.bA=s}else{q=r.b
 s.b=q
 $.bA=r.b=s
 if(q==null)$.bz=s}},
-iE(a,b){A.ds(a,"stream",t.K)
+iE(a,b){A.dr(a,"stream",t.K)
 return new A.ck(b.h("ck<0>"))},
 fW(a,b){var s=$.m
 if(s===B.b)return A.eB(a,t.d.a(b))
 return A.eB(a,t.d.a(s.aJ(b,t.p)))},
-dn(a,b){A.i0(new A.dp(a,b))},
+dm(a,b){A.i_(new A.dn(a,b))},
 f3(a,b,c,d,e){var s,r=$.m
 if(r===c)return d.$0()
 $.m=c
@@ -1478,7 +1478,7 @@ $.m=c
 s=r
 try{r=d.$1(e)
 return r}finally{$.m=s}},
-i_(a,b,c,d,e,f,g,h,i){var s,r=$.m
+hZ(a,b,c,d,e,f,g,h,i){var s,r=$.m
 if(r===c)return d.$2(e,f)
 $.m=c
 s=r
@@ -1508,7 +1508,7 @@ this.b=!1
 this.$ti=b},
 di:function di(a){this.a=a},
 dj:function dj(a){this.a=a},
-dr:function dr(a){this.a=a},
+dq:function dq(a){this.a=a},
 bq:function bq(a,b){var _=this
 _.a=a
 _.e=_.d=_.c=_.b=null
@@ -1556,7 +1556,7 @@ cf:function cf(a){this.a=a
 this.b=null},
 ck:function ck(a){this.$ti=a},
 bx:function bx(){},
-dp:function dp(a,b){this.a=a
+dn:function dn(a,b){this.a=a
 this.b=b},
 cj:function cj(){},
 d8:function d8(a,b){this.a=a
@@ -1572,7 +1572,7 @@ dY(){var s=Object.create(null)
 A.dZ(s,"<non-identifier-key>",s)
 delete s["<non-identifier-key>"]
 return s},
-B(a,b,c){return b.h("@<0>").k(c).h("eu<1,2>").a(A.ii(a,new A.a7(b.h("@<0>").k(c).h("a7<1,2>"))))},
+B(a,b,c){return b.h("@<0>").k(c).h("eu<1,2>").a(A.ih(a,new A.a7(b.h("@<0>").k(c).h("a7<1,2>"))))},
 dQ(a,b){return new A.a7(a.h("@<0>").k(b).h("a7<1,2>"))},
 dR(a){var s,r
 if(A.ed(a))return"{...}"
@@ -1636,8 +1636,8 @@ return"0"+a},
 cs(a){if(typeof a=="number"||A.dk(a)||a==null)return J.aI(a)
 if(typeof a=="string")return JSON.stringify(a)
 return A.ex(a)},
-fC(a,b){A.ds(a,"error",t.K)
-A.ds(b,"stackTrace",t.l)
+fC(a,b){A.dr(a,"error",t.K)
+A.dr(b,"stackTrace",t.l)
 A.fB(a,b)},
 bD(a){return new A.bC(a)},
 al(a,b){return new A.Q(!1,null,b,a)},
@@ -1762,22 +1762,22 @@ if(e===1)return a.$1(b)
 return a.$0()},
 f0(a){return a==null||A.dk(a)||typeof a=="number"||typeof a=="string"||t.D.b(a)||t.bX.b(a)||t.ca.b(a)||t.W.b(a)||t.a.b(a)||t.k.b(a)||t.x.b(a)||t.B.b(a)||t.q.b(a)||t.J.b(a)||t.Y.b(a)},
 aG(a){if(A.f0(a))return a
-return new A.dD(new A.au(t.A)).$1(a)},
+return new A.dC(new A.au(t.A)).$1(a)},
 ef(a,b){var s=new A.r($.m,b.h("r<0>")),r=new A.bc(s,b.h("bc<0>"))
-a.then(A.aD(new A.dG(r,b),1),A.aD(new A.dH(r),1))
+a.then(A.aD(new A.dF(r,b),1),A.aD(new A.dG(r),1))
 return s},
 f_(a){return a==null||typeof a==="boolean"||typeof a==="number"||typeof a==="string"||a instanceof Int8Array||a instanceof Uint8Array||a instanceof Uint8ClampedArray||a instanceof Int16Array||a instanceof Uint16Array||a instanceof Int32Array||a instanceof Uint32Array||a instanceof Float32Array||a instanceof Float64Array||a instanceof ArrayBuffer||a instanceof DataView},
 e8(a){if(A.f_(a))return a
-return new A.dt(new A.au(t.A)).$1(a)},
-dD:function dD(a){this.a=a},
-dG:function dG(a,b){this.a=a
+return new A.ds(new A.au(t.A)).$1(a)},
+dC:function dC(a){this.a=a},
+dF:function dF(a,b){this.a=a
 this.b=b},
-dH:function dH(a){this.a=a},
-dt:function dt(a){this.a=a},
+dG:function dG(a){this.a=a},
+ds:function ds(a){this.a=a},
 iA(){var s=$.aH()
-s.a=t.e.a(A.ib())
-s.saO(A.ic())},
-io(a){var s,r,q,p,o,n=null,m="threshold"
+s.a=t.e.a(A.ia())
+s.saO(A.ib())},
+im(a){var s,r,q,p,o,n=null,m="threshold"
 if(!t.f.b(a))return
 switch(a.j(0,"op")){case"watch":s=A.cn(a.j(0,"city"))
 r=s==null?n:s.toLowerCase()
@@ -1788,7 +1788,7 @@ s=$.bB
 if(s!=null)s.Y()
 A.ac(A.B(["kind","watching","city",r,"threshold",q],t.N,t.X))
 A.f1(r,q)
-$.bB=A.fW(B.t,new A.dy(r,q))
+$.bB=A.fW(B.t,new A.dx(r,q))
 break
 case"stop":s=$.bB
 if(s!=null)s.Y()
@@ -1822,9 +1822,9 @@ hF(a){var s,r,q,p
 for(s=new A.aL(a),r=t.V,s=new A.R(s,s.gl(0),r.h("R<f.E>")),r=r.h("f.E"),q=0;s.m();){p=s.d
 if(p==null)p=r.a(p)
 q=q*31+p&2147483647}return q},
-eb(a,b){return A.im(a,t.h.a(b))},
-im(a,b){var s=0,r=A.dl(t.y),q,p,o,n,m,l,k,j,i,h
-var $async$eb=A.dq(function(c,d){if(c===1)return A.df(d,r)
+eb(a,b){return A.il(a,t.h.a(b))},
+il(a,b){var s=0,r=A.dl(t.y),q,p,o,n,m,l,k,j,i,h
+var $async$eb=A.dp(function(c,d){if(c===1)return A.df(d,r)
 for(;;)switch(s){case 0:h=b==null
 if(!h&&J.P(b.j(0,"fail"),!0)){q=!1
 s=1
@@ -1843,28 +1843,28 @@ A.ac(A.B(["kind","task-done","city",o,"tempC",k,"below",j],h,p))
 h=j?"\u2744\ufe0f "+o+" below the alert threshold":"Temperature check: "+A.hz(o)
 p=B.v.aX(k,1)
 i=j?"below the alert threshold":"all good"
-A.hY(h,p+"\xb0C \u2014 "+i)
+A.ix(h,p+"\xb0C \u2014 "+i)
 q=!0
 s=1
 break
 case 1:return A.dg(q,r)}})
 return A.dh($async$eb,r)},
-hY(a,b){var s,r,q,p,o=v.G
-if(!("registration" in o))return
-s=t.X
-s=A.ef(A.by(A.aT(A.by(o.registration),"showNotification",a,A.aG(A.B(["body",b,"tag","workmanager-demo"],t.N,s)),s)),s)
-r=new A.dm()
-q=s.$ti
-p=$.m
-if(p!==B.b)r=A.f2(r,p)
-s.G(new A.V(new A.r(p,q),2,null,r,q.h("V<1,1>")))},
 hz(a){var s=a.length
 if(s===0)return a
 if(0>=s)return A.y(a,0)
 return a[0].toUpperCase()+B.j.an(a,1)},
-dy:function dy(a,b){this.a=a
+dx:function dx(a,b){this.a=a
 this.b=b},
-dm:function dm(){},
+ix(a,b){var s,r,q,p,o=v.G
+if(!("registration" in o))return
+s=t.X
+s=A.ef(A.by(A.aT(A.by(o.registration),"showNotification",a,A.aG(A.B(["body",b,"tag","workmanager-demo"],t.N,s)),s)),s)
+r=new A.dH()
+q=s.$ti
+p=$.m
+if(p!==B.b)r=A.f2(r,p)
+s.G(new A.V(new A.r(p,q),2,null,r,q.h("V<1,1>")))},
+dH:function dH(){},
 cc:function cc(){this.c=this.b=this.a=null},
 h2(a){var s,r,q,p,o="Attempting to rewrap a JS function."
 if($.eE)return
@@ -1895,7 +1895,7 @@ return}r=A.fX(a)
 if(r==null)return
 A.cN(r.b,r.c,r.a)},
 cN(a,b,c){var s=0,r=A.dl(t.H),q,p
-var $async$cN=A.dq(function(d,e){if(d===1)return A.df(e,r)
+var $async$cN=A.dp(function(d,e){if(d===1)return A.df(e,r)
 for(;;)switch(s){case 0:s=2
 return A.e1(A.cd(b,c),$async$cN)
 case 2:q=e
@@ -1905,7 +1905,7 @@ return A.dg(null,r)}})
 return A.dh($async$cN,r)},
 h0(a,b,c){A.cM(A.az(a),b,t.g.a(c))},
 cM(a,b,c){var s=0,r=A.dl(t.H),q,p,o,n,m
-var $async$cM=A.dq(function(d,e){if(d===1)return A.df(e,r)
+var $async$cM=A.dp(function(d,e){if(d===1)return A.df(e,r)
 for(;;)switch(s){case 0:s=2
 return A.e1(A.cd(a,b==null?null:A.e8(b)),$async$cM)
 case 2:q=e
@@ -1918,7 +1918,7 @@ return A.dg(null,r)}})
 return A.dh($async$cM,r)},
 cd(a,b){return A.h_(a,b)},
 h_(a,b){var s=0,r=A.dl(t.t),q,p=2,o=[],n,m,l,k,j,i,h
-var $async$cd=A.dq(function(c,d){if(c===1){o.push(d)
+var $async$cd=A.dp(function(c,d){if(c===1){o.push(d)
 s=p}for(;;)switch(s){case 0:j=null
 i=null
 p=4
@@ -1969,7 +1969,7 @@ return new A.bo(p.a(q.j(0,"inputData")),s,r)},
 fY(a){var s=a.a,r=a.$ti.h("4?")
 if(!J.P(r.a(s.j(0,"type")),"message"))return null
 return r.a(s.j(0,"payload"))},
-iv(){A.h2(A.id())}},B={}
+iu(){A.h2(A.ic())}},B={}
 var w=[A,J,B]
 var $={}
 A.dO.prototype={}
@@ -2023,11 +2023,11 @@ i(a){return A.es(a,"[","]")},
 gp(a){return new J.aJ(a,a.length,A.ay(a).h("aJ<1>"))},
 gq(a){return A.c1(a)},
 gl(a){return a.length},
-j(a,b){if(!(b>=0&&b<a.length))throw A.e(A.du(a,b))
+j(a,b){if(!(b>=0&&b<a.length))throw A.e(A.dt(a,b))
 return a[b]},
 v(a,b,c){A.ay(a).c.a(c)
 a.$flags&2&&A.eg(a)
-if(!(b>=0&&b<a.length))throw A.e(A.du(a,b))
+if(!(b>=0&&b<a.length))throw A.e(A.dt(a,b))
 a[b]=c},
 $id:1,
 $ib:1,
@@ -2305,7 +2305,7 @@ C(a,b){if(b==null)return!1
 if(this===b)return!0
 if(!(b instanceof A.am))return!1
 return this.$_target===b.$_target&&this.a===b.a},
-gq(a){return(A.dF(this.a)^A.c1(this.$_target))>>>0},
+gq(a){return(A.dE(this.a)^A.c1(this.$_target))>>>0},
 i(a){return"Closure '"+this.$_name+"' of "+("Instance of '"+A.c2(this.a)+"'")}}
 A.c4.prototype={
 i(a){return"RuntimeError: "+this.a}}
@@ -2403,13 +2403,13 @@ return!1}else{r.d=new A.q(s.a,s.b,r.$ti.h("q<1,2>"))
 r.c=s.c
 return!0}},
 $iz:1}
-A.dz.prototype={
+A.dy.prototype={
 $1(a){return this.a(a)},
 $S:7}
-A.dA.prototype={
+A.dz.prototype={
 $2(a,b){return this.a(a,b)},
 $S:8}
-A.dB.prototype={
+A.dA.prototype={
 $1(a){return this.a(A.az(a))},
 $S:9}
 A.W.prototype={
@@ -2589,7 +2589,7 @@ $S:2}
 A.dj.prototype={
 $2(a,b){this.a.$2(1,new A.aP(a,t.l.a(b)))},
 $S:11}
-A.dr.prototype={
+A.dq.prototype={
 $2(a,b){this.a(A.a2(a),b)},
 $S:12}
 A.bq.prototype={
@@ -2814,7 +2814,7 @@ $S:0}
 A.cf.prototype={}
 A.ck.prototype={}
 A.bx.prototype={$ieF:1}
-A.dp.prototype={
+A.dn.prototype={
 $0(){A.fC(this.a,this.b)},
 $S:0}
 A.cj.prototype={
@@ -2823,14 +2823,14 @@ t.M.a(a)
 try{if(B.b===$.m){a.$0()
 return}A.f3(null,null,this,a,t.H)}catch(q){s=A.ak(q)
 r=A.ah(q)
-A.dn(A.aa(s),t.l.a(r))}},
+A.dm(A.aa(s),t.l.a(r))}},
 aV(a,b,c){var s,r,q
 c.h("~(0)").a(a)
 c.a(b)
 try{if(B.b===$.m){a.$1(b)
 return}A.f4(null,null,this,a,b,t.H,c)}catch(q){s=A.ak(q)
 r=A.ah(q)
-A.dn(A.aa(s),t.l.a(r))}},
+A.dm(A.aa(s),t.l.a(r))}},
 aI(a){return new A.d8(this,t.M.a(a))},
 aJ(a,b){return new A.d9(this,b.h("~(0)").a(a),b)},
 aS(a,b){b.h("0()").a(a)
@@ -2844,7 +2844,7 @@ aT(a,b,c,d,e,f){d.h("@<0>").k(e).k(f).h("1(2,3)").a(a)
 e.a(b)
 f.a(c)
 if($.m===B.b)return a.$2(b,c)
-return A.i_(null,null,this,a,b,c,d,e,f)},
+return A.hZ(null,null,this,a,b,c,d,e,f)},
 ak(a,b,c,d){return b.h("@<0>").k(c).k(d).h("1(2,3)").a(a)}}
 A.d8.prototype={
 $0(){return this.a.aU(this.b)},
@@ -2881,7 +2881,7 @@ if(typeof b=="string"&&b!=="__proto__"){s=m.b
 m.a8(s==null?m.b=A.dY():s,b,c)}else if(typeof b=="number"&&(b&1073741823)===b){r=m.c
 m.a8(r==null?m.c=A.dY():r,b,c)}else{q=m.d
 if(q==null)q=m.d=A.dY()
-p=A.dF(b)&1073741823
+p=A.dE(b)&1073741823
 o=q[p]
 if(o==null){A.dZ(q,p,[b,c]);++m.a
 m.e=null}else{n=m.T(o,b)
@@ -2917,7 +2917,7 @@ s.c.a(b)
 s.y[1].a(c)
 if(a[b]==null){++this.a
 this.e=null}A.dZ(a,b,c)},
-ab(a,b){return a[A.dF(b)&1073741823]}}
+ab(a,b){return a[A.dE(b)&1073741823]}}
 A.au.prototype={
 T(a,b){var s,r,q
 if(a==null)return-1
@@ -3063,7 +3063,7 @@ A.c.prototype={$ic:1,
 C(a,b){return this===b},
 gq(a){return A.c1(this)},
 i(a){return"Instance of '"+A.c2(this)+"'"},
-gt(a){return A.ik(this)},
+gt(a){return A.ij(this)},
 toString(){return this.i(this)}}
 A.cl.prototype={
 i(a){return""},
@@ -3074,7 +3074,7 @@ i(a){var s=this.a
 return s.charCodeAt(0)==0?s:s}}
 A.cC.prototype={
 i(a){return"Promise was rejected with a value of `"+(this.a?"undefined":"null")+"`."}}
-A.dD.prototype={
+A.dC.prototype={
 $1(a){var s,r,q,p
 if(A.f0(a))return a
 s=this.a
@@ -3087,14 +3087,14 @@ s.v(0,a,p)
 B.a.aH(p,J.ek(a,this,t.z))
 return p}else return a},
 $S:3}
-A.dG.prototype={
+A.dF.prototype={
 $1(a){return this.a.a_(this.b.h("0/?").a(a))},
 $S:2}
-A.dH.prototype={
+A.dG.prototype={
 $1(a){if(a==null)return this.a.ah(new A.cC(a===undefined))
 return this.a.ah(a)},
 $S:2}
-A.dt.prototype={
+A.ds.prototype={
 $1(a){var s,r,q,p,o,n,m,l,k,j,i,h
 if(A.f_(a))return a
 s=this.a
@@ -3102,7 +3102,7 @@ a.toString
 if(s.K(a))return s.j(0,a)
 if(a instanceof Date){r=a.getTime()
 if(r<-864e13||r>864e13)A.cp(A.c3(r,-864e13,864e13,"millisecondsSinceEpoch",null))
-A.ds(!0,"isUtc",t.y)
+A.dr(!0,"isUtc",t.y)
 return new A.bH(r,0,!0)}if(a instanceof RegExp)throw A.e(A.al("structured clone of RegExp",null))
 if(a instanceof Promise)return A.ef(a,t.X)
 q=Object.getPrototypeOf(a)
@@ -3111,7 +3111,7 @@ o=A.dQ(p,p)
 s.v(0,a,o)
 n=Object.keys(a)
 m=[]
-for(s=J.dx(n),p=s.gp(n);p.m();)m.push(A.e8(p.gn()))
+for(s=J.dw(n),p=s.gp(n);p.m();)m.push(A.e8(p.gn()))
 for(l=0;l<s.gl(n);++l){k=s.j(n,l)
 if(!(l<m.length))return A.y(m,l)
 j=m[l]
@@ -3122,11 +3122,11 @@ h=A.a2(a.length)
 for(s=J.e9(i),l=0;l<h;++l)o.push(this.$1(s.j(i,l)))
 return o}return a},
 $S:3}
-A.dy.prototype={
+A.dx.prototype={
 $1(a){t.p.a(a)
 return A.f1(this.a,this.b)},
 $S:15}
-A.dm.prototype={
+A.dH.prototype={
 $1(a){A.aa(a)
 return null},
 $S:16}
@@ -3166,13 +3166,13 @@ $1(a){var s=t.X
 A.aT(this.a,"postMessage",A.aG(A.B(["type","workerMessage","payload",a],t.N,s)),null,s)},
 $S:4};(function aliases(){var s=J.Z.prototype
 s.ap=s.i})();(function installTearOffs(){var s=hunkHelpers._static_1,r=hunkHelpers._static_0,q=hunkHelpers._static_2,p=hunkHelpers._instance_1u,o=hunkHelpers.installStaticTearOff
-s(A,"i8","h4",5)
-s(A,"i9","h5",5)
-s(A,"ia","h6",5)
-r(A,"f8","i3",0)
-r(A,"id","iA",0)
-s(A,"ic","io",4)
-q(A,"ib","eb",19)
+s(A,"i7","h4",5)
+s(A,"i8","h5",5)
+s(A,"i9","h6",5)
+r(A,"f8","i2",0)
+r(A,"ic","iA",0)
+s(A,"ib","im",4)
+q(A,"ia","eb",19)
 p(A.cc.prototype,"gaQ","N",3)
 o(A,"eh",3,null,["$3"],["h0"],20,0)})();(function inheritance(){var s=hunkHelpers.mixin,r=hunkHelpers.inherit,q=hunkHelpers.inheritMany
 r(A.c,null)
@@ -3187,8 +3187,8 @@ q(A.b,[A.as,A.d,A.a8,A.bh,A.ax])
 r(A.a4,A.as)
 r(A.bd,A.a4)
 q(A.k,[A.a5,A.a7,A.be])
-q(A.Y,[A.bF,A.cq,A.bE,A.c8,A.dz,A.dB,A.cT,A.cS,A.di,A.d4,A.d9,A.cA,A.dD,A.dG,A.dH,A.dt,A.dy,A.dm,A.cR,A.cP,A.cO,A.cQ])
-q(A.bF,[A.cr,A.dA,A.dj,A.dr,A.d5,A.cB])
+q(A.Y,[A.bF,A.cq,A.bE,A.c8,A.dy,A.dA,A.cT,A.cS,A.di,A.d4,A.d9,A.cA,A.dC,A.dF,A.dG,A.ds,A.dx,A.dH,A.cR,A.cP,A.cO,A.cQ])
+q(A.bF,[A.cr,A.dz,A.dj,A.dq,A.d5,A.cB])
 q(A.l,[A.bQ,A.T,A.bP,A.cb,A.c4,A.ch,A.bC,A.Q,A.bb,A.ca,A.c5,A.bG])
 r(A.ar,A.f)
 r(A.aL,A.ar)
@@ -3210,7 +3210,7 @@ r(A.b2,A.bm)
 q(A.b1,[A.bS,A.bT])
 q(A.b2,[A.bU,A.bV,A.bW,A.bX,A.bY,A.b4,A.bZ])
 r(A.bs,A.ch)
-q(A.bE,[A.cU,A.cV,A.db,A.da,A.cX,A.d0,A.d_,A.cZ,A.cY,A.d3,A.d2,A.d1,A.dp,A.d8])
+q(A.bE,[A.cU,A.cV,A.db,A.da,A.cX,A.d0,A.d_,A.cZ,A.cY,A.d3,A.d2,A.d1,A.dn,A.d8])
 r(A.bc,A.cg)
 r(A.cj,A.bx)
 r(A.au,A.be)
@@ -3224,7 +3224,7 @@ var v={G:typeof self!="undefined"?self:globalThis,typeUniverse:{eC:new Map(),tR:
 A.hl(v.typeUniverse,JSON.parse('{"N":"Z","c0":"Z","b9":"Z","iC":"ap","bN":{"ae":[],"j":[]},"aR":{"p":[],"j":[]},"aV":{"o":[]},"Z":{"o":[]},"x":{"i":["1"],"d":["1"],"o":[],"b":["1"]},"bM":{"b7":[]},"cy":{"x":["1"],"i":["1"],"d":["1"],"o":[],"b":["1"]},"aJ":{"z":["1"]},"aS":{"h":[],"aj":[]},"aQ":{"h":[],"a":[],"aj":[],"j":[]},"bO":{"h":[],"aj":[],"j":[]},"ao":{"v":[],"j":[]},"as":{"b":["2"]},"aK":{"z":["2"]},"a4":{"as":["1","2"],"b":["2"],"b.E":"2"},"bd":{"a4":["1","2"],"as":["1","2"],"d":["2"],"b":["2"],"b.E":"2"},"a5":{"k":["3","4"],"D":["3","4"],"k.K":"3","k.V":"4"},"bQ":{"l":[]},"aL":{"f":["a"],"ba":["a"],"i":["a"],"d":["a"],"b":["a"],"f.E":"a"},"d":{"b":["1"]},"O":{"d":["1"],"b":["1"]},"R":{"z":["1"]},"a8":{"b":["2"],"b.E":"2"},"aO":{"a8":["1","2"],"d":["2"],"b":["2"],"b.E":"2"},"b0":{"z":["2"]},"S":{"O":["2"],"d":["2"],"b":["2"],"b.E":"2","O.E":"2"},"ar":{"f":["1"],"ba":["1"],"i":["1"],"d":["1"],"b":["1"]},"bn":{"av":[],"W":[]},"bo":{"aw":[],"W":[]},"aM":{"D":["1","2"]},"aN":{"aM":["1","2"],"D":["1","2"]},"bh":{"b":["1"],"b.E":"1"},"bi":{"z":["1"]},"b5":{"T":[],"l":[]},"bP":{"l":[]},"cb":{"l":[]},"bp":{"a_":[]},"Y":{"a6":[]},"bE":{"a6":[]},"bF":{"a6":[]},"c8":{"a6":[]},"c6":{"a6":[]},"am":{"a6":[]},"c4":{"l":[]},"a7":{"k":["1","2"],"eu":["1","2"],"D":["1","2"],"k.K":"1","k.V":"2"},"b_":{"d":["1"],"b":["1"],"b.E":"1"},"aZ":{"z":["1"]},"aX":{"d":["q<1,2>"],"b":["q<1,2>"],"b.E":"q<1,2>"},"aY":{"z":["q<1,2>"]},"av":{"W":[]},"aw":{"W":[]},"ap":{"o":[],"dM":[],"j":[]},"b3":{"o":[]},"bR":{"dN":[],"o":[],"j":[]},"aq":{"C":["1"],"o":[]},"b1":{"f":["h"],"i":["h"],"C":["h"],"d":["h"],"o":[],"b":["h"],"A":["h"]},"b2":{"f":["a"],"i":["a"],"C":["a"],"d":["a"],"o":[],"b":["a"],"A":["a"]},"bS":{"ct":[],"f":["h"],"i":["h"],"C":["h"],"d":["h"],"o":[],"b":["h"],"A":["h"],"j":[],"f.E":"h"},"bT":{"cu":[],"f":["h"],"i":["h"],"C":["h"],"d":["h"],"o":[],"b":["h"],"A":["h"],"j":[],"f.E":"h"},"bU":{"cv":[],"f":["a"],"i":["a"],"C":["a"],"d":["a"],"o":[],"b":["a"],"A":["a"],"j":[],"f.E":"a"},"bV":{"cw":[],"f":["a"],"i":["a"],"C":["a"],"d":["a"],"o":[],"b":["a"],"A":["a"],"j":[],"f.E":"a"},"bW":{"cx":[],"f":["a"],"i":["a"],"C":["a"],"d":["a"],"o":[],"b":["a"],"A":["a"],"j":[],"f.E":"a"},"bX":{"cH":[],"f":["a"],"i":["a"],"C":["a"],"d":["a"],"o":[],"b":["a"],"A":["a"],"j":[],"f.E":"a"},"bY":{"cI":[],"f":["a"],"i":["a"],"C":["a"],"d":["a"],"o":[],"b":["a"],"A":["a"],"j":[],"f.E":"a"},"b4":{"cJ":[],"f":["a"],"i":["a"],"C":["a"],"d":["a"],"o":[],"b":["a"],"A":["a"],"j":[],"f.E":"a"},"bZ":{"cK":[],"f":["a"],"i":["a"],"C":["a"],"d":["a"],"o":[],"b":["a"],"A":["a"],"j":[],"f.E":"a"},"ch":{"l":[]},"bs":{"T":[],"l":[]},"br":{"c9":[]},"bq":{"z":["1"]},"ax":{"b":["1"],"b.E":"1"},"H":{"l":[]},"bc":{"cg":["1"]},"r":{"M":["1"]},"bx":{"eF":[]},"cj":{"bx":[],"eF":[]},"be":{"k":["1","2"],"D":["1","2"]},"au":{"be":["1","2"],"k":["1","2"],"D":["1","2"],"k.K":"1","k.V":"2"},"bf":{"d":["1"],"b":["1"],"b.E":"1"},"bg":{"z":["1"]},"f":{"i":["1"],"d":["1"],"b":["1"]},"k":{"D":["1","2"]},"h":{"aj":[]},"a":{"aj":[]},"i":{"d":["1"],"b":["1"]},"bC":{"l":[]},"T":{"l":[]},"Q":{"l":[]},"b6":{"l":[]},"bK":{"l":[]},"bb":{"l":[]},"ca":{"l":[]},"c5":{"l":[]},"bG":{"l":[]},"c_":{"l":[]},"b8":{"l":[]},"cl":{"a_":[]},"cx":{"i":["a"],"d":["a"],"b":["a"]},"cK":{"i":["a"],"d":["a"],"b":["a"]},"cJ":{"i":["a"],"d":["a"],"b":["a"]},"cv":{"i":["a"],"d":["a"],"b":["a"]},"cH":{"i":["a"],"d":["a"],"b":["a"]},"cw":{"i":["a"],"d":["a"],"b":["a"]},"cI":{"i":["a"],"d":["a"],"b":["a"]},"ct":{"i":["h"],"d":["h"],"b":["h"]},"cu":{"i":["h"],"d":["h"],"b":["h"]}}'))
 A.hk(v.typeUniverse,JSON.parse('{"ar":1,"aq":1}'))
 var u={c:"Error handler must accept one Object or one Object and a StackTrace as arguments, and return a value of the returned future's type"}
-var t=(function rtii(){var s=A.dw
+var t=(function rtii(){var s=A.dv
 return{n:s("H"),J:s("dM"),Y:s("dN"),V:s("aL"),O:s("d<@>"),C:s("l"),B:s("ct"),q:s("cu"),Z:s("a6"),e:s("M<ae>(v,D<v,@>?)"),W:s("cv"),k:s("cw"),D:s("cx"),R:s("b<@>"),G:s("x<c>"),s:s("x<v>"),b:s("x<@>"),T:s("aR"),m:s("o"),g:s("N"),E:s("C<@>"),j:s("i<@>"),f:s("D<@,@>"),P:s("p"),K:s("c"),L:s("iD"),r:s("+()"),t:s("+(c?,v?)"),l:s("a_"),N:s("v"),p:s("c9"),w:s("j"),c:s("T"),a:s("cH"),x:s("cI"),ca:s("cJ"),bX:s("cK"),cr:s("b9"),_:s("r<@>"),A:s("au<c?,c?>"),y:s("ae"),bG:s("ae(c)"),i:s("h"),z:s("@"),bd:s("@()"),v:s("@(c)"),Q:s("@(c,a_)"),S:s("a"),bc:s("M<p>?"),aQ:s("o?"),h:s("D<v,@>?"),X:s("c?"),aD:s("v?"),F:s("V<@,@>?"),u:s("ae?"),I:s("h?"),a3:s("a?"),ae:s("aj?"),U:s("~(c?)?"),o:s("aj"),H:s("~"),M:s("~()"),d:s("~(c9)")}})();(function constants(){B.u=J.bL.prototype
 B.a=J.x.prototype
 B.c=J.aQ.prototype
@@ -3365,7 +3365,7 @@ B.b=new A.cj()
 B.e=new A.cl()
 B.t=new A.bJ(3e6)
 B.z={cardiff:0,taipei:1}
-B.y=new A.aN(B.z,[11,26],A.dw("aN<v,h>"))
+B.y=new A.aN(B.z,[11,26],A.dv("aN<v,h>"))
 B.A=A.L("dM")
 B.B=A.L("dN")
 B.C=A.L("ct")
@@ -3385,10 +3385,10 @@ $.en=null
 $.fa=null
 $.f7=null
 $.fc=null
-$.dv=null
-$.dC=null
+$.du=null
+$.dB=null
 $.ec=null
-$.d7=A.K([],A.dw("x<i<c>?>"))
+$.d7=A.K([],A.dv("x<i<c>?>"))
 $.aA=null
 $.bz=null
 $.bA=null
@@ -3396,8 +3396,8 @@ $.e3=!1
 $.m=B.b
 $.bB=null
 $.eE=!1})();(function lazyInitializers(){var s=hunkHelpers.lazyFinal
-s($,"iB","ei",()=>A.ij("_$dart_dartClosure"))
-s($,"iS","fp",()=>A.K([new J.bM()],A.dw("x<b7>")))
+s($,"iB","ei",()=>A.ii("_$dart_dartClosure"))
+s($,"iS","fp",()=>A.K([new J.bM()],A.dv("x<b7>")))
 s($,"iF","ff",()=>A.U(A.cG({
 toString:function(){return"$receiver$"}})))
 s($,"iG","fg",()=>A.U(A.cG({$method$:null,
@@ -3413,7 +3413,7 @@ s($,"iJ","fj",()=>A.U(function(){try{null.$method$}catch(r){return r.message}}()
 s($,"iO","fo",()=>A.U(A.eC(void 0)))
 s($,"iN","fn",()=>A.U(function(){try{(void 0).$method$}catch(r){return r.message}}()))
 s($,"iQ","ej",()=>A.h3())
-s($,"iR","dI",()=>A.dF(B.H))
+s($,"iR","dI",()=>A.dE(B.H))
 s($,"iP","aH",()=>new A.cc())})();(function nativeSupport(){!function(){var s=function(a){var m={}
 m[a]=1
 return Object.keys(hunkHelpers.convertToFastObject(m))[0]}
@@ -3446,5 +3446,5 @@ convertToFastObject($);(function(a){if(typeof document==="undefined"){a(null)
 return}if(typeof document.currentScript!="undefined"){a(document.currentScript)
 return}var s=document.scripts
 function onLoad(b){for(var q=0;q<s.length;++q){s[q].removeEventListener("load",onLoad,false)}a(b.target)}for(var r=0;r<s.length;++r){s[r].addEventListener("load",onLoad,false)}})(function(a){v.currentScript=a
-var s=A.iv
+var s=A.iu
 if(typeof dartMainRunner==="function"){dartMainRunner(s,[])}else{s([])}})})()

--- a/workmanager_web/README.md
+++ b/workmanager_web/README.md
@@ -118,7 +118,7 @@ messaging over `postMessage`:
 WorkmanagerWeb().workerMessages.listen((payload) {
   print('worker says: $payload');
 });
-WorkmanagerWeb().sendMessageToWorker({'op': 'watch', 'ticker': 'btc'});
+WorkmanagerWeb().sendMessageToWorker({'op': 'watch', 'city': 'cardiff', 'threshold': 5.0});
 ```
 
 ```dart
@@ -145,7 +145,7 @@ How it maps to the browser:
   `backgroundEvents` on the next load).
 
 The example app demonstrates this with a live "worker chat" panel and a
-simulated price-watch use case.
+simulated weather-watch use case.
 
 ## Testing it (what the maintainers verified)
 

--- a/workmanager_web/README.md
+++ b/workmanager_web/README.md
@@ -106,6 +106,47 @@ The example app in this repository wires all of this up — see
 [`example/`](../../example) and its `web/` folder for a runnable reference,
 including the PWA manifest.
 
+### 5. Communicating with the background worker
+
+Task execution is request/response — the page asks the worker to run a task and
+gets the result back. For anything more interactive (progress updates, live
+data, "worker, do X now"), the worker also supports free-form two-way
+messaging over `postMessage`:
+
+```dart
+// Page side — send a message, listen for replies.
+WorkmanagerWeb().workerMessages.listen((payload) {
+  print('worker says: $payload');
+});
+WorkmanagerWeb().sendMessageToWorker({'op': 'watch', 'ticker': 'btc'});
+```
+
+```dart
+// Dispatcher side (Flutter-free bundle) — receive and reply.
+void callbackDispatcher() {
+  WorkmanagerExecution.instance.executeTask((taskName, inputData) async {
+    return true;
+  });
+  WorkmanagerExecution.instance.messageHandler = (payload) {
+    WorkmanagerExecution.instance.sendToPage?.call({'kind': 'ack'});
+  };
+}
+```
+
+How it maps to the browser:
+
+- **Page open** — messages travel between the page and the dedicated Web
+  Worker over `postMessage`, so the handler runs off the main thread.
+- **No Web Worker available** — the message is delivered directly to the
+  in-page dispatcher; replies surface on the same `workerMessages` stream.
+- **Service Worker execution (page closed)** — a `sendToPage` call is
+  delivered to every open page via `clients.postMessage`; when no page is
+  open it is dropped (persistent task results still arrive through
+  `backgroundEvents` on the next load).
+
+The example app demonstrates this with a live "worker chat" panel and a
+simulated price-watch use case.
+
 ## Testing it (what the maintainers verified)
 
 1. `flutter run -d chrome` (or `flutter build web` + serve over HTTPS or
@@ -162,6 +203,9 @@ including the PWA manifest.
 - `triggerTask(...)` — run a task now (demos/tests)
 - `backgroundEvents` — live stream of execution events, including events
   replayed from the Service Worker
+- `sendMessageToWorker(payload)` / `workerMessages` — free-form two-way
+  messaging with the background worker (see "Communicating with the
+  background worker")
 
 iOS-only task types (`registerProcessingTask`, `registerHealthResearchTask`,
 `registerContinuedProcessingTask`) throw `UnsupportedError` on web.
@@ -174,7 +218,7 @@ lib/
   execution.dart            # Flutter-free handler registry (used by the bundle)
   worker.dart               # WorkmanagerWebWorker — bundle entrypoint
   src/
-    worker_protocol.dart    # page <-> worker message contract (unit-tested)
+    worker_protocol.dart    # page <-> worker message contract incl. chat messages (unit-tested)
     browser_glue_*.dart     # js_interop bindings (web) + VM-safe stubs
 web/
   workmanager_service_worker.js   # the Service Worker (copy into your app)

--- a/workmanager_web/README.md
+++ b/workmanager_web/README.md
@@ -144,8 +144,10 @@ How it maps to the browser:
   open it is dropped (persistent task results still arrive through
   `backgroundEvents` on the next load).
 
-The example app demonstrates this with a live "worker chat" panel and a
-simulated weather-watch use case.
+The example app demonstrates this with a live "worker chat" panel, a
+simulated weather-watch use case, and browser notifications when a
+background task finishes (including while the tab is closed, via the
+Service Worker).
 
 ## Testing it (what the maintainers verified)
 

--- a/workmanager_web/lib/execution.dart
+++ b/workmanager_web/lib/execution.dart
@@ -31,6 +31,21 @@ typedef BackgroundTaskHandler = Future<bool> Function(
   Map<String, dynamic>? inputData,
 );
 
+/// Signature of the handler invoked when the page sends a free-form message
+/// to the background worker (see `WorkmanagerWeb.sendMessageToWorker`).
+///
+/// The handler runs in the same context as the task handler (Web Worker,
+/// Service Worker or in-page fallback), so it must stay Flutter-free too.
+typedef WorkerMessageHandler = void Function(Object? payload);
+
+/// Signature used by dispatcher code to push a free-form message back to the
+/// page while a task or message handler is running.
+///
+/// The page receives it on `WorkmanagerWeb.workerMessages`. In the Service
+/// Worker context the message is delivered to open pages via
+/// `clients.postMessage`; when no page is open it is dropped.
+typedef PageMessageSender = void Function(Object? payload);
+
 /// Shared registry that holds the currently registered background task
 /// handler.
 ///
@@ -45,6 +60,21 @@ class WorkmanagerExecution {
 
   /// The handler registered by the most recent [executeTask] call.
   BackgroundTaskHandler? taskHandler;
+
+  /// The handler invoked when the page sends a message to the worker.
+  ///
+  /// Registered by the callback dispatcher (mirrors [executeTask]); the Web
+  /// Worker and Service Worker runtimes route page messages here.
+  WorkerMessageHandler? messageHandler;
+
+  /// Sends a message back to the page, when a page is reachable.
+  ///
+  /// Wired by the runtime: the compiled worker bundle sets it to post to the
+  /// owning page (or to open pages via `clients.postMessage` in the Service
+  /// Worker context); the page sets it for the in-page fallback path. Dispatcher
+  /// code can call this at any time; the page observes the message on
+  /// `WorkmanagerWeb.workerMessages`.
+  PageMessageSender? sendToPage;
 
   /// The callback dispatcher passed to `WorkmanagerWeb().initialize(...)`.
   ///

--- a/workmanager_web/lib/src/worker_protocol.dart
+++ b/workmanager_web/lib/src/worker_protocol.dart
@@ -18,7 +18,16 @@ abstract final class WorkerProtocol {
   /// Worker -> page: task finished (or failed).
   static const String typeResult = 'result';
 
+  /// Page -> worker: a free-form message for the dispatcher's message
+  /// handler (`WorkmanagerExecution.messageHandler`).
+  static const String typeMessage = 'message';
+
+  /// Worker -> page: a free-form message sent by the dispatcher via
+  /// `WorkmanagerExecution.sendToPage`.
+  static const String typeWorkerMessage = 'workerMessage';
+
   static const String fieldRequestId = 'requestId';
+  static const String fieldPayload = 'payload';
   static const String fieldTaskName = 'taskName';
   static const String fieldInputData = 'inputData';
   static const String fieldResult = 'result';
@@ -69,6 +78,40 @@ abstract final class WorkerProtocol {
       fieldResult: result,
       fieldError: error,
     };
+  }
+
+  /// Builds a page -> worker `message` message.
+  static Map<String, Object?> encodeMessage(Object? payload) {
+    return <String, Object?>{
+      'type': typeMessage,
+      fieldPayload: payload,
+    };
+  }
+
+  /// Parses a page -> worker `message` message. Returns `null` when [raw] is
+  /// not of that type.
+  static Object? decodeMessage(Map<Object?, Object?> raw) {
+    if (raw['type'] != typeMessage) {
+      return null;
+    }
+    return raw[fieldPayload];
+  }
+
+  /// Builds a worker -> page `workerMessage` message.
+  static Map<String, Object?> encodeWorkerMessage(Object? payload) {
+    return <String, Object?>{
+      'type': typeWorkerMessage,
+      fieldPayload: payload,
+    };
+  }
+
+  /// Parses a worker -> page `workerMessage` message. Returns `null` when
+  /// [raw] is not of that type.
+  static Object? decodeWorkerMessage(Map<Object?, Object?> raw) {
+    if (raw['type'] != typeWorkerMessage) {
+      return null;
+    }
+    return raw[fieldPayload];
   }
 
   /// Parses a `result` message. Returns `null` when [raw] is malformed.

--- a/workmanager_web/lib/src/worker_runtime_web.dart
+++ b/workmanager_web/lib/src/worker_runtime_web.dart
@@ -46,6 +46,7 @@ class WorkmanagerWebWorker {
         }
       }).toJS,
     );
+    _wirePageMessaging();
     // The page waits for this message before routing work to the worker. It
     // is a harmless no-op inside a Service Worker global.
     self.callMethod(
@@ -54,7 +55,61 @@ class WorkmanagerWebWorker {
     );
   }
 
+  /// Wires `WorkmanagerExecution.sendToPage` so dispatcher code can push
+  /// messages back to the page from either execution context:
+  ///
+  /// * **Dedicated Web Worker**: `self.postMessage` delivers directly to the
+  ///   page that spawned the worker.
+  /// * **Service Worker global**: there is no `postMessage` on the SW global;
+  ///   messages are delivered to every open page via `clients.postMessage`.
+  ///   When no page is open they are dropped (persistent results still flow
+  ///   through the IndexedDB event log).
+  static void _wirePageMessaging() {
+    final self = globalContext;
+    final execution = WorkmanagerExecution.instance;
+    if (self.has('clients')) {
+      execution.sendToPage = (Object? payload) {
+        final message = WorkerProtocol.encodeWorkerMessage(payload).jsify();
+        final clients = self['clients'] as JSObject;
+        final promise = clients.callMethod(
+          'matchAll'.toJS,
+          <String, Object?>{
+            'type': 'window'.toJS,
+            'includeUncontrolled': true,
+          }.jsify(),
+        ) as JSPromise<JSAny?>;
+        promise.toDart.then((Object? result) {
+          if (result is! List) {
+            return;
+          }
+          for (final client in result) {
+            if (client is JSObject) {
+              client.callMethod('postMessage'.toJS, message);
+            }
+          }
+        });
+      };
+    } else {
+      execution.sendToPage = (Object? payload) {
+        self.callMethod(
+          'postMessage'.toJS,
+          WorkerProtocol.encodeWorkerMessage(payload).jsify(),
+        );
+      };
+    }
+  }
+
   static void _handleMessage(Map<Object?, Object?> raw) {
+    // Free-form page -> worker messages go to the dispatcher's message
+    // handler (when one is registered).
+    final message = WorkerProtocol.decodeMessage(raw);
+    if (message != null || raw['type'] == WorkerProtocol.typeMessage) {
+      final handler = WorkmanagerExecution.instance.messageHandler;
+      if (handler != null) {
+        handler(message);
+      }
+      return;
+    }
     final request = WorkerProtocol.decodeExecuteTask(raw);
     if (request == null) {
       return;

--- a/workmanager_web/lib/workmanager_web.dart
+++ b/workmanager_web/lib/workmanager_web.dart
@@ -146,6 +146,8 @@ class WorkmanagerWeb extends WorkmanagerPlatform {
 
   final StreamController<WorkmanagerWebEvent> _events =
       StreamController<WorkmanagerWebEvent>.broadcast();
+  final StreamController<Object?> _workerMessages =
+      StreamController<Object?>.broadcast();
   final Map<String, _RegisteredTask> _tasks = <String, _RegisteredTask>{};
   final Map<String, Timer> _oneOffTimers = <String, Timer>{};
   final Map<int, Completer<Object?>> _pendingWorkerRequests =
@@ -161,6 +163,16 @@ class WorkmanagerWeb extends WorkmanagerPlatform {
   /// Live stream of background-execution events, including events replayed
   /// from the Service Worker after the page was closed.
   Stream<WorkmanagerWebEvent> get backgroundEvents => _events.stream;
+
+  /// Live stream of free-form messages pushed by the background worker (or,
+  /// on the in-page fallback path, by the dispatcher running in the page).
+  ///
+  /// Dispatcher code sends messages via
+  /// `WorkmanagerExecution.instance.sendToPage`. Messages from a Service
+  /// Worker execution are delivered to open pages via `clients.postMessage`;
+  /// when no page is open they are dropped (persistent task results still
+  /// arrive through [backgroundEvents] on the next load).
+  Stream<Object?> get workerMessages => _workerMessages.stream;
 
   @override
   Future<void> initialize(
@@ -210,6 +222,15 @@ class WorkmanagerWeb extends WorkmanagerPlatform {
     if (useWebWorker) {
       _initializeWebWorker(resolvedDispatcherUrl);
     }
+
+    // In-page fallback path: when no Web Worker is available the dispatcher
+    // runs inside the page itself, so its `sendToPage` calls must surface on
+    // the page's [workerMessages] stream instead of posting to a worker.
+    WorkmanagerExecution.instance.sendToPage = (Object? payload) {
+      if (!_workerMessages.isClosed) {
+        _workerMessages.add(payload);
+      }
+    };
 
     await _syncTasksToServiceWorker();
   }
@@ -393,6 +414,25 @@ class WorkmanagerWeb extends WorkmanagerPlatform {
   }) async {
     _checkInitialized();
     await _runTask(taskName, inputData, 'trigger');
+  }
+
+  /// Sends a free-form message to the background worker's dispatcher.
+  ///
+  /// The message is delivered to the handler registered with
+  /// `WorkmanagerExecution.instance.messageHandler` in the compiled dispatcher
+  /// bundle. When no Web Worker is available the message is delivered
+  /// directly to the in-page dispatcher instead. The call never throws for
+  /// missing handlers — it is fire-and-forget, like `postMessage`.
+  void sendMessageToWorker(Object? payload) {
+    _checkInitialized();
+    if (_worker != null && !_workerFailed) {
+      BrowserGlue.workerPostMessage(
+        _worker,
+        WorkerProtocol.encodeMessage(payload),
+      );
+      return;
+    }
+    WorkmanagerExecution.instance.messageHandler?.call(payload);
   }
 
   Future<void> _initializeServiceWorker(
@@ -610,7 +650,15 @@ class WorkmanagerWeb extends WorkmanagerPlatform {
     if (raw is! Map) {
       return;
     }
-    final result = WorkerProtocol.decodeResult(raw.cast<Object?, Object?>());
+    final map = raw.cast<Object?, Object?>();
+    final message = WorkerProtocol.decodeWorkerMessage(map);
+    if (message != null || map['type'] == WorkerProtocol.typeWorkerMessage) {
+      if (!_workerMessages.isClosed) {
+        _workerMessages.add(message);
+      }
+      return;
+    }
+    final result = WorkerProtocol.decodeResult(map);
     if (result == null) {
       return;
     }
@@ -670,6 +718,13 @@ class WorkmanagerWeb extends WorkmanagerPlatform {
         final event = map['event'];
         if (event is Map) {
           _emitEventFromMap(event.cast<Object?, Object?>());
+        }
+      case 'workerMessage':
+        // Free-form message pushed by the dispatcher bundle while running in
+        // the Service Worker global (delivered via clients.postMessage).
+        final payload = map['payload'];
+        if (!_workerMessages.isClosed) {
+          _workerMessages.add(payload);
         }
     }
   }

--- a/workmanager_web/lib/workmanager_web.dart
+++ b/workmanager_web/lib/workmanager_web.dart
@@ -123,7 +123,7 @@ class WorkmanagerWeb extends WorkmanagerPlatform {
     WorkmanagerPlatform.instance = WorkmanagerWeb();
   }
 
-  /// Default Service Worker script URL, relative to the app origin.
+  /// Default Service Worker script URL, relative to the app's base path.
   ///
   /// Copy `workmanager_service_worker.js` from this package's `web/` folder
   /// into your app's `web/` folder so it is served from this path.
@@ -136,6 +136,20 @@ class WorkmanagerWeb extends WorkmanagerPlatform {
   /// `dart compile js -O2 web/background.dart -o web/background.dart.js` and
   /// commit the output next to your app's `web/` folder.
   static const String defaultDispatcherUrl = '/background.dart.js';
+
+  /// Resolves a user-supplied or default script URL against the app's base
+  /// URI, so deployments under a subpath (e.g. GitHub Pages project sites)
+  /// resolve the defaults correctly while root deployments keep working.
+  static String _resolveScriptUrl(String? url, String defaultUrl) {
+    if (url != null) {
+      return url;
+    }
+    var base = Uri.base;
+    if (!base.path.endsWith('/')) {
+      base = base.replace(path: '${base.path}/');
+    }
+    return base.resolve(defaultUrl.substring(1)).toString();
+  }
 
   /// Chrome's minimum Periodic Background Sync interval.
   ///
@@ -196,7 +210,8 @@ class WorkmanagerWeb extends WorkmanagerPlatform {
     _initialized = true;
     WorkmanagerExecution.instance.callbackDispatcher = callbackDispatcher;
 
-    final resolvedDispatcherUrl = dispatcherUrl ?? defaultDispatcherUrl;
+    final resolvedDispatcherUrl =
+        _resolveScriptUrl(dispatcherUrl, defaultDispatcherUrl);
     _emit(
       'info',
       'workmanager_web initialized. '
@@ -206,7 +221,7 @@ class WorkmanagerWeb extends WorkmanagerPlatform {
 
     if (BrowserGlue.supportsServiceWorker) {
       await _initializeServiceWorker(
-        serviceWorkerUrl ?? defaultServiceWorkerUrl,
+        _resolveScriptUrl(serviceWorkerUrl, defaultServiceWorkerUrl),
         resolvedDispatcherUrl,
       );
     } else {

--- a/workmanager_web/test/execution_test.dart
+++ b/workmanager_web/test/execution_test.dart
@@ -54,5 +54,25 @@ void main() {
       );
       expect(execution.normalizeInputData(null), isNull);
     });
+
+    test('messageHandler receives messages sent to the worker', () {
+      final execution = WorkmanagerExecution.instance;
+      Object? received;
+      execution.messageHandler = (Object? payload) {
+        received = payload;
+      };
+      execution.messageHandler?.call(<String, Object?>{'op': 'watch'});
+      expect(received, <String, Object?>{'op': 'watch'});
+    });
+
+    test('sendToPage delivers messages back to the page', () {
+      final execution = WorkmanagerExecution.instance;
+      Object? delivered;
+      execution.sendToPage = (Object? payload) {
+        delivered = payload;
+      };
+      execution.sendToPage?.call(<String, Object?>{'kind': 'tick'});
+      expect(delivered, <String, Object?>{'kind': 'tick'});
+    });
   });
 }

--- a/workmanager_web/test/web_worker_integration_test.dart
+++ b/workmanager_web/test/web_worker_integration_test.dart
@@ -48,6 +48,38 @@ self.onmessage = (event) => {
     expect(decoded.error, isNull);
     expect(decoded.result, 'ok:demoTask:{"a":1,"b":"two"}');
   });
+
+  test('free-form messages round-trip in a real Web Worker', () async {
+    final workerUrl = _createBlobWorkerUrl('''
+self.onmessage = (event) => {
+  const data = event.data || {};
+  if (data.type === 'message') {
+    self.postMessage({
+      type: 'workerMessage',
+      payload: { kind: 'echo', text: data.payload.text },
+    });
+  }
+};
+''');
+    final worker = _createWorker(workerUrl);
+    addTearDown(() => worker.callMethod('terminate'.toJS));
+
+    final reply = await _postAndAwait(
+      worker,
+      WorkerProtocol.encodeMessage(<String, Object?>{
+        'text': 'hello worker',
+      }),
+    );
+
+    expect(reply, isA<Map>());
+    final decoded = WorkerProtocol.decodeWorkerMessage(
+      (reply! as Map).cast<Object?, Object?>(),
+    );
+    expect(
+      decoded,
+      <String, Object?>{'kind': 'echo', 'text': 'hello worker'},
+    );
+  });
 }
 
 String _createBlobWorkerUrl(String code) {

--- a/workmanager_web/test/worker_protocol_test.dart
+++ b/workmanager_web/test/worker_protocol_test.dart
@@ -68,5 +68,60 @@ void main() {
       );
       expect(decoded!.error, 'boom');
     });
+
+    test('message encodes and decodes round-trip', () {
+      final encoded = WorkerProtocol.encodeMessage(<String, Object?>{
+        'op': 'watch',
+        'ticker': 'btc',
+      });
+      expect(encoded['type'], WorkerProtocol.typeMessage);
+      final decoded = WorkerProtocol.decodeMessage(
+        encoded.cast<Object?, Object?>(),
+      );
+      expect(
+        decoded,
+        <String, Object?>{'op': 'watch', 'ticker': 'btc'},
+      );
+    });
+
+    test('message round-trips a null payload', () {
+      final encoded = WorkerProtocol.encodeMessage(null);
+      final decoded = WorkerProtocol.decodeMessage(
+        encoded.cast<Object?, Object?>(),
+      );
+      expect(decoded, isNull);
+      // The type is still recognisable even when the payload is null.
+      expect(encoded['type'], WorkerProtocol.typeMessage);
+    });
+
+    test('workerMessage encodes and decodes round-trip', () {
+      final encoded = WorkerProtocol.encodeWorkerMessage(<String, Object?>{
+        'kind': 'tick',
+        'price': 59123.45,
+      });
+      expect(encoded['type'], WorkerProtocol.typeWorkerMessage);
+      final decoded = WorkerProtocol.decodeWorkerMessage(
+        encoded.cast<Object?, Object?>(),
+      );
+      expect(
+        decoded,
+        <String, Object?>{'kind': 'tick', 'price': 59123.45},
+      );
+    });
+
+    test('decodeMessage and decodeWorkerMessage reject other types', () {
+      expect(
+        WorkerProtocol.decodeMessage(<Object?, Object?>{
+          'type': WorkerProtocol.typeResult,
+        }),
+        isNull,
+      );
+      expect(
+        WorkerProtocol.decodeWorkerMessage(<Object?, Object?>{
+          'type': WorkerProtocol.typeExecuteTask,
+        }),
+        isNull,
+      );
+    });
   });
 }


### PR DESCRIPTION
## Summary
Adds free-form two-way messaging between the app and the background worker on web, complementing request/response task execution.

- `WorkerProtocol`: new `message` (page -> worker) and `workerMessage` (worker -> page) wire types
- `WorkmanagerExecution`: `messageHandler` + `sendToPage` hooks on the Flutter-free dispatcher side
- `WorkmanagerWebWorker` runtime: routes messages and wires `sendToPage` for both the dedicated Web Worker (`postMessage`) and the Service Worker (`clients.postMessage`)
- `WorkmanagerWeb`: `sendMessageToWorker()` + `workerMessages` stream, including the in-page fallback path
- Example: live worker chat with a simulated price-watch use case; demo UI simplified (tabs, auto-registered task)

No IsolateNameServer equivalent exists on web — this is the postMessage/IndexedDB communication model.

## Verification
- `dart analyze` clean (package + example)
- 19 VM tests + 2 real-Chrome Web Worker round-trip tests pass (incl. new message type)
- `flutter build web` builds; `web/background.dart.js` rebuilt