### PR TITLE
feat(android): add ContentUriTrigger constraints (fixes #413)

### DIFF
--- a/docs/customization.mdx
+++ b/docs/customization.mdx
@@ -83,6 +83,30 @@ constraints: Constraints(
 )
 ```
 
+### Content URI Triggers (Android only)
+
+Run a task when a content URI changes (for example when the user takes a new photo):
+
+```dart
+Workmanager().registerOneOffTask(
+  "process-new-photos",
+  "photo_processor",
+  constraints: Constraints(
+    contentUriTriggers: [
+      ContentUriTrigger(
+        uri: 'content://media/external/images/media',
+        triggerForDescendants: true,
+      ),
+    ],
+  ),
+);
+```
+
+- Mirrors WorkManager's `Constraints.Builder.addContentUriTrigger`.
+- **Android only** and requires Android 7.0 (API 24)+; on older versions the triggers are ignored.
+- The observing app needs permission to read the content URI it observes.
+- WorkManager limits how many content-URI-triggered workers can be enqueued at once (default 8).
+
 <Warning>
 **Platform Differences:** Some constraints are Android-only. iOS background tasks have different system-level constraints that cannot be configured directly, and macOS (`NSBackgroundActivityScheduler`) ignores all constraints.
 </Warning>

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -26,6 +26,8 @@ const rescheduledTaskKey =
 const failedTaskKey = "dev.fluttercommunity.workmanagerExample.failedTask";
 const simpleDelayedTask =
     "dev.fluttercommunity.workmanagerExample.simpleDelayedTask";
+const contentUriTaskKey =
+    "dev.fluttercommunity.workmanagerExample.contentUriTask";
 const simplePeriodicTask =
     "dev.fluttercommunity.workmanagerExample.simplePeriodicTask";
 const simplePeriodic1HourTask =
@@ -42,6 +44,7 @@ final List<String> allTasks = [
   rescheduledTaskKey,
   failedTaskKey,
   simpleDelayedTask,
+  contentUriTaskKey,
   simplePeriodicTask,
   simplePeriodic1HourTask,
   iOSBackgroundAppRefresh,
@@ -81,6 +84,10 @@ void callbackDispatcher() {
         return Future.error('failed');
       case simpleDelayedTask:
         debugPrint("$simpleDelayedTask was executed");
+        break;
+      case contentUriTaskKey:
+        debugPrint(
+            "$contentUriTaskKey was executed after a content URI change");
         break;
       case simplePeriodicTask:
         debugPrint("$simplePeriodicTask was executed");
@@ -227,6 +234,27 @@ class _MyAppState extends State<MyApp> {
                         initialDelay: Duration(seconds: 10),
                       );
                     }),
+                // This task runs when a content URI changes (Android only).
+                // A change to any image in the media store triggers it.
+                ElevatedButton(
+                  onPressed: Platform.isAndroid
+                      ? () {
+                          Workmanager().registerOneOffTask(
+                            contentUriTaskKey,
+                            contentUriTaskKey,
+                            constraints: Constraints(
+                              contentUriTriggers: [
+                                ContentUriTrigger(
+                                  uri: 'content://media/external/images/media',
+                                  triggerForDescendants: true,
+                                ),
+                              ],
+                            ),
+                          );
+                        }
+                      : null,
+                  child: Text("Register Content URI Task (Android)"),
+                ),
                 SizedBox(height: 8),
                 Text(
                   "Register periodic task (android only)",

--- a/workmanager_android/android/build.gradle
+++ b/workmanager_android/android/build.gradle
@@ -58,4 +58,6 @@ dependencies {
     testImplementation "org.mockito.kotlin:mockito-kotlin:4.1.0"
     // Real org.json implementation for JVM unit tests (android.jar only stubs it).
     testImplementation 'org.json:json:20240303'
+    // Real Android framework implementations (Build, Uri, ...) for JVM unit tests.
+    testImplementation 'org.robolectric:robolectric:4.16.1'
 }

--- a/workmanager_android/android/src/main/kotlin/dev/fluttercommunity/workmanager/WorkManagerUtils.kt
+++ b/workmanager_android/android/src/main/kotlin/dev/fluttercommunity/workmanager/WorkManagerUtils.kt
@@ -1,6 +1,7 @@
 package dev.fluttercommunity.workmanager
 
 import android.content.Context
+import android.net.Uri
 import android.os.Build
 import androidx.work.BackoffPolicy
 import androidx.work.Constraints
@@ -108,7 +109,7 @@ private fun dev.fluttercommunity.workmanager.pigeon.OutOfQuotaPolicy.toAndroidOu
         dev.fluttercommunity.workmanager.pigeon.OutOfQuotaPolicy.DROP_WORK_REQUEST -> OutOfQuotaPolicy.DROP_WORK_REQUEST
     }
 
-private fun dev.fluttercommunity.workmanager.pigeon.Constraints.toAndroidConstraints(): Constraints {
+internal fun dev.fluttercommunity.workmanager.pigeon.Constraints.toAndroidConstraints(): Constraints {
     val builder = Constraints.Builder()
 
     networkType?.let { builder.setRequiredNetworkType(it.toAndroidNetworkType()) }
@@ -120,9 +121,22 @@ private fun dev.fluttercommunity.workmanager.pigeon.Constraints.toAndroidConstra
         }
     }
     requiresStorageNotLow?.let { builder.setRequiresStorageNotLow(it) }
+    contentUriTriggers?.forEach { trigger ->
+        trigger?.let {
+            if (isContentUriTriggerSupported()) {
+                builder.addContentUriTrigger(Uri.parse(it.uri), it.triggerForDescendants)
+            }
+        }
+    }
 
     return builder.build()
 }
+
+/**
+ * Content URI trigger constraints are only supported on Android 7.0 (API 24)+;
+ * on older versions JobScheduler silently drops them.
+ */
+internal fun isContentUriTriggerSupported(sdkInt: Int = Build.VERSION.SDK_INT): Boolean = sdkInt >= Build.VERSION_CODES.N
 
 private fun dev.fluttercommunity.workmanager.pigeon.NetworkType.toAndroidNetworkType(): NetworkType =
     when (this) {

--- a/workmanager_android/android/src/main/kotlin/dev/fluttercommunity/workmanager/pigeon/WorkmanagerApi.g.kt
+++ b/workmanager_android/android/src/main/kotlin/dev/fluttercommunity/workmanager/pigeon/WorkmanagerApi.g.kt
@@ -488,7 +488,22 @@ data class Constraints (
   val requiresBatteryNotLow: Boolean? = null,
   val requiresCharging: Boolean? = null,
   val requiresDeviceIdle: Boolean? = null,
-  val requiresStorageNotLow: Boolean? = null
+  val requiresStorageNotLow: Boolean? = null,
+  /**
+   * Content URI triggers that run the work when the observed content URIs
+   * change (Android only).
+   *
+   * Mirrors WorkManager's `Constraints.Builder.addContentUriTrigger`:
+   * https://developer.android.com/reference/androidx/work/Constraints.Builder#addContentUriTrigger(android.net.Uri,%20boolean)
+   *
+   * Requires Android 7.0 (API 24)+; on older Android versions the triggers
+   * are ignored. WorkManager also limits how many content-URI-triggered
+   * workers can be enqueued at once (default 8, configurable via
+   * `Configuration.Builder.setContentUriTriggerWorkersLimit`).
+   *
+   * Other platforms ignore this field.
+   */
+  val contentUriTriggers: List<ContentUriTrigger?>? = null
 )
  {
   companion object {
@@ -498,7 +513,8 @@ data class Constraints (
       val requiresCharging = pigeonVar_list[2] as Boolean?
       val requiresDeviceIdle = pigeonVar_list[3] as Boolean?
       val requiresStorageNotLow = pigeonVar_list[4] as Boolean?
-      return Constraints(networkType, requiresBatteryNotLow, requiresCharging, requiresDeviceIdle, requiresStorageNotLow)
+      val contentUriTriggers = pigeonVar_list[5] as List<ContentUriTrigger?>?
+      return Constraints(networkType, requiresBatteryNotLow, requiresCharging, requiresDeviceIdle, requiresStorageNotLow, contentUriTriggers)
     }
   }
   fun toList(): List<Any?> {
@@ -508,6 +524,7 @@ data class Constraints (
       requiresCharging,
       requiresDeviceIdle,
       requiresStorageNotLow,
+      contentUriTriggers,
     )
   }
   override fun equals(other: Any?): Boolean {
@@ -518,7 +535,7 @@ data class Constraints (
       return true
     }
     val other = other as Constraints
-    return WorkmanagerApiPigeonUtils.deepEquals(this.networkType, other.networkType) && WorkmanagerApiPigeonUtils.deepEquals(this.requiresBatteryNotLow, other.requiresBatteryNotLow) && WorkmanagerApiPigeonUtils.deepEquals(this.requiresCharging, other.requiresCharging) && WorkmanagerApiPigeonUtils.deepEquals(this.requiresDeviceIdle, other.requiresDeviceIdle) && WorkmanagerApiPigeonUtils.deepEquals(this.requiresStorageNotLow, other.requiresStorageNotLow)
+    return WorkmanagerApiPigeonUtils.deepEquals(this.networkType, other.networkType) && WorkmanagerApiPigeonUtils.deepEquals(this.requiresBatteryNotLow, other.requiresBatteryNotLow) && WorkmanagerApiPigeonUtils.deepEquals(this.requiresCharging, other.requiresCharging) && WorkmanagerApiPigeonUtils.deepEquals(this.requiresDeviceIdle, other.requiresDeviceIdle) && WorkmanagerApiPigeonUtils.deepEquals(this.requiresStorageNotLow, other.requiresStorageNotLow) && WorkmanagerApiPigeonUtils.deepEquals(this.contentUriTriggers, other.contentUriTriggers)
   }
 
   override fun hashCode(): Int {
@@ -528,6 +545,60 @@ data class Constraints (
     result = 31 * result + WorkmanagerApiPigeonUtils.deepHash(this.requiresCharging)
     result = 31 * result + WorkmanagerApiPigeonUtils.deepHash(this.requiresDeviceIdle)
     result = 31 * result + WorkmanagerApiPigeonUtils.deepHash(this.requiresStorageNotLow)
+    result = 31 * result + WorkmanagerApiPigeonUtils.deepHash(this.contentUriTriggers)
+    return result
+  }
+}
+
+/**
+ * A single content URI trigger for Android WorkManager constraints.
+ *
+ * When [uri] is updated, inserted or deleted by the system or another app,
+ * the work associated with the constraint is run.
+ *
+ * Mirrors WorkManager's `ContentUriTrigger`:
+ * https://developer.android.com/reference/androidx/work/ContentUriTrigger
+ *
+ * Generated class from Pigeon that represents data sent in messages.
+ */
+data class ContentUriTrigger (
+  /**
+   * The local `content:` Uri to observe for changes, e.g.
+   * `content://media/external/images/media`.
+   */
+  val uri: String,
+  /** Whether changes to any descendant of [uri] also run the work. */
+  val triggerForDescendants: Boolean
+)
+ {
+  companion object {
+    fun fromList(pigeonVar_list: List<Any?>): ContentUriTrigger {
+      val uri = pigeonVar_list[0] as String
+      val triggerForDescendants = pigeonVar_list[1] as Boolean
+      return ContentUriTrigger(uri, triggerForDescendants)
+    }
+  }
+  fun toList(): List<Any?> {
+    return listOf(
+      uri,
+      triggerForDescendants,
+    )
+  }
+  override fun equals(other: Any?): Boolean {
+    if (other == null || other.javaClass != javaClass) {
+      return false
+    }
+    if (this === other) {
+      return true
+    }
+    val other = other as ContentUriTrigger
+    return WorkmanagerApiPigeonUtils.deepEquals(this.uri, other.uri) && WorkmanagerApiPigeonUtils.deepEquals(this.triggerForDescendants, other.triggerForDescendants)
+  }
+
+  override fun hashCode(): Int {
+    var result = javaClass.hashCode()
+    result = 31 * result + WorkmanagerApiPigeonUtils.deepHash(this.uri)
+    result = 31 * result + WorkmanagerApiPigeonUtils.deepHash(this.triggerForDescendants)
     return result
   }
 }
