### PR TITLE
fix(android): AGP 9 built-in Kotlin compilerOptions

### DIFF
--- a/workmanager_android/CHANGELOG.md
+++ b/workmanager_android/CHANGELOG.md
@@ -1,4 +1,6 @@
-## 0.10.0+1
+## 0.10.1+1
+
+ - **FIX**(android): configure the Kotlin compiler for AGP 9+ via `kotlin.compilerOptions` (the `android.kotlinOptions` block was removed in AGP 9), aligning with Flutter's built-in Kotlin migration guide. Note: apps on AGP 9 must use built-in Kotlin (`android.builtInKotlin` unset/true) — with `android.builtInKotlin=false` no Kotlin plugin compiles at all (see #710).
 
  - **FIX**(android): notify running callbacks when work is cancelled (fixes #432) (#705).
 

--- a/workmanager_android/CHANGELOG.md
+++ b/workmanager_android/CHANGELOG.md
@@ -1,6 +1,4 @@
-## 0.10.1+1
-
- - **FIX**(android): configure the Kotlin compiler for AGP 9+ via `kotlin.compilerOptions` (the `android.kotlinOptions` block was removed in AGP 9), aligning with Flutter's built-in Kotlin migration guide. Note: apps on AGP 9 must use built-in Kotlin (`android.builtInKotlin` unset/true) — with `android.builtInKotlin=false` no Kotlin plugin compiles at all (see #710).
+## 0.10.0+1
 
  - **FIX**(android): notify running callbacks when work is cancelled (fixes #432) (#705).
 

--- a/workmanager_android/android/build.gradle
+++ b/workmanager_android/android/build.gradle
@@ -9,7 +9,13 @@ rootProject.allprojects {
 }
 
 apply plugin: 'com.android.library'
-// AGP 9+ has built-in Kotlin support; older versions need the plugin explicitly.
+
+// AGP 9+ ships built-in Kotlin support; older versions need the Kotlin Gradle
+// Plugin (KGP) applied explicitly. Do NOT apply KGP on AGP 9+: it is a no-op
+// there for library modules (and deprecated), so Kotlin sources only compile
+// via AGP's built-in Kotlin (see flutter/flutter#183910 and #710). Apps that
+// still set `android.builtInKotlin=false` on AGP 9 must migrate to built-in
+// Kotlin — with that flag no Kotlin plugin compiles at all.
 def agpMajor = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0] as int
 if (agpMajor < 9) {
     apply plugin: 'kotlin-android'
@@ -43,6 +49,17 @@ android {
             tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
                 kotlinOptions.jvmTarget = "1.8"
             }
+        }
+    }
+}
+
+// AGP 9: `kotlinOptions` inside `android {}` was removed. Configure the Kotlin
+// compiler via the `kotlin` extension (provided by built-in Kotlin, or by KGP
+// 2.0+ on the legacy path). Kept in sync with compileOptions above.
+if (agpMajor >= 9) {
+    kotlin {
+        compilerOptions {
+            jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_1_8
         }
     }
 }


### PR DESCRIPTION
## What

Fixes #710 (Android plugin fails with AGP 9 + Flutter 3.44: `cannot find symbol: class WorkmanagerPlugin`).

`android.kotlinOptions` was removed in AGP 9. This migrates the plugin to `kotlin.compilerOptions` (the DSL from Flutter's [built-in Kotlin migration guide for plugin authors](https://docs.flutter.dev/release/breaking-changes/migrate-to-built-in-kotlin/for-plugin-authors)), keeping jvmTarget 1.8 in sync with `compileOptions`.

## Verified (scratch app, Flutter 3.44.0)

| Config | Result |
|---|---|
| AGP 9.0.1 + `android.builtInKotlin=true` | builds |
| AGP 9.2.1 + `android.builtInKotlin=true` | builds |
| AGP 9.0.1 + `android.builtInKotlin=false` | cannot find symbol (even with KGP applied to the plugin module — KGP is a no-op for library modules on AGP 9) |
| AGP 9.2.1 + `android.builtInKotlin=false` | same (reporter's exact setup) |

## Note for app developers

On AGP 9, if `android.builtInKotlin=false` is set (current Flutter template default), no Kotlin plugin compiles at all — affects every Kotlin-based plugin, not just workmanager. Fix is app-side: remove `android.builtInKotlin=false` / `android.newDsl=false` and migrate to built-in Kotlin (Flutter prints exactly this guidance). Plugin-side there is nothing more to do: applying KGP on AGP 9 registers no Kotlin compile tasks for library modules.

## Tests

- AGP < 9 path unchanged (kotlinOptions still used there).
- AGP 9 path verified via full `flutter build apk --debug` against Flutter 3.44.0.