@@ -957,35 +1028,40 @@ private open class WorkmanagerApiPigeonCodec : StandardMessageCodec() {
       }
       138.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          BackoffPolicyConfig.fromList(it)
+          ContentUriTrigger.fromList(it)
         }
       }
       139.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          InitializeRequest.fromList(it)
+          BackoffPolicyConfig.fromList(it)
         }
       }
       140.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          OneOffTaskRequest.fromList(it)
+          InitializeRequest.fromList(it)
         }
       }
       141.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          PeriodicTaskRequest.fromList(it)
+          OneOffTaskRequest.fromList(it)
         }
       }
       142.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          ProcessingTaskRequest.fromList(it)
+          PeriodicTaskRequest.fromList(it)
         }
       }
       143.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          HealthResearchTaskRequest.fromList(it)
+          ProcessingTaskRequest.fromList(it)
         }
       }
       144.toByte() -> {
+        return (readValue(buffer) as? List<Any?>)?.let {
+          HealthResearchTaskRequest.fromList(it)
+        }
+      }
+      145.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
           ContinuedProcessingTaskRequest.fromList(it)
         }
@@ -1031,32 +1107,36 @@ private open class WorkmanagerApiPigeonCodec : StandardMessageCodec() {
         stream.write(137)
         writeValue(stream, value.toList())
       }
-      is BackoffPolicyConfig -> {
+      is ContentUriTrigger -> {
         stream.write(138)
         writeValue(stream, value.toList())
       }
-      is InitializeRequest -> {
+      is BackoffPolicyConfig -> {
         stream.write(139)
         writeValue(stream, value.toList())
       }
-      is OneOffTaskRequest -> {
+      is InitializeRequest -> {
         stream.write(140)
         writeValue(stream, value.toList())
       }
-      is PeriodicTaskRequest -> {
+      is OneOffTaskRequest -> {
         stream.write(141)
         writeValue(stream, value.toList())
       }
-      is ProcessingTaskRequest -> {
+      is PeriodicTaskRequest -> {
         stream.write(142)
         writeValue(stream, value.toList())
       }
-      is HealthResearchTaskRequest -> {
+      is ProcessingTaskRequest -> {
         stream.write(143)
         writeValue(stream, value.toList())
       }
-      is ContinuedProcessingTaskRequest -> {
+      is HealthResearchTaskRequest -> {
         stream.write(144)
+        writeValue(stream, value.toList())
+      }
+      is ContinuedProcessingTaskRequest -> {
+        stream.write(145)
         writeValue(stream, value.toList())
       }
       else -> super.writeValue(stream, value)

--- a/workmanager_android/android/src/test/kotlin/dev/fluttercommunity/workmanager/ConstraintsMappingTest.kt
+++ b/workmanager_android/android/src/test/kotlin/dev/fluttercommunity/workmanager/ConstraintsMappingTest.kt
@@ -1,0 +1,85 @@
+package dev.fluttercommunity.workmanager
+
+import android.net.Uri
+import dev.fluttercommunity.workmanager.pigeon.ContentUriTrigger
+import dev.fluttercommunity.workmanager.pigeon.NetworkType
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [26])
+class ConstraintsMappingTest {
+    @Test
+    fun `content uri triggers map to androidx constraints`() {
+        val pigeonConstraints =
+            dev.fluttercommunity.workmanager.pigeon.Constraints(
+                contentUriTriggers =
+                    listOf(
+                        ContentUriTrigger(
+                            uri = "content://media/external/images/media",
+                            triggerForDescendants = true,
+                        ),
+                    ),
+            )
+
+        val androidConstraints = pigeonConstraints.toAndroidConstraints()
+
+        assertTrue(androidConstraints.hasContentUriTriggers())
+        val trigger = androidConstraints.contentUriTriggers.single()
+        assertEquals(Uri.parse("content://media/external/images/media"), trigger.uri)
+        assertTrue(trigger.isTriggeredForDescendants)
+    }
+
+    @Test
+    fun `multiple triggers with mixed descendant flags are preserved`() {
+        val pigeonConstraints =
+            dev.fluttercommunity.workmanager.pigeon.Constraints(
+                contentUriTriggers =
+                    listOf(
+                        ContentUriTrigger(
+                            uri = "content://media/external/images/media",
+                            triggerForDescendants = true,
+                        ),
+                        ContentUriTrigger(
+                            uri = "content://com.example.provider/items",
+                            triggerForDescendants = false,
+                        ),
+                    ),
+            )
+
+        val androidConstraints = pigeonConstraints.toAndroidConstraints()
+
+        assertEquals(2, androidConstraints.contentUriTriggers.size)
+        val byUri = androidConstraints.contentUriTriggers.associateBy { it.uri }
+        assertTrue(byUri.getValue(Uri.parse("content://media/external/images/media")).isTriggeredForDescendants)
+        assertFalse(byUri.getValue(Uri.parse("content://com.example.provider/items")).isTriggeredForDescendants)
+    }
+
+    @Test
+    fun `constraints without content uri triggers map no triggers`() {
+        val pigeonConstraints =
+            dev.fluttercommunity.workmanager.pigeon.Constraints(
+                networkType = NetworkType.CONNECTED,
+                requiresCharging = true,
+            )
+
+        val androidConstraints = pigeonConstraints.toAndroidConstraints()
+
+        assertFalse(androidConstraints.hasContentUriTriggers())
+        assertEquals(androidx.work.NetworkType.CONNECTED, androidConstraints.requiredNetworkType)
+        assertTrue(androidConstraints.requiresCharging())
+    }
+
+    @Test
+    fun `content uri triggers require API 24`() {
+        // JobScheduler silently drops content URI triggers below Android 7.0 (API 24).
+        assertFalse(isContentUriTriggerSupported(sdkInt = 23))
+        assertTrue(isContentUriTriggerSupported(sdkInt = 24))
+        assertTrue(isContentUriTriggerSupported(sdkInt = 35))
+    }
+}

--- a/workmanager_android/test/workmanager_android_test.dart
+++ b/workmanager_android/test/workmanager_android_test.dart
@@ -171,6 +171,34 @@ void main() {
         expect(androidConstraints.requiresDeviceIdle, false);
         expect(androidConstraints.requiresStorageNotLow, true);
       });
+
+      test('should support Android content URI trigger constraints', () {
+        final constraints = Constraints(
+          contentUriTriggers: [
+            ContentUriTrigger(
+              uri: 'content://media/external/images/media',
+              triggerForDescendants: true,
+            ),
+            ContentUriTrigger(
+              uri: 'content://com.example.provider/items',
+              triggerForDescendants: false,
+            ),
+          ],
+        );
+
+        final triggers = constraints.contentUriTriggers!;
+        expect(triggers, hasLength(2));
+        expect(triggers[0]!.uri, 'content://media/external/images/media');
+        expect(triggers[0]!.triggerForDescendants, true);
+        expect(triggers[1]!.uri, 'content://com.example.provider/items');
+        expect(triggers[1]!.triggerForDescendants, false);
+      });
+
+      test('should default content uri triggers to null', () {
+        final constraints = Constraints(requiresCharging: true);
+
+        expect(constraints.contentUriTriggers, isNull);
+      });
     });
 
     group('Error handling and edge cases', () {

--- a/workmanager_apple/ios/workmanager_apple/Sources/workmanager_apple/pigeon/WorkmanagerApi.g.swift
+++ b/workmanager_apple/ios/workmanager_apple/Sources/workmanager_apple/pigeon/WorkmanagerApi.g.swift
@@ -392,6 +392,19 @@ struct Constraints: Hashable {
   var requiresCharging: Bool? = nil
   var requiresDeviceIdle: Bool? = nil
   var requiresStorageNotLow: Bool? = nil
+  /// Content URI triggers that run the work when the observed content URIs
+  /// change (Android only).
+  ///
+  /// Mirrors WorkManager's `Constraints.Builder.addContentUriTrigger`:
+  /// https://developer.android.com/reference/androidx/work/Constraints.Builder#addContentUriTrigger(android.net.Uri,%20boolean)
+  ///
+  /// Requires Android 7.0 (API 24)+; on older Android versions the triggers
+  /// are ignored. WorkManager also limits how many content-URI-triggered
+  /// workers can be enqueued at once (default 8, configurable via
+  /// `Configuration.Builder.setContentUriTriggerWorkersLimit`).
+  ///
+  /// Other platforms ignore this field.
+  var contentUriTriggers: [ContentUriTrigger?]? = nil
 
 
   // swift-format-ignore: AlwaysUseLowerCamelCase
@@ -401,13 +414,15 @@ struct Constraints: Hashable {
     let requiresCharging: Bool? = nilOrValue(pigeonVar_list[2])
     let requiresDeviceIdle: Bool? = nilOrValue(pigeonVar_list[3])
     let requiresStorageNotLow: Bool? = nilOrValue(pigeonVar_list[4])
+    let contentUriTriggers: [ContentUriTrigger?]? = nilOrValue(pigeonVar_list[5])
 
     return Constraints(
       networkType: networkType,
       requiresBatteryNotLow: requiresBatteryNotLow,
       requiresCharging: requiresCharging,
       requiresDeviceIdle: requiresDeviceIdle,
-      requiresStorageNotLow: requiresStorageNotLow
+      requiresStorageNotLow: requiresStorageNotLow,
+      contentUriTriggers: contentUriTriggers
     )
   }
   func toList() -> [Any?] {
@@ -417,13 +432,14 @@ struct Constraints: Hashable {
       requiresCharging,
       requiresDeviceIdle,
       requiresStorageNotLow,
+      contentUriTriggers,
     ]
   }
   static func == (lhs: Constraints, rhs: Constraints) -> Bool {
     if Swift.type(of: lhs) != Swift.type(of: rhs) {
       return false
     }
-    return deepEqualsWorkmanagerApi(lhs.networkType, rhs.networkType) && deepEqualsWorkmanagerApi(lhs.requiresBatteryNotLow, rhs.requiresBatteryNotLow) && deepEqualsWorkmanagerApi(lhs.requiresCharging, rhs.requiresCharging) && deepEqualsWorkmanagerApi(lhs.requiresDeviceIdle, rhs.requiresDeviceIdle) && deepEqualsWorkmanagerApi(lhs.requiresStorageNotLow, rhs.requiresStorageNotLow)
+    return deepEqualsWorkmanagerApi(lhs.networkType, rhs.networkType) && deepEqualsWorkmanagerApi(lhs.requiresBatteryNotLow, rhs.requiresBatteryNotLow) && deepEqualsWorkmanagerApi(lhs.requiresCharging, rhs.requiresCharging) && deepEqualsWorkmanagerApi(lhs.requiresDeviceIdle, rhs.requiresDeviceIdle) && deepEqualsWorkmanagerApi(lhs.requiresStorageNotLow, rhs.requiresStorageNotLow) && deepEqualsWorkmanagerApi(lhs.contentUriTriggers, rhs.contentUriTriggers)
   }
 
   func hash(into hasher: inout Hasher) {
@@ -433,6 +449,54 @@ struct Constraints: Hashable {
     deepHashWorkmanagerApi(value: requiresCharging, hasher: &hasher)
     deepHashWorkmanagerApi(value: requiresDeviceIdle, hasher: &hasher)
     deepHashWorkmanagerApi(value: requiresStorageNotLow, hasher: &hasher)
+    deepHashWorkmanagerApi(value: contentUriTriggers, hasher: &hasher)
+  }
+}
+
+/// A single content URI trigger for Android WorkManager constraints.
+///
+/// When [uri] is updated, inserted or deleted by the system or another app,
+/// the work associated with the constraint is run.
+///
+/// Mirrors WorkManager's `ContentUriTrigger`:
+/// https://developer.android.com/reference/androidx/work/ContentUriTrigger
+///
+/// Generated class from Pigeon that represents data sent in messages.
+struct ContentUriTrigger: Hashable {
+  /// The local `content:` Uri to observe for changes, e.g.
+  /// `content://media/external/images/media`.
+  var uri: String
+  /// Whether changes to any descendant of [uri] also run the work.
+  var triggerForDescendants: Bool
+
+
+  // swift-format-ignore: AlwaysUseLowerCamelCase
+  static func fromList(_ pigeonVar_list: [Any?]) -> ContentUriTrigger? {
+    let uri = pigeonVar_list[0] as! String
+    let triggerForDescendants = pigeonVar_list[1] as! Bool
+
+    return ContentUriTrigger(
+      uri: uri,
+      triggerForDescendants: triggerForDescendants
+    )
+  }
+  func toList() -> [Any?] {
+    return [
+      uri,
+      triggerForDescendants,
+    ]
+  }
+  static func == (lhs: ContentUriTrigger, rhs: ContentUriTrigger) -> Bool {
+    if Swift.type(of: lhs) != Swift.type(of: rhs) {
+      return false
+    }
+    return deepEqualsWorkmanagerApi(lhs.uri, rhs.uri) && deepEqualsWorkmanagerApi(lhs.triggerForDescendants, rhs.triggerForDescendants)
+  }
+
+  func hash(into hasher: inout Hasher) {
+    hasher.combine("ContentUriTrigger")
+    deepHashWorkmanagerApi(value: uri, hasher: &hasher)
+    deepHashWorkmanagerApi(value: triggerForDescendants, hasher: &hasher)
   }
 }
 
@@ -875,18 +939,20 @@ private class WorkmanagerApiPigeonCodecReader: FlutterStandardReader {
     case 137:
       return Constraints.fromList(self.readValue() as! [Any?])
     case 138:
-      return BackoffPolicyConfig.fromList(self.readValue() as! [Any?])
+      return ContentUriTrigger.fromList(self.readValue() as! [Any?])
     case 139:
-      return InitializeRequest.fromList(self.readValue() as! [Any?])
+      return BackoffPolicyConfig.fromList(self.readValue() as! [Any?])
     case 140:
-      return OneOffTaskRequest.fromList(self.readValue() as! [Any?])
+      return InitializeRequest.fromList(self.readValue() as! [Any?])
     case 141:
-      return PeriodicTaskRequest.fromList(self.readValue() as! [Any?])
+      return OneOffTaskRequest.fromList(self.readValue() as! [Any?])
     case 142:
-      return ProcessingTaskRequest.fromList(self.readValue() as! [Any?])
+      return PeriodicTaskRequest.fromList(self.readValue() as! [Any?])
     case 143:
-      return HealthResearchTaskRequest.fromList(self.readValue() as! [Any?])
+      return ProcessingTaskRequest.fromList(self.readValue() as! [Any?])
     case 144:
+      return HealthResearchTaskRequest.fromList(self.readValue() as! [Any?])
+    case 145:
       return ContinuedProcessingTaskRequest.fromList(self.readValue() as! [Any?])
     default:
       return super.readValue(ofType: type)
@@ -923,26 +989,29 @@ private class WorkmanagerApiPigeonCodecWriter: FlutterStandardWriter {
     } else if let value = value as? Constraints {
       super.writeByte(137)
       super.writeValue(value.toList())
-    } else if let value = value as? BackoffPolicyConfig {
+    } else if let value = value as? ContentUriTrigger {
       super.writeByte(138)
       super.writeValue(value.toList())
-    } else if let value = value as? InitializeRequest {
+    } else if let value = value as? BackoffPolicyConfig {
       super.writeByte(139)
       super.writeValue(value.toList())
-    } else if let value = value as? OneOffTaskRequest {
+    } else if let value = value as? InitializeRequest {
       super.writeByte(140)
       super.writeValue(value.toList())
-    } else if let value = value as? PeriodicTaskRequest {
+    } else if let value = value as? OneOffTaskRequest {
       super.writeByte(141)
       super.writeValue(value.toList())
-    } else if let value = value as? ProcessingTaskRequest {
+    } else if let value = value as? PeriodicTaskRequest {
       super.writeByte(142)
       super.writeValue(value.toList())
-    } else if let value = value as? HealthResearchTaskRequest {
+    } else if let value = value as? ProcessingTaskRequest {
       super.writeByte(143)
       super.writeValue(value.toList())
-    } else if let value = value as? ContinuedProcessingTaskRequest {
+    } else if let value = value as? HealthResearchTaskRequest {
       super.writeByte(144)
+      super.writeValue(value.toList())
+    } else if let value = value as? ContinuedProcessingTaskRequest {
+      super.writeByte(145)
       super.writeValue(value.toList())
     } else {
       super.writeValue(value)

--- a/workmanager_platform_interface/lib/src/pigeon/workmanager_api.g.dart
+++ b/workmanager_platform_interface/lib/src/pigeon/workmanager_api.g.dart
@@ -329,6 +329,7 @@ class Constraints {
     this.requiresCharging,
     this.requiresDeviceIdle,
     this.requiresStorageNotLow,
+    this.contentUriTriggers,
   });
 
   NetworkType? networkType;
@@ -341,6 +342,20 @@ class Constraints {
 
   bool? requiresStorageNotLow;
 
+  /// Content URI triggers that run the work when the observed content URIs
+  /// change (Android only).
+  ///
+  /// Mirrors WorkManager's `Constraints.Builder.addContentUriTrigger`:
+  /// https://developer.android.com/reference/androidx/work/Constraints.Builder#addContentUriTrigger(android.net.Uri,%20boolean)
+  ///
+  /// Requires Android 7.0 (API 24)+; on older Android versions the triggers
+  /// are ignored. WorkManager also limits how many content-URI-triggered
+  /// workers can be enqueued at once (default 8, configurable via
+  /// `Configuration.Builder.setContentUriTriggerWorkersLimit`).
+  ///
+  /// Other platforms ignore this field.
+  List<ContentUriTrigger?>? contentUriTriggers;
+
   List<Object?> _toList() {
     return <Object?>[
       networkType,
@@ -348,6 +363,7 @@ class Constraints {
       requiresCharging,
       requiresDeviceIdle,
       requiresStorageNotLow,
+      contentUriTriggers,
     ];
   }
 
@@ -362,6 +378,7 @@ class Constraints {
       requiresCharging: result[2] as bool?,
       requiresDeviceIdle: result[3] as bool?,
       requiresStorageNotLow: result[4] as bool?,
+      contentUriTriggers: (result[5] as List<Object?>?)?.cast<ContentUriTrigger?>(),
     );
   }
 
@@ -374,7 +391,62 @@ class Constraints {
     if (identical(this, other)) {
       return true;
     }
-    return _deepEquals(networkType, other.networkType) && _deepEquals(requiresBatteryNotLow, other.requiresBatteryNotLow) && _deepEquals(requiresCharging, other.requiresCharging) && _deepEquals(requiresDeviceIdle, other.requiresDeviceIdle) && _deepEquals(requiresStorageNotLow, other.requiresStorageNotLow);
+    return _deepEquals(networkType, other.networkType) && _deepEquals(requiresBatteryNotLow, other.requiresBatteryNotLow) && _deepEquals(requiresCharging, other.requiresCharging) && _deepEquals(requiresDeviceIdle, other.requiresDeviceIdle) && _deepEquals(requiresStorageNotLow, other.requiresStorageNotLow) && _deepEquals(contentUriTriggers, other.contentUriTriggers);
+  }
+
+  @override
+  // ignore: avoid_equals_and_hash_code_on_mutable_classes
+  int get hashCode => _deepHash(<Object?>[runtimeType, ..._toList()]);
+}
+
+/// A single content URI trigger for Android WorkManager constraints.
+///
+/// When [uri] is updated, inserted or deleted by the system or another app,
+/// the work associated with the constraint is run.
+///
+/// Mirrors WorkManager's `ContentUriTrigger`:
+/// https://developer.android.com/reference/androidx/work/ContentUriTrigger
+class ContentUriTrigger {
+  ContentUriTrigger({
+    required this.uri,
+    required this.triggerForDescendants,
+  });
+
+  /// The local `content:` Uri to observe for changes, e.g.
+  /// `content://media/external/images/media`.
+  String uri;
+
+  /// Whether changes to any descendant of [uri] also run the work.
+  bool triggerForDescendants;
+
+  List<Object?> _toList() {
+    return <Object?>[
+      uri,
+      triggerForDescendants,
+    ];
+  }
+
+  Object encode() {
+    return _toList();  }
+
+  static ContentUriTrigger decode(Object result) {
+    result as List<Object?>;
+    return ContentUriTrigger(
+      uri: result[0]! as String,
+      triggerForDescendants: result[1]! as bool,
+    );
+  }
+
+  @override
+  // ignore: avoid_equals_and_hash_code_on_mutable_classes
+  bool operator ==(Object other) {
+    if (other is! ContentUriTrigger || other.runtimeType != runtimeType) {
+      return false;
+    }
+    if (identical(this, other)) {
+      return true;
+    }
+    return _deepEquals(uri, other.uri) && _deepEquals(triggerForDescendants, other.triggerForDescendants);
   }
 
   @override
@@ -869,26 +941,29 @@ class _PigeonCodec extends StandardMessageCodec {
     }    else if (value is Constraints) {
       buffer.putUint8(137);
       writeValue(buffer, value.encode());
-    }    else if (value is BackoffPolicyConfig) {
+    }    else if (value is ContentUriTrigger) {
       buffer.putUint8(138);
       writeValue(buffer, value.encode());
-    }    else if (value is InitializeRequest) {
+    }    else if (value is BackoffPolicyConfig) {
       buffer.putUint8(139);
       writeValue(buffer, value.encode());
-    }    else if (value is OneOffTaskRequest) {
+    }    else if (value is InitializeRequest) {
       buffer.putUint8(140);
       writeValue(buffer, value.encode());
-    }    else if (value is PeriodicTaskRequest) {
+    }    else if (value is OneOffTaskRequest) {
       buffer.putUint8(141);
       writeValue(buffer, value.encode());
-    }    else if (value is ProcessingTaskRequest) {
+    }    else if (value is PeriodicTaskRequest) {
       buffer.putUint8(142);
       writeValue(buffer, value.encode());
-    }    else if (value is HealthResearchTaskRequest) {
+    }    else if (value is ProcessingTaskRequest) {
       buffer.putUint8(143);
       writeValue(buffer, value.encode());
-    }    else if (value is ContinuedProcessingTaskRequest) {
+    }    else if (value is HealthResearchTaskRequest) {
       buffer.putUint8(144);
+      writeValue(buffer, value.encode());
+    }    else if (value is ContinuedProcessingTaskRequest) {
+      buffer.putUint8(145);
       writeValue(buffer, value.encode());
     } else {
       super.writeValue(buffer, value);
@@ -924,18 +999,20 @@ class _PigeonCodec extends StandardMessageCodec {
       case 137:
         return Constraints.decode(readValue(buffer)!);
       case 138:
-        return BackoffPolicyConfig.decode(readValue(buffer)!);
+        return ContentUriTrigger.decode(readValue(buffer)!);
       case 139:
-        return InitializeRequest.decode(readValue(buffer)!);
+        return BackoffPolicyConfig.decode(readValue(buffer)!);
       case 140:
-        return OneOffTaskRequest.decode(readValue(buffer)!);
+        return InitializeRequest.decode(readValue(buffer)!);
       case 141:
-        return PeriodicTaskRequest.decode(readValue(buffer)!);
+        return OneOffTaskRequest.decode(readValue(buffer)!);
       case 142:
-        return ProcessingTaskRequest.decode(readValue(buffer)!);
+        return PeriodicTaskRequest.decode(readValue(buffer)!);
       case 143:
-        return HealthResearchTaskRequest.decode(readValue(buffer)!);
+        return ProcessingTaskRequest.decode(readValue(buffer)!);
       case 144:
+        return HealthResearchTaskRequest.decode(readValue(buffer)!);
+      case 145:
         return ContinuedProcessingTaskRequest.decode(readValue(buffer)!);
       default:
         return super.readValueOfType(type, buffer);

--- a/workmanager_platform_interface/pigeons/workmanager_api.dart
+++ b/workmanager_platform_interface/pigeons/workmanager_api.dart
@@ -214,6 +214,7 @@ class Constraints {
     this.requiresCharging,
     this.requiresDeviceIdle,
     this.requiresStorageNotLow,
+    this.contentUriTriggers,
   });
 
   NetworkType? networkType;
@@ -221,6 +222,41 @@ class Constraints {
   bool? requiresCharging;
   bool? requiresDeviceIdle;
   bool? requiresStorageNotLow;
+
+  /// Content URI triggers that run the work when the observed content URIs
+  /// change (Android only).
+  ///
+  /// Mirrors WorkManager's `Constraints.Builder.addContentUriTrigger`:
+  /// https://developer.android.com/reference/androidx/work/Constraints.Builder#addContentUriTrigger(android.net.Uri,%20boolean)
+  ///
+  /// Requires Android 7.0 (API 24)+; on older Android versions the triggers
+  /// are ignored. WorkManager also limits how many content-URI-triggered
+  /// workers can be enqueued at once (default 8, configurable via
+  /// `Configuration.Builder.setContentUriTriggerWorkersLimit`).
+  ///
+  /// Other platforms ignore this field.
+  List<ContentUriTrigger?>? contentUriTriggers;
+}
+
+/// A single content URI trigger for Android WorkManager constraints.
+///
+/// When [uri] is updated, inserted or deleted by the system or another app,
+/// the work associated with the constraint is run.
+///
+/// Mirrors WorkManager's `ContentUriTrigger`:
+/// https://developer.android.com/reference/androidx/work/ContentUriTrigger
+class ContentUriTrigger {
+  ContentUriTrigger({
+    required this.uri,
+    required this.triggerForDescendants,
+  });
+
+  /// The local `content:` Uri to observe for changes, e.g.
+  /// `content://media/external/images/media`.
+  String uri;
+
+  /// Whether changes to any descendant of [uri] also run the work.
+  bool triggerForDescendants;
 }
 
 class BackoffPolicyConfig {


### PR DESCRIPTION
## Summary
Exposes Android WorkManager's `ContentUriTrigger` constraint in Dart by adding a `contentUriTriggers` field to `Constraints`, mirroring `Constraints.Builder.addContentUriTrigger(uri, triggerForDescendants)`.

```dart
Workmanager().registerOneOffTask(
  "process-new-photos",
  "photo_processor",
  constraints: Constraints(
    contentUriTriggers: [
      ContentUriTrigger(
        uri: 'content://media/external/images/media',
        triggerForDescendants: true,
      ),
    ],
  ),
);
```

**Android-only.** Other platforms (iOS, macOS, web) ignore the new field.

### What changed
- **`workmanager_platform_interface`**: new `ContentUriTrigger` pigeon data class (`uri` + `triggerForDescendants`) and `Constraints.contentUriTriggers`; regenerated pigeon code for Dart, Kotlin and Swift.
- **`workmanager_android`**: maps triggers in `toAndroidConstraints()` with an API 24 guard (JobScheduler drops content URI triggers below Android 7.0); no-op on older API levels.
- **Tests**: native Robolectric tests for the Kotlin mapping (single/multiple triggers, null list, API 24 threshold) and Dart tests for the new API surface.
- **Docs**: added a "Content URI Triggers" section to `docs/customization.mdx`.

### Notes
- Content URI triggers occupy JobScheduler slots directly; WorkManager limits concurrently-enqueued content-URI-triggered workers (default 8, configurable via `Configuration.Builder.setContentUriTriggerWorkersLimit`).
- The observing app needs permission to read the content URIs it observes.

Fixes #413