### PR TITLE
feat!: BackgroundTaskResult enum instead of bool (fixes #23)

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ before it finishes:
 void callbackDispatcher() {
   Workmanager().executeTask(
     (taskName, inputData) async {
-      return true;
+      return BackgroundTaskResult.success;
     },
     onTaskStopped: (taskName, stopReason) async {
       // Mark the task as cancelled / persist state, then return promptly.

--- a/docs.json
+++ b/docs.json
@@ -34,6 +34,10 @@
           "href": "/task-status"
         },
         {
+          "title": "Migrating to BackgroundTaskResult",
+          "href": "/migrating-to-background-task-result"
+        },
+        {
           "title": "Debugging",
           "href": "/debugging"
         },

--- a/docs/customization.mdx
+++ b/docs/customization.mdx
@@ -161,7 +161,7 @@ void callbackDispatcher() {
   Workmanager().executeTask(
     (taskName, inputData) async {
       // The task itself...
-      return true;
+      return BackgroundTaskResult.success;
     },
     onTaskStopped: (taskName, stopReason) async {
       // Persist progress or mark the task as cancelled before the engine
@@ -246,7 +246,7 @@ void callbackDispatcher() {
       "sync",
       initialDelay: Duration(hours: 1),
     );
-    return true;
+    return BackgroundTaskResult.success;
   });
 }
 ```

--- a/docs/customization.mdx
+++ b/docs/customization.mdx
@@ -38,7 +38,7 @@ void callbackDispatcher() {
     // Use the data in your task logic
     await uploadFile(fileName, uploadUrl, userId);
     
-    return Future.value(true);
+    return BackgroundTaskResult.success;
   });
 }
 ```
@@ -332,7 +332,7 @@ void callbackDispatcher() {
         return await handleNotificationCheck(inputData);
       default:
         print('Unknown task: $task');
-        return Future.value(false);
+        return BackgroundTaskResult.retry;
     }
   });
 }
@@ -349,7 +349,7 @@ void callbackDispatcher() {
     try {
       // Your task logic
       await performTask(inputData);
-      return Future.value(true);
+      return BackgroundTaskResult.success;
       
     } catch (e) {
       print('Task failed: $e');
@@ -357,10 +357,10 @@ void callbackDispatcher() {
       // Decide whether to retry
       if (retryCount < 3 && isRetryableError(e)) {
         print('Retrying task (attempt ${retryCount + 1})');
-        return Future.value(false); // Tell system to retry
+        return BackgroundTaskResult.retry; // Tell system to retry
       } else {
         print('Task failed permanently');
-        return Future.value(true); // Don't retry
+        return BackgroundTaskResult.failure; // Permanent failure
       }
     }
   });
@@ -384,7 +384,7 @@ void callbackDispatcher() {
   Workmanager().executeTask((task, inputData) async {
     // Fast operation
     await syncCriticalData();
-    return Future.value(true);
+    return BackgroundTaskResult.success;
   });
 }
 
@@ -394,7 +394,7 @@ void callbackDispatcher() {
   Workmanager().executeTask((task, inputData) async {
     // This might timeout on iOS (30-second limit)
     await processLargeDataset(); // ❌ Too slow
-    return Future.value(true);
+    return BackgroundTaskResult.success;
   });
 }
 ```
@@ -414,7 +414,7 @@ void callbackDispatcher() {
       // Perform task
       await performNetworkOperation(client);
       
-      return Future.value(true);
+      return BackgroundTaskResult.success;
       
     } finally {
       // Clean up resources

--- a/docs/debugging.mdx
+++ b/docs/debugging.mdx
@@ -246,10 +246,10 @@ void callbackDispatcher() {
       // Your task logic
       final result = await performTask();
       print('[iOS BG] Task completed successfully');
-      return true;
+      return BackgroundTaskResult.success;
     } catch (e) {
       print('[iOS BG] Task failed: $e');
-      return false;
+      return BackgroundTaskResult.failure;
     }
   });
 }
@@ -334,7 +334,7 @@ void callbackDispatcher() {
       print('❌ Task failed after ${duration.inSeconds}s: $e');
       print('📋 Stack trace: $stackTrace');
       
-      return false; // Retry
+      return BackgroundTaskResult.retry; // Retry
     }
   });
 }

--- a/docs/migrating-to-background-task-result.mdx
+++ b/docs/migrating-to-background-task-result.mdx
@@ -1,0 +1,42 @@
+# Migrating to BackgroundTaskResult
+
+Since **0.11** the background-task handler must return `BackgroundTaskResult`
+instead of `bool`. This makes the outcome explicit and fixes a long-standing
+Android footgun ([#23](https://github.com/fluttercommunity/flutter_workmanager/issues/23)):
+previously every `false` result was mapped to WorkManager's `Result.retry()`,
+so tasks that failed permanently were retried forever. With the enum you choose:
+`success`, `retry` (backoff on Android) or `failure` (permanent).
+
+## What changed
+
+| Before | After |
+|---|---|
+| `Future<bool> Function(...)` | `Future<BackgroundTaskResult> Function(...)` |
+| `return true;` | `return BackgroundTaskResult.success;` |
+| `return false;` | `return BackgroundTaskResult.retry;` (see [behavior notes](#behavior-notes)) |
+| `return Future.value(true);` | `return Future.value(BackgroundTaskResult.success);` |
+
+## Migrating
+
+There is nothing to install and nothing to run — the change is mechanical and
+**the type system does the finding**: the handler return type is now
+`Future<BackgroundTaskResult>`, so every `return true` / `return false` in your
+`callbackDispatcher` shows up as a compile error in the IDE. Work through the
+errors and apply the mapping above. `Future.value(...)` / `Future<bool>.value(...)`
+forms migrate the same way.
+
+That's the whole migration.
+
+## Behavior notes
+
+- **`false` maps to `retry`**, preserving the pre-0.11 behavior. If you
+  returned `false` to mean "this failed, stop trying", switch those sites to
+  `BackgroundTaskResult.failure` — that's the new way to fail permanently.
+- **Android:** `retry` reschedules with the configured backoff policy;
+  `failure` stops the work and its chain.
+- **iOS:** `retry` and `failure` both report a failed fetch — there is no
+  automatic retry, so schedule another attempt if needed. See
+  [Task status](task-status).
+- **Exceptions:** if the handler throws (or its `Future` errors), the plugin
+  catches it, logs it, and reports `BackgroundTaskResult.failure` — it is never
+  retried. See [Task status](task-status).

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -374,7 +374,7 @@ void callbackDispatcher() {
         break;
     }
     
-    return Future.value(true);
+    return BackgroundTaskResult.success;
   });
 }
 ```
@@ -400,7 +400,7 @@ void callbackDispatcher() {
         await syncData(inputData);
         break;
     }
-    return Future.value(true);
+    return BackgroundTaskResult.success;
   });
 }
 ```
@@ -555,11 +555,15 @@ falls back to running as a regular background worker within the usual limits.
 
 ## Task Results
 
-Your background tasks can return:
+Your background tasks return a `BackgroundTaskResult`:
 
-- `Future.value(true)` - ✅ Task successful
-- `Future.value(false)` - 🔄 Task should be retried
-- `Future.error(...)` - ❌ Task failed
+- `BackgroundTaskResult.success` - ✅ Task successful
+- `BackgroundTaskResult.retry` - 🔄 Task should be retried (Android applies backoff)
+- `BackgroundTaskResult.failure` - ❌ Task failed permanently, no retry
+
+If the handler throws (or its `Future` errors), the plugin catches it, logs it,
+and reports `BackgroundTaskResult.failure` — it is never retried. See
+[Task Status](task-status) and the [migration guide](migrating-to-background-task-result).
 
 
 ## Key Points

--- a/docs/task-status.mdx
+++ b/docs/task-status.mdx
@@ -239,14 +239,16 @@ void callbackDispatcher() {
 | Invalid data | `BackgroundTaskResult.failure` | Task fails permanently |
 | Temporary server error | `BackgroundTaskResult.retry` | Task will retry with backoff |
 | Authentication failure | `BackgroundTaskResult.failure` | Task fails, needs user intervention |
-| Unhandled exception in the handler | `throw` (or let it bubble) | Treated as permanent failure — no retry |
+| Unhandled exception in the handler | `throw` (or let it bubble) | Caught, logged, reported as permanent failure — no retry |
 
 > **Throwing vs returning:** if your handler throws (or its `Future` completes
-> with an error), the platform treats it as a permanent failure — Android
-> `Result.failure()`, iOS a failed fetch — and does **not** retry. Only
-> returning `BackgroundTaskResult.retry` triggers an Android backoff retry.
-> Catching and returning `BackgroundTaskResult.failure` is equivalent but
-> keeps the error path explicit.
+> with an error), the plugin **catches it, logs it, and reports
+> `BackgroundTaskResult.failure`** — a permanent failure that is **not**
+> retried. Background isolates have no console or debugger, so the exception
+> never surfaces as a channel error; the failure flows through the normal
+> status pipeline (`WorkmanagerDebug` handlers see a failed task) and the
+> exception is written via `debugPrint` for local debugging. Only returning
+> `BackgroundTaskResult.retry` triggers an Android backoff retry.
 
 ### Monitoring Task Health
 

--- a/docs/task-status.mdx
+++ b/docs/task-status.mdx
@@ -239,6 +239,14 @@ void callbackDispatcher() {
 | Invalid data | `BackgroundTaskResult.failure` | Task fails permanently |
 | Temporary server error | `BackgroundTaskResult.retry` | Task will retry with backoff |
 | Authentication failure | `BackgroundTaskResult.failure` | Task fails, needs user intervention |
+| Unhandled exception in the handler | `throw` (or let it bubble) | Treated as permanent failure — no retry |
+
+> **Throwing vs returning:** if your handler throws (or its `Future` completes
+> with an error), the platform treats it as a permanent failure — Android
+> `Result.failure()`, iOS a failed fetch — and does **not** retry. Only
+> returning `BackgroundTaskResult.retry` triggers an Android backoff retry.
+> Catching and returning `BackgroundTaskResult.failure` is equivalent but
+> keeps the error path explicit.
 
 ### Monitoring Task Health
 

--- a/docs/task-status.mdx
+++ b/docs/task-status.mdx
@@ -215,15 +215,17 @@ void callbackDispatcher() {
     try {
       // Your task logic here
       final result = await performWork(task, inputData);
-      
+
       if (result.isSuccess) {
-        return true;  // ✅ Task succeeded
+        return BackgroundTaskResult.success;
       } else {
-        return false; // 🔄 Retry with backoff (Android) or manual reschedule (iOS)
+        // Transient failure: retry with backoff (Android) or manual
+        // reschedule (iOS).
+        return BackgroundTaskResult.retry;
       }
     } catch (e) {
-      // 🔥 Permanent failure - will not retry
-      throw Exception('Task failed: $e');
+      // Permanent failure - will not retry (Android `Result.failure()`).
+      return BackgroundTaskResult.failure;
     }
   });
 }
@@ -233,10 +235,10 @@ void callbackDispatcher() {
 
 | Error Type | Recommended Return | Result |
 |------------|-------------------|--------|
-| Network timeout | `return false` | Task will retry later |
-| Invalid data | `throw Exception()` | Task fails permanently |
-| Temporary server error | `return false` | Task will retry with backoff |
-| Authentication failure | `throw Exception()` | Task fails, needs user intervention |
+| Network timeout | `BackgroundTaskResult.retry` | Task will retry later |
+| Invalid data | `BackgroundTaskResult.failure` | Task fails permanently |
+| Temporary server error | `BackgroundTaskResult.retry` | Task will retry with backoff |
+| Authentication failure | `BackgroundTaskResult.failure` | Task fails, needs user intervention |
 
 ### Monitoring Task Health
 

--- a/docs/task-status.mdx
+++ b/docs/task-status.mdx
@@ -32,20 +32,20 @@ The behavior of task status depends on what your Dart background function return
 
 | Dart Return | Task Status | System Behavior | Debug Notification |
 |-------------|-------------|-----------------|-------------------|
-| `true` | **Completed** | Task succeeds, won't retry | ✅ Success |
-| `false` | **Rescheduled** | WorkManager schedules retry with backoff | 🔄 Rescheduled |
-| `Future.error()` | **Failed** | Task fails permanently, no retry | ❌ Failed + error |
-| Exception thrown | **Failed** | Task fails permanently, no retry | ❌ Failed + error |
+| `BackgroundTaskResult.success` | **Completed** | Task succeeds, won't retry | ✅ Success |
+| `BackgroundTaskResult.retry` | **Rescheduled** | WorkManager schedules retry with backoff | 🔄 Rescheduled |
+| `BackgroundTaskResult.failure` | **Failed** | Task fails permanently, no retry | ❌ Failed |
+| Exception thrown | **Failed** | Caught, logged, reported as failure — no retry | ❌ Failed (see log) |
 
   </TabItem>
   <TabItem label="iOS" value="ios">
 
 | Dart Return | Task Status | System Behavior | Debug Notification |
 |-------------|-------------|-----------------|-------------------|
-| `true` | **Completed** | Task succeeds, won't retry | ✅ Success |
-| `false` | **Retrying** | App must manually reschedule | 🔄 Retrying |
-| `Future.error()` | **Failed** | Task fails, no automatic retry | ❌ Failed + error |
-| Exception thrown | **Failed** | Task fails, no automatic retry | ❌ Failed + error |
+| `BackgroundTaskResult.success` | **Completed** | Task succeeds, won't retry | ✅ Success |
+| `BackgroundTaskResult.retry` | **Retrying** | No automatic retry — app must reschedule | 🔄 Retrying |
+| `BackgroundTaskResult.failure` | **Failed** | Task fails, no retry | ❌ Failed |
+| Exception thrown | **Failed** | Caught, logged, reported as failure | ❌ Failed (see log) |
 
   </TabItem>
 </Tabs>

--- a/example/integration_test/workmanager_integration_test.dart
+++ b/example/integration_test/workmanager_integration_test.dart
@@ -36,10 +36,10 @@ void callbackDispatcher() {
       var counterName = inputData!['counter_name'];
       final count = prefs.getInt(counterName) ?? 0;
       if (count == kMaxRetryAttempts) {
-        return Future.value(true);
+        return Future.value(BackgroundTaskResult.success);
       } else {
         await prefs.setInt(counterName, count + 1);
-        return Future.value(false);
+        return Future.value(BackgroundTaskResult.retry);
       }
     }
     if (task == dataTransferTaskName) {
@@ -70,7 +70,7 @@ void callbackDispatcher() {
       SharedPreferences prefs = await SharedPreferences.getInstance();
       await prefs.setString(inputData!['result_key'], task);
     }
-    return true;
+    return BackgroundTaskResult.success;
   });
 }
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -73,11 +73,11 @@ void callbackDispatcher() {
         final key = inputData!['key']!;
         if (prefs.containsKey('unique-$key')) {
           debugPrint('has been running before, task is successful');
-          return true;
+          return BackgroundTaskResult.success;
         } else {
           await prefs.setBool('unique-$key', true);
           debugPrint('reschedule task');
-          return false;
+          return BackgroundTaskResult.retry;
         }
       case failedTaskKey:
         debugPrint('failed task');
@@ -117,12 +117,12 @@ void callbackDispatcher() {
             "$periodicUpdatePolicyTask executed with frequency: $frequency minutes at ${DateTime.now()}");
         break;
       default:
-        return Future.value(false);
+        return Future.value(BackgroundTaskResult.retry);
     }
 
-    // Return true to indicate that the task was successful
+    // Return success to indicate that the task was successful
     debugPrint("$task finished successfully");
-    return Future.value(true);
+    return Future.value(BackgroundTaskResult.success);
   });
 }
 

--- a/workmanager/README.md
+++ b/workmanager/README.md
@@ -34,7 +34,7 @@ void callbackDispatcher() {
   Workmanager().executeTask((task, inputData) async {
     print("Background task: $task");
     // Your background work here
-    return Future.value(true);
+    return BackgroundTaskResult.success;
   });
 }
 

--- a/workmanager/lib/src/workmanager_impl.dart
+++ b/workmanager/lib/src/workmanager_impl.dart
@@ -71,7 +71,7 @@ typedef BackgroundTaskStoppedHandler = Future<void> Function(
 ///         print("Replace this print statement with your code that should be executed in the background here");
 ///         break;
 ///     }
-///     return Future.value(true);
+///     return BackgroundTaskResult.success;
 ///   });
 /// }
 ///
@@ -136,7 +136,7 @@ class Workmanager {
   ///          break;
   ///      }
   ///
-  ///     return Future.value(true);
+  ///     return BackgroundTaskResult.success;
   ///   });
   /// }
   /// ```

--- a/workmanager/lib/src/workmanager_impl.dart
+++ b/workmanager/lib/src/workmanager_impl.dart
@@ -9,20 +9,22 @@ import 'package:workmanager_apple/workmanager_apple.dart';
 import 'package:workmanager_web/workmanager_web.dart';
 
 /// Function that executes your background work.
-/// You should return whether the task ran successfully or not.
+/// You should return the [BackgroundTaskResult] describing the outcome.
 ///
 /// [taskName] Returns the value you provided when registering the task.
 /// iOS will pass [Workmanager.iOSBackgroundTask] (for background-fetch) or
 /// custom task IDs for BGTaskScheduler based tasks.
 ///
-/// The behavior for retries is different on each platform:
-/// - Android: return `false` from the this method will reschedule the work
-///   based on the policy given in [Workmanager.registerOneOffTask], for example
-/// - iOS: The return value is ignored, but if work has failed, you can schedule
-///   another attempt using [Workmanager.registerOneOffTask]. This depends on
+/// The behavior differs on each platform:
+/// - Android: [BackgroundTaskResult.retry] reschedules the work based on the
+///   policy given in [Workmanager.registerOneOffTask], while
+///   [BackgroundTaskResult.failure] stops the chain permanently.
+/// - iOS: [BackgroundTaskResult.retry] and [BackgroundTaskResult.failure] both
+///   report a failed fetch; there is no automatic retry, so schedule another
+///   attempt using [Workmanager.registerOneOffTask]. This depends on
 ///   BGTaskScheduler being set up correctly. Please follow the README for
 ///   instructions.
-typedef BackgroundTaskHandler = Future<bool> Function(
+typedef BackgroundTaskHandler = Future<BackgroundTaskResult> Function(
     String taskName, Map<String, dynamic>? inputData);
 
 /// Callback invoked when a running background task is stopped by the platform
@@ -196,7 +198,8 @@ class Workmanager {
   /// you registered the task with.
   /// The [inputData] will contain all the data you registered the task with.
   ///
-  /// You need to return a [Future<bool>] that will tell the OS if the task was successful or not.
+  /// You need to return a [Future<BackgroundTaskResult>] that tells the OS how
+  /// the task went: [BackgroundTaskResult.success], retry or failure.
   ///
   /// You can perfectly call other Flutter plugins inside this callback, as the callback is simply running within a Flutter background isolate.
   ///
@@ -569,12 +572,12 @@ class _WorkmanagerFlutterApiImpl extends WorkmanagerFlutterApi {
   }
 
   @override
-  Future<bool> executeTask(
+  Future<BackgroundTaskResult> executeTask(
       String taskName, Map<String?, Object?>? inputData) async {
     final convertedInputData = convertPigeonInputData(inputData);
     final result = await Workmanager._backgroundTaskHandler
         ?.call(taskName, convertedInputData);
-    return result ?? false;
+    return result ?? BackgroundTaskResult.retry;
   }
 
   @override

--- a/workmanager/lib/src/workmanager_impl.dart
+++ b/workmanager/lib/src/workmanager_impl.dart
@@ -1,7 +1,7 @@
 import 'dart:async';
 import 'dart:io';
 
-import 'package:flutter/foundation.dart' show kIsWeb;
+import 'package:flutter/foundation.dart' show debugPrint, kIsWeb;
 import 'package:flutter/widgets.dart';
 import 'package:workmanager_platform_interface/workmanager_platform_interface.dart';
 import 'package:workmanager_android/workmanager_android.dart';
@@ -26,8 +26,9 @@ import 'package:workmanager_web/workmanager_web.dart';
 ///   instructions.
 ///
 /// If the handler throws (or the returned Future completes with an error),
-/// the task is treated as a permanent failure on both platforms — Android
-/// `Result.failure()`, iOS a failed fetch — and is not retried.
+/// the plugin catches it, logs it, and reports [BackgroundTaskResult.failure]
+/// — a permanent failure on both platforms (Android `Result.failure()`, iOS a
+/// failed fetch) that is never retried.
 typedef BackgroundTaskHandler = Future<BackgroundTaskResult> Function(
     String taskName, Map<String, dynamic>? inputData);
 
@@ -578,10 +579,25 @@ class _WorkmanagerFlutterApiImpl extends WorkmanagerFlutterApi {
   @override
   Future<BackgroundTaskResult> executeTask(
       String taskName, Map<String?, Object?>? inputData) async {
+    final handler = Workmanager._backgroundTaskHandler;
+    if (handler == null) {
+      // No handler registered: retry, matching the historical `false` result.
+      return BackgroundTaskResult.retry;
+    }
     final convertedInputData = convertPigeonInputData(inputData);
-    final result = await Workmanager._backgroundTaskHandler
-        ?.call(taskName, convertedInputData);
-    return result ?? BackgroundTaskResult.retry;
+    try {
+      return await handler(taskName, convertedInputData);
+    } catch (error, stackTrace) {
+      // Background isolates have no console and no debugger, and a channel
+      // error would be invisible to the app. Catch, log, and report an
+      // ordinary permanent failure so the result flows through the native
+      // TaskStatus/debug pipeline like any other failure — and never retries.
+      debugPrint('[workmanager] Task "$taskName" threw an exception. '
+          'Reporting it as a permanent failure '
+          '(BackgroundTaskResult.failure); it will not be retried.\n'
+          '$error\n$stackTrace');
+      return BackgroundTaskResult.failure;
+    }
   }
 
   @override

--- a/workmanager/lib/src/workmanager_impl.dart
+++ b/workmanager/lib/src/workmanager_impl.dart
@@ -24,6 +24,10 @@ import 'package:workmanager_web/workmanager_web.dart';
 ///   attempt using [Workmanager.registerOneOffTask]. This depends on
 ///   BGTaskScheduler being set up correctly. Please follow the README for
 ///   instructions.
+///
+/// If the handler throws (or the returned Future completes with an error),
+/// the task is treated as a permanent failure on both platforms — Android
+/// `Result.failure()`, iOS a failed fetch — and is not retried.
 typedef BackgroundTaskHandler = Future<BackgroundTaskResult> Function(
     String taskName, Map<String, dynamic>? inputData);
 

--- a/workmanager/test/in_process_task_execution_test.dart
+++ b/workmanager/test/in_process_task_execution_test.dart
@@ -1,35 +1,12 @@
-import 'dart:typed_data';
-
-import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:workmanager/workmanager.dart';
-import 'package:workmanager_apple/workmanager_apple.dart';
-
-const String _channelPrefix =
-    'dev.flutter.pigeon.workmanager_platform_interface.WorkmanagerFlutterApi.';
-
-/// Fake platform that records initialize() calls without touching real
-/// platform channels. Extends [WorkmanagerApple] so Workmanager's platform
-/// auto-selection (which runs on macOS/iOS/Android hosts) does not replace it.
-class _FakeApplePlatform extends WorkmanagerApple {
-  Function? lastCallbackDispatcher;
-
-  @override
-  Future<void> initialize(
-    Function callbackDispatcher, {
-    @Deprecated(
-        'Use WorkmanagerDebug handlers instead. This parameter has no effect.')
-    bool isInDebugMode = false,
-  }) async {
-    lastCallbackDispatcher = callbackDispatcher;
-  }
-}
+import 'pigeon_test_utils.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   setUp(() {
-    WorkmanagerPlatform.instance = _FakeApplePlatform();
+    WorkmanagerPlatform.instance = FakeApplePlatform();
   });
 
   test(
@@ -54,31 +31,17 @@ void main() {
 
     final messenger =
         TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
-    final codec = WorkmanagerFlutterApi.pigeonChannelCodec;
-
-    Future<List<Object?>?> send(String channel, Object? message) async {
-      ByteData? reply;
-      await messenger.handlePlatformMessage(
-        channel,
-        codec.encodeMessage(message),
-        (data) {
-          reply = data;
-        },
-      );
-      return reply == null
-          ? null
-          : codec.decodeMessage(reply) as List<Object?>?;
-    }
 
     // Simulate the native side executing a one-off task on the running
     // (main) engine: backgroundChannelInitialized, then executeTask.
-    final initReply =
-        await send('${_channelPrefix}backgroundChannelInitialized', null);
+    final initReply = await sendPigeonMessage(
+        messenger, '${pigeonChannelPrefix}backgroundChannelInitialized', null);
     expect(initReply, isEmpty);
     expect(dispatcherRuns, 1);
 
-    final taskReply = await send(
-      '${_channelPrefix}executeTask',
+    final taskReply = await sendPigeonMessage(
+      messenger,
+      '${pigeonChannelPrefix}executeTask',
       <Object?>[
         'dev.fluttercommunity.test.oneOff',
         <String?, Object?>{'foo': 'bar'},
@@ -88,9 +51,11 @@ void main() {
     expect(executedTasks, ['dev.fluttercommunity.test.oneOff']);
 
     // A second task must not run the dispatcher again.
-    await send('${_channelPrefix}backgroundChannelInitialized', null);
-    await send(
-      '${_channelPrefix}executeTask',
+    await sendPigeonMessage(
+        messenger, '${pigeonChannelPrefix}backgroundChannelInitialized', null);
+    await sendPigeonMessage(
+      messenger,
+      '${pigeonChannelPrefix}executeTask',
       <Object?>['dev.fluttercommunity.test.oneOff.two', null],
     );
     expect(dispatcherRuns, 1);

--- a/workmanager/test/in_process_task_execution_test.dart
+++ b/workmanager/test/in_process_task_execution_test.dart
@@ -42,7 +42,7 @@ void main() {
       dispatcherRuns++;
       Workmanager().executeTask((taskName, inputData) async {
         executedTasks.add(taskName);
-        return true;
+        return BackgroundTaskResult.success;
       });
     }
 
@@ -84,7 +84,7 @@ void main() {
         <String?, Object?>{'foo': 'bar'},
       ],
     );
-    expect(taskReply, [true]);
+    expect(taskReply, [BackgroundTaskResult.success]);
     expect(executedTasks, ['dev.fluttercommunity.test.oneOff']);
 
     // A second task must not run the dispatcher again.

--- a/workmanager/test/on_task_stopped_test.dart
+++ b/workmanager/test/on_task_stopped_test.dart
@@ -50,7 +50,7 @@ void main() {
 
     void callbackDispatcher() {
       Workmanager().executeTask(
-        (taskName, inputData) async => true,
+        (taskName, inputData) async => BackgroundTaskResult.success,
         onTaskStopped: (taskName, stopReason) async {
           stopped.add((taskName, stopReason));
         },

--- a/workmanager/test/pigeon_test_utils.dart
+++ b/workmanager/test/pigeon_test_utils.dart
@@ -1,0 +1,51 @@
+import 'dart:typed_data';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:workmanager/workmanager.dart';
+import 'package:workmanager_apple/workmanager_apple.dart';
+
+/// Prefix of the Pigeon channel names generated for WorkmanagerFlutterApi.
+const String pigeonChannelPrefix =
+    'dev.flutter.pigeon.workmanager_platform_interface.WorkmanagerFlutterApi.';
+
+/// Fake platform that records initialize() calls without touching real
+/// platform channels. Extends [WorkmanagerApple] so Workmanager's platform
+/// auto-selection (which runs on macOS/iOS/Android hosts) does not replace it.
+class FakeApplePlatform extends WorkmanagerApple {
+  Function? lastCallbackDispatcher;
+
+  @override
+  Future<void> initialize(
+    Function callbackDispatcher, {
+    @Deprecated(
+        'Use WorkmanagerDebug handlers instead. This parameter has no effect.')
+    bool isInDebugMode = false,
+  }) async {
+    lastCallbackDispatcher = callbackDispatcher;
+  }
+}
+
+/// Sends a Pigeon message on [messenger] and returns the decoded reply.
+///
+/// The Workmanager statics (registered dispatcher, handler) are per-isolate,
+/// so tests that register different handlers must live in separate test files
+/// (each file runs in its own isolate).
+Future<List<Object?>?> sendPigeonMessage(
+  TestDefaultBinaryMessenger messenger,
+  String channel,
+  Object? message,
+) async {
+  ByteData? reply;
+  await messenger.handlePlatformMessage(
+    channel,
+    WorkmanagerFlutterApi.pigeonChannelCodec.encodeMessage(message),
+    (data) {
+      reply = data;
+    },
+  );
+  return reply == null
+      ? null
+      : WorkmanagerFlutterApi.pigeonChannelCodec.decodeMessage(reply)
+          as List<Object?>?;
+}

--- a/workmanager/test/task_result_test.dart
+++ b/workmanager/test/task_result_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart' show debugPrint;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:workmanager/workmanager.dart';
 import 'pigeon_test_utils.dart';
@@ -5,11 +6,20 @@ import 'pigeon_test_utils.dart';
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
+  final logged = <String>[];
+  final originalDebugPrint = debugPrint;
+
   setUp(() {
     WorkmanagerPlatform.instance = FakeApplePlatform();
+    logged.clear();
+    debugPrint = (message, {wrapWidth}) => logged.add(message ?? '');
   });
 
-  test('task results: success value and thrown exceptions (no retry)',
+  tearDown(() {
+    debugPrint = originalDebugPrint;
+  });
+
+  test('task results: success round-trips; thrown exceptions become failure',
       () async {
     void callbackDispatcher() {
       Workmanager().executeTask((taskName, inputData) async {
@@ -37,18 +47,18 @@ void main() {
     );
     expect(okReply, [BackgroundTaskResult.success]);
 
-    // A thrown exception surfaces as a Pigeon error reply (code 'error'), not
-    // a BackgroundTaskResult. Native implementations map that to a permanent
-    // failure — Android `Result.failure()`, iOS `.failed` — i.e. no retry.
+    // A thrown exception is caught by the plugin, logged, and reported as a
+    // normal BackgroundTaskResult.failure — never a Pigeon channel error.
+    // Native implementations map that to a permanent failure — Android
+    // `Result.failure()`, iOS `.failed` — i.e. no retry.
     final boomReply = await sendPigeonMessage(
       messenger,
       '${pigeonChannelPrefix}executeTask',
       <Object?>['dev.fluttercommunity.test.boom', null],
     );
-    expect(boomReply, isNotNull);
-    final errorReply = boomReply as List<Object?>;
-    expect(errorReply.length, 3);
-    expect(errorReply[0], 'error');
-    expect(errorReply[1], contains('task logic exploded'));
+    expect(boomReply, [BackgroundTaskResult.failure]);
+
+    // The exception is logged so it is debuggable without a console.
+    expect(logged.join('\n'), contains('task logic exploded'));
   });
 }

--- a/workmanager/test/task_result_test.dart
+++ b/workmanager/test/task_result_test.dart
@@ -1,0 +1,54 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:workmanager/workmanager.dart';
+import 'pigeon_test_utils.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    WorkmanagerPlatform.instance = FakeApplePlatform();
+  });
+
+  test('task results: success value and thrown exceptions (no retry)',
+      () async {
+    void callbackDispatcher() {
+      Workmanager().executeTask((taskName, inputData) async {
+        if (taskName == 'dev.fluttercommunity.test.boom') {
+          throw StateError('task logic exploded');
+        }
+        return BackgroundTaskResult.success;
+      });
+    }
+
+    await Workmanager().initialize(callbackDispatcher);
+
+    final messenger =
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+
+    // Native side: initialize the channel, then execute the task.
+    await sendPigeonMessage(
+        messenger, '${pigeonChannelPrefix}backgroundChannelInitialized', null);
+
+    // A returning handler surfaces the BackgroundTaskResult on the channel.
+    final okReply = await sendPigeonMessage(
+      messenger,
+      '${pigeonChannelPrefix}executeTask',
+      <Object?>['dev.fluttercommunity.test.ok', null],
+    );
+    expect(okReply, [BackgroundTaskResult.success]);
+
+    // A thrown exception surfaces as a Pigeon error reply (code 'error'), not
+    // a BackgroundTaskResult. Native implementations map that to a permanent
+    // failure — Android `Result.failure()`, iOS `.failed` — i.e. no retry.
+    final boomReply = await sendPigeonMessage(
+      messenger,
+      '${pigeonChannelPrefix}executeTask',
+      <Object?>['dev.fluttercommunity.test.boom', null],
+    );
+    expect(boomReply, isNotNull);
+    final errorReply = boomReply as List<Object?>;
+    expect(errorReply.length, 3);
+    expect(errorReply[0], 'error');
+    expect(errorReply[1], contains('task logic exploded'));
+  });
+}

--- a/workmanager_android/android/src/main/kotlin/dev/fluttercommunity/workmanager/BackgroundWorker.kt
+++ b/workmanager_android/android/src/main/kotlin/dev/fluttercommunity/workmanager/BackgroundWorker.kt
@@ -8,6 +8,7 @@ import androidx.concurrent.futures.CallbackToFutureAdapter
 import androidx.work.ListenableWorker
 import androidx.work.WorkerParameters
 import com.google.common.util.concurrent.ListenableFuture
+import dev.fluttercommunity.workmanager.pigeon.BackgroundTaskResult
 import dev.fluttercommunity.workmanager.pigeon.ForegroundServiceConfig
 import dev.fluttercommunity.workmanager.pigeon.TaskStatus
 import dev.fluttercommunity.workmanager.pigeon.WorkmanagerFlutterApi
@@ -286,8 +287,17 @@ class BackgroundWorker(
         flutterApi.executeTask(localDartTask, pigeonPayload) { result ->
             when {
                 result.isSuccess -> {
-                    val wasSuccessful = result.getOrNull() ?: false
-                    stopEngine(if (wasSuccessful) Result.success() else Result.retry())
+                    val taskResult = result.getOrNull()
+                    val wmResult =
+                        when (taskResult) {
+                            BackgroundTaskResult.SUCCESS -> Result.success()
+                            BackgroundTaskResult.RETRY -> Result.retry()
+                            BackgroundTaskResult.FAILURE -> Result.failure()
+                            // No handler registered / null result: retry, matching
+                            // the historical `false` behaviour.
+                            null -> Result.retry()
+                        }
+                    stopEngine(wmResult)
                 }
                 result.isFailure -> {
                     val exception = result.exceptionOrNull()

--- a/workmanager_android/android/src/main/kotlin/dev/fluttercommunity/workmanager/pigeon/WorkmanagerApi.g.kt
+++ b/workmanager_android/android/src/main/kotlin/dev/fluttercommunity/workmanager/pigeon/WorkmanagerApi.g.kt
@@ -223,6 +223,33 @@ enum class TaskStatus(val raw: Int) {
 }
 
 /**
+ * Result of a background task execution.
+ *
+ * Replaces the previous `bool` return value of the task handler. Maps to
+ * platform-specific semantics:
+ * - [success]: Android `Result.success()`, iOS `UIBackgroundFetchResult.newData`.
+ * - [retry]: Android `Result.retry()` (transient failure, backoff applies).
+ *   iOS has no automatic retry — the task finishes as `.failed` and you can
+ *   re-schedule it yourself.
+ * - [failure]: Android `Result.failure()` (permanent failure, dependent work
+ *   stops and the task is not retried). iOS `UIBackgroundFetchResult.failed`.
+ */
+enum class BackgroundTaskResult(val raw: Int) {
+  /** The task completed successfully. */
+  SUCCESS(0),
+  /** The task failed transiently and should be retried (Android only). */
+  RETRY(1),
+  /** The task failed permanently and must not be retried. */
+  FAILURE(2);
+
+  companion object {
+    fun ofRaw(raw: Int): BackgroundTaskResult? {
+      return values().firstOrNull { it.raw == raw }
+    }
+  }
+}
+
+/**
  * An enumeration of various network types that can be used as Constraints for work.
  *
  * Fully supported on Android.
@@ -988,80 +1015,85 @@ private open class WorkmanagerApiPigeonCodec : StandardMessageCodec() {
       }
       130.toByte() -> {
         return (readValue(buffer) as Long?)?.let {
-          NetworkType.ofRaw(it.toInt())
+          BackgroundTaskResult.ofRaw(it.toInt())
         }
       }
       131.toByte() -> {
         return (readValue(buffer) as Long?)?.let {
-          BackoffPolicy.ofRaw(it.toInt())
+          NetworkType.ofRaw(it.toInt())
         }
       }
       132.toByte() -> {
         return (readValue(buffer) as Long?)?.let {
-          ExistingWorkPolicy.ofRaw(it.toInt())
+          BackoffPolicy.ofRaw(it.toInt())
         }
       }
       133.toByte() -> {
         return (readValue(buffer) as Long?)?.let {
-          ExistingPeriodicWorkPolicy.ofRaw(it.toInt())
+          ExistingWorkPolicy.ofRaw(it.toInt())
         }
       }
       134.toByte() -> {
         return (readValue(buffer) as Long?)?.let {
-          OutOfQuotaPolicy.ofRaw(it.toInt())
+          ExistingPeriodicWorkPolicy.ofRaw(it.toInt())
         }
       }
       135.toByte() -> {
         return (readValue(buffer) as Long?)?.let {
-          ForegroundServiceType.ofRaw(it.toInt())
+          OutOfQuotaPolicy.ofRaw(it.toInt())
         }
       }
       136.toByte() -> {
-        return (readValue(buffer) as? List<Any?>)?.let {
-          ForegroundServiceConfig.fromList(it)
+        return (readValue(buffer) as Long?)?.let {
+          ForegroundServiceType.ofRaw(it.toInt())
         }
       }
       137.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          Constraints.fromList(it)
+          ForegroundServiceConfig.fromList(it)
         }
       }
       138.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          ContentUriTrigger.fromList(it)
+          Constraints.fromList(it)
         }
       }
       139.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          BackoffPolicyConfig.fromList(it)
+          ContentUriTrigger.fromList(it)
         }
       }
       140.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          InitializeRequest.fromList(it)
+          BackoffPolicyConfig.fromList(it)
         }
       }
       141.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          OneOffTaskRequest.fromList(it)
+          InitializeRequest.fromList(it)
         }
       }
       142.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          PeriodicTaskRequest.fromList(it)
+          OneOffTaskRequest.fromList(it)
         }
       }
       143.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          ProcessingTaskRequest.fromList(it)
+          PeriodicTaskRequest.fromList(it)
         }
       }
       144.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          HealthResearchTaskRequest.fromList(it)
+          ProcessingTaskRequest.fromList(it)
         }
       }
       145.toByte() -> {
+        return (readValue(buffer) as? List<Any?>)?.let {
+          HealthResearchTaskRequest.fromList(it)
+        }
+      }
+      146.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
           ContinuedProcessingTaskRequest.fromList(it)
         }
@@ -1075,68 +1107,72 @@ private open class WorkmanagerApiPigeonCodec : StandardMessageCodec() {
         stream.write(129)
         writeValue(stream, value.raw.toLong())
       }
-      is NetworkType -> {
+      is BackgroundTaskResult -> {
         stream.write(130)
         writeValue(stream, value.raw.toLong())
       }
-      is BackoffPolicy -> {
+      is NetworkType -> {
         stream.write(131)
         writeValue(stream, value.raw.toLong())
       }
-      is ExistingWorkPolicy -> {
+      is BackoffPolicy -> {
         stream.write(132)
         writeValue(stream, value.raw.toLong())
       }
-      is ExistingPeriodicWorkPolicy -> {
+      is ExistingWorkPolicy -> {
         stream.write(133)
         writeValue(stream, value.raw.toLong())
       }
-      is OutOfQuotaPolicy -> {
+      is ExistingPeriodicWorkPolicy -> {
         stream.write(134)
         writeValue(stream, value.raw.toLong())
       }
-      is ForegroundServiceType -> {
+      is OutOfQuotaPolicy -> {
         stream.write(135)
         writeValue(stream, value.raw.toLong())
       }
-      is ForegroundServiceConfig -> {
+      is ForegroundServiceType -> {
         stream.write(136)
-        writeValue(stream, value.toList())
+        writeValue(stream, value.raw.toLong())
       }
-      is Constraints -> {
+      is ForegroundServiceConfig -> {
         stream.write(137)
         writeValue(stream, value.toList())
       }
-      is ContentUriTrigger -> {
+      is Constraints -> {
         stream.write(138)
         writeValue(stream, value.toList())
       }
-      is BackoffPolicyConfig -> {
+      is ContentUriTrigger -> {
         stream.write(139)
         writeValue(stream, value.toList())
       }
-      is InitializeRequest -> {
+      is BackoffPolicyConfig -> {
         stream.write(140)
         writeValue(stream, value.toList())
       }
-      is OneOffTaskRequest -> {
+      is InitializeRequest -> {
         stream.write(141)
         writeValue(stream, value.toList())
       }
-      is PeriodicTaskRequest -> {
+      is OneOffTaskRequest -> {
         stream.write(142)
         writeValue(stream, value.toList())
       }
-      is ProcessingTaskRequest -> {
+      is PeriodicTaskRequest -> {
         stream.write(143)
         writeValue(stream, value.toList())
       }
-      is HealthResearchTaskRequest -> {
+      is ProcessingTaskRequest -> {
         stream.write(144)
         writeValue(stream, value.toList())
       }
-      is ContinuedProcessingTaskRequest -> {
+      is HealthResearchTaskRequest -> {
         stream.write(145)
+        writeValue(stream, value.toList())
+      }
+      is ContinuedProcessingTaskRequest -> {
+        stream.write(146)
         writeValue(stream, value.toList())
       }
       else -> super.writeValue(stream, value)
@@ -1403,7 +1439,7 @@ class WorkmanagerFlutterApi(private val binaryMessenger: BinaryMessenger, privat
       } 
     }
   }
-  fun executeTask(taskNameArg: String, inputDataArg: Map<String?, Any?>?, callback: (Result<Boolean>) -> Unit)
+  fun executeTask(taskNameArg: String, inputDataArg: Map<String?, Any?>?, callback: (Result<BackgroundTaskResult>) -> Unit)
 {
     val separatedMessageChannelSuffix = if (messageChannelSuffix.isNotEmpty()) ".$messageChannelSuffix" else ""
     val channelName = "dev.flutter.pigeon.workmanager_platform_interface.WorkmanagerFlutterApi.executeTask$separatedMessageChannelSuffix"
@@ -1415,7 +1451,7 @@ class WorkmanagerFlutterApi(private val binaryMessenger: BinaryMessenger, privat
         } else if (it[0] == null) {
           callback(Result.failure(FlutterError("null-error", "Flutter api returned null value for non-null return value.", "")))
         } else {
-          val output = it[0] as Boolean
+          val output = it[0] as BackgroundTaskResult
           callback(Result.success(output))
         }
       } else {

--- a/workmanager_android/android/src/main/kotlin/dev/fluttercommunity/workmanager/pigeon/WorkmanagerApi.g.kt
+++ b/workmanager_android/android/src/main/kotlin/dev/fluttercommunity/workmanager/pigeon/WorkmanagerApi.g.kt
@@ -223,33 +223,6 @@ enum class TaskStatus(val raw: Int) {
 }
 
 /**
- * Result of a background task execution.
- *
- * Replaces the previous `bool` return value of the task handler. Maps to
- * platform-specific semantics:
- * - [success]: Android `Result.success()`, iOS `UIBackgroundFetchResult.newData`.
- * - [retry]: Android `Result.retry()` (transient failure, backoff applies).
- *   iOS has no automatic retry — the task finishes as `.failed` and you can
- *   re-schedule it yourself.
- * - [failure]: Android `Result.failure()` (permanent failure, dependent work
- *   stops and the task is not retried). iOS `UIBackgroundFetchResult.failed`.
- */
-enum class BackgroundTaskResult(val raw: Int) {
-  /** The task completed successfully. */
-  SUCCESS(0),
-  /** The task failed transiently and should be retried (Android only). */
-  RETRY(1),
-  /** The task failed permanently and must not be retried. */
-  FAILURE(2);
-
-  companion object {
-    fun ofRaw(raw: Int): BackgroundTaskResult? {
-      return values().firstOrNull { it.raw == raw }
-    }
-  }
-}
-
-/**
  * An enumeration of various network types that can be used as Constraints for work.
  *
  * Fully supported on Android.
@@ -425,6 +398,33 @@ enum class ForegroundServiceType(val raw: Int) {
 
   companion object {
     fun ofRaw(raw: Int): ForegroundServiceType? {
+      return values().firstOrNull { it.raw == raw }
+    }
+  }
+}
+
+/**
+ * Result of a background task execution.
+ *
+ * Replaces the previous `bool` return value of the task handler. Maps to
+ * platform-specific semantics:
+ * - [success]: Android `Result.success()`, iOS `UIBackgroundFetchResult.newData`.
+ * - [retry]: Android `Result.retry()` (transient failure, backoff applies).
+ *   iOS has no automatic retry — the task finishes as `.failed` and you can
+ *   re-schedule it yourself.
+ * - [failure]: Android `Result.failure()` (permanent failure, dependent work
+ *   stops and the task is not retried). iOS `UIBackgroundFetchResult.failed`.
+ */
+enum class BackgroundTaskResult(val raw: Int) {
+  /** The task completed successfully. */
+  SUCCESS(0),
+  /** The task failed transiently and should be retried (Android only). */
+  RETRY(1),
+  /** The task failed permanently and must not be retried. */
+  FAILURE(2);
+
+  companion object {
+    fun ofRaw(raw: Int): BackgroundTaskResult? {
       return values().firstOrNull { it.raw == raw }
     }
   }
@@ -1015,37 +1015,37 @@ private open class WorkmanagerApiPigeonCodec : StandardMessageCodec() {
       }
       130.toByte() -> {
         return (readValue(buffer) as Long?)?.let {
-          BackgroundTaskResult.ofRaw(it.toInt())
+          NetworkType.ofRaw(it.toInt())
         }
       }
       131.toByte() -> {
         return (readValue(buffer) as Long?)?.let {
-          NetworkType.ofRaw(it.toInt())
+          BackoffPolicy.ofRaw(it.toInt())
         }
       }
       132.toByte() -> {
         return (readValue(buffer) as Long?)?.let {
-          BackoffPolicy.ofRaw(it.toInt())
+          ExistingWorkPolicy.ofRaw(it.toInt())
         }
       }
       133.toByte() -> {
         return (readValue(buffer) as Long?)?.let {
-          ExistingWorkPolicy.ofRaw(it.toInt())
+          ExistingPeriodicWorkPolicy.ofRaw(it.toInt())
         }
       }
       134.toByte() -> {
         return (readValue(buffer) as Long?)?.let {
-          ExistingPeriodicWorkPolicy.ofRaw(it.toInt())
+          OutOfQuotaPolicy.ofRaw(it.toInt())
         }
       }
       135.toByte() -> {
         return (readValue(buffer) as Long?)?.let {
-          OutOfQuotaPolicy.ofRaw(it.toInt())
+          ForegroundServiceType.ofRaw(it.toInt())
         }
       }
       136.toByte() -> {
         return (readValue(buffer) as Long?)?.let {
-          ForegroundServiceType.ofRaw(it.toInt())
+          BackgroundTaskResult.ofRaw(it.toInt())
         }
       }
       137.toByte() -> {
@@ -1107,31 +1107,31 @@ private open class WorkmanagerApiPigeonCodec : StandardMessageCodec() {
         stream.write(129)
         writeValue(stream, value.raw.toLong())
       }
-      is BackgroundTaskResult -> {
+      is NetworkType -> {
         stream.write(130)
         writeValue(stream, value.raw.toLong())
       }
-      is NetworkType -> {
+      is BackoffPolicy -> {
         stream.write(131)
         writeValue(stream, value.raw.toLong())
       }
-      is BackoffPolicy -> {
+      is ExistingWorkPolicy -> {
         stream.write(132)
         writeValue(stream, value.raw.toLong())
       }
-      is ExistingWorkPolicy -> {
+      is ExistingPeriodicWorkPolicy -> {
         stream.write(133)
         writeValue(stream, value.raw.toLong())
       }
-      is ExistingPeriodicWorkPolicy -> {
+      is OutOfQuotaPolicy -> {
         stream.write(134)
         writeValue(stream, value.raw.toLong())
       }
-      is OutOfQuotaPolicy -> {
+      is ForegroundServiceType -> {
         stream.write(135)
         writeValue(stream, value.raw.toLong())
       }
-      is ForegroundServiceType -> {
+      is BackgroundTaskResult -> {
         stream.write(136)
         writeValue(stream, value.raw.toLong())
       }

--- a/workmanager_apple/ios/workmanager_apple/Sources/workmanager_apple/BackgroundWorker.swift
+++ b/workmanager_apple/ios/workmanager_apple/Sources/workmanager_apple/BackgroundWorker.swift
@@ -180,14 +180,21 @@ class BackgroundWorker {
                     let errorMessage: String?
 
                     switch taskResult {
-                    case .success(let wasSuccessful):
-                        if wasSuccessful {
+                    case .success(let backgroundTaskResult):
+                        switch backgroundTaskResult {
+                        case .success:
                             fetchResult = .newData
                             status = .completed
                             errorMessage = nil
-                        } else {
+                        case .retry:
+                            // iOS has no automatic retry: report the fetch as
+                            // failed; callers can re-schedule the task.
                             fetchResult = .failed
                             status = .retrying
+                            errorMessage = nil
+                        case .failure:
+                            fetchResult = .failed
+                            status = .failed
                             errorMessage = nil
                         }
                     case .failure(let error):

--- a/workmanager_apple/ios/workmanager_apple/Sources/workmanager_apple/WorkmanagerPlugin.swift
+++ b/workmanager_apple/ios/workmanager_apple/Sources/workmanager_apple/WorkmanagerPlugin.swift
@@ -585,7 +585,7 @@ extension WorkmanagerPlugin {
         taskIdentifier: UIBackgroundTaskIdentifier,
         taskInfo: TaskDebugInfo,
         taskSessionStart: Date,
-        taskResult: Result<Bool, PigeonError>
+        taskResult: Result<BackgroundTaskResult, PigeonError>
     ) {
         UIApplication.shared.endBackgroundTask(taskIdentifier)
 
@@ -593,8 +593,15 @@ extension WorkmanagerPlugin {
         let status: TaskStatus
         let errorMessage: String?
         switch taskResult {
-        case .success:
-            status = .completed
+        case .success(let backgroundTaskResult):
+            switch backgroundTaskResult {
+            case .success:
+                status = .completed
+            case .retry:
+                status = .retrying
+            case .failure:
+                status = .failed
+            }
             errorMessage = nil
         case .failure(let error):
             status = .failed

--- a/workmanager_apple/ios/workmanager_apple/Sources/workmanager_apple/pigeon/WorkmanagerApi.g.swift
+++ b/workmanager_apple/ios/workmanager_apple/Sources/workmanager_apple/pigeon/WorkmanagerApi.g.swift
@@ -199,6 +199,25 @@ enum TaskStatus: Int {
   case rescheduled = 6
 }
 
+/// Result of a background task execution.
+///
+/// Replaces the previous `bool` return value of the task handler. Maps to
+/// platform-specific semantics:
+/// - [success]: Android `Result.success()`, iOS `UIBackgroundFetchResult.newData`.
+/// - [retry]: Android `Result.retry()` (transient failure, backoff applies).
+///   iOS has no automatic retry — the task finishes as `.failed` and you can
+///   re-schedule it yourself.
+/// - [failure]: Android `Result.failure()` (permanent failure, dependent work
+///   stops and the task is not retried). iOS `UIBackgroundFetchResult.failed`.
+enum BackgroundTaskResult: Int {
+  /// The task completed successfully.
+  case success = 0
+  /// The task failed transiently and should be retried (Android only).
+  case retry = 1
+  /// The task failed permanently and must not be retried.
+  case failure = 2
+}
+
 /// An enumeration of various network types that can be used as Constraints for work.
 ///
 /// Fully supported on Android.
@@ -901,58 +920,64 @@ private class WorkmanagerApiPigeonCodecReader: FlutterStandardReader {
     case 130:
       let enumResultAsInt: Int? = nilOrValue(self.readValue() as! Int?)
       if let enumResultAsInt = enumResultAsInt {
-        return NetworkType(rawValue: enumResultAsInt)
+        return BackgroundTaskResult(rawValue: enumResultAsInt)
       }
       return nil
     case 131:
       let enumResultAsInt: Int? = nilOrValue(self.readValue() as! Int?)
       if let enumResultAsInt = enumResultAsInt {
-        return BackoffPolicy(rawValue: enumResultAsInt)
+        return NetworkType(rawValue: enumResultAsInt)
       }
       return nil
     case 132:
       let enumResultAsInt: Int? = nilOrValue(self.readValue() as! Int?)
       if let enumResultAsInt = enumResultAsInt {
-        return ExistingWorkPolicy(rawValue: enumResultAsInt)
+        return BackoffPolicy(rawValue: enumResultAsInt)
       }
       return nil
     case 133:
       let enumResultAsInt: Int? = nilOrValue(self.readValue() as! Int?)
       if let enumResultAsInt = enumResultAsInt {
-        return ExistingPeriodicWorkPolicy(rawValue: enumResultAsInt)
+        return ExistingWorkPolicy(rawValue: enumResultAsInt)
       }
       return nil
     case 134:
       let enumResultAsInt: Int? = nilOrValue(self.readValue() as! Int?)
       if let enumResultAsInt = enumResultAsInt {
-        return OutOfQuotaPolicy(rawValue: enumResultAsInt)
+        return ExistingPeriodicWorkPolicy(rawValue: enumResultAsInt)
       }
       return nil
     case 135:
       let enumResultAsInt: Int? = nilOrValue(self.readValue() as! Int?)
       if let enumResultAsInt = enumResultAsInt {
-        return ForegroundServiceType(rawValue: enumResultAsInt)
+        return OutOfQuotaPolicy(rawValue: enumResultAsInt)
       }
       return nil
     case 136:
-      return ForegroundServiceConfig.fromList(self.readValue() as! [Any?])
+      let enumResultAsInt: Int? = nilOrValue(self.readValue() as! Int?)
+      if let enumResultAsInt = enumResultAsInt {
+        return ForegroundServiceType(rawValue: enumResultAsInt)
+      }
+      return nil
     case 137:
-      return Constraints.fromList(self.readValue() as! [Any?])
+      return ForegroundServiceConfig.fromList(self.readValue() as! [Any?])
     case 138:
-      return ContentUriTrigger.fromList(self.readValue() as! [Any?])
+      return Constraints.fromList(self.readValue() as! [Any?])
     case 139:
-      return BackoffPolicyConfig.fromList(self.readValue() as! [Any?])
+      return ContentUriTrigger.fromList(self.readValue() as! [Any?])
     case 140:
-      return InitializeRequest.fromList(self.readValue() as! [Any?])
+      return BackoffPolicyConfig.fromList(self.readValue() as! [Any?])
     case 141:
-      return OneOffTaskRequest.fromList(self.readValue() as! [Any?])
+      return InitializeRequest.fromList(self.readValue() as! [Any?])
     case 142:
-      return PeriodicTaskRequest.fromList(self.readValue() as! [Any?])
+      return OneOffTaskRequest.fromList(self.readValue() as! [Any?])
     case 143:
-      return ProcessingTaskRequest.fromList(self.readValue() as! [Any?])
+      return PeriodicTaskRequest.fromList(self.readValue() as! [Any?])
     case 144:
-      return HealthResearchTaskRequest.fromList(self.readValue() as! [Any?])
+      return ProcessingTaskRequest.fromList(self.readValue() as! [Any?])
     case 145:
+      return HealthResearchTaskRequest.fromList(self.readValue() as! [Any?])
+    case 146:
       return ContinuedProcessingTaskRequest.fromList(self.readValue() as! [Any?])
     default:
       return super.readValue(ofType: type)
@@ -965,53 +990,56 @@ private class WorkmanagerApiPigeonCodecWriter: FlutterStandardWriter {
     if let value = value as? TaskStatus {
       super.writeByte(129)
       super.writeValue(value.rawValue)
-    } else if let value = value as? NetworkType {
+    } else if let value = value as? BackgroundTaskResult {
       super.writeByte(130)
       super.writeValue(value.rawValue)
-    } else if let value = value as? BackoffPolicy {
+    } else if let value = value as? NetworkType {
       super.writeByte(131)
       super.writeValue(value.rawValue)
-    } else if let value = value as? ExistingWorkPolicy {
+    } else if let value = value as? BackoffPolicy {
       super.writeByte(132)
       super.writeValue(value.rawValue)
-    } else if let value = value as? ExistingPeriodicWorkPolicy {
+    } else if let value = value as? ExistingWorkPolicy {
       super.writeByte(133)
       super.writeValue(value.rawValue)
-    } else if let value = value as? OutOfQuotaPolicy {
+    } else if let value = value as? ExistingPeriodicWorkPolicy {
       super.writeByte(134)
       super.writeValue(value.rawValue)
-    } else if let value = value as? ForegroundServiceType {
+    } else if let value = value as? OutOfQuotaPolicy {
       super.writeByte(135)
       super.writeValue(value.rawValue)
-    } else if let value = value as? ForegroundServiceConfig {
+    } else if let value = value as? ForegroundServiceType {
       super.writeByte(136)
-      super.writeValue(value.toList())
-    } else if let value = value as? Constraints {
+      super.writeValue(value.rawValue)
+    } else if let value = value as? ForegroundServiceConfig {
       super.writeByte(137)
       super.writeValue(value.toList())
-    } else if let value = value as? ContentUriTrigger {
+    } else if let value = value as? Constraints {
       super.writeByte(138)
       super.writeValue(value.toList())
-    } else if let value = value as? BackoffPolicyConfig {
+    } else if let value = value as? ContentUriTrigger {
       super.writeByte(139)
       super.writeValue(value.toList())
-    } else if let value = value as? InitializeRequest {
+    } else if let value = value as? BackoffPolicyConfig {
       super.writeByte(140)
       super.writeValue(value.toList())
-    } else if let value = value as? OneOffTaskRequest {
+    } else if let value = value as? InitializeRequest {
       super.writeByte(141)
       super.writeValue(value.toList())
-    } else if let value = value as? PeriodicTaskRequest {
+    } else if let value = value as? OneOffTaskRequest {
       super.writeByte(142)
       super.writeValue(value.toList())
-    } else if let value = value as? ProcessingTaskRequest {
+    } else if let value = value as? PeriodicTaskRequest {
       super.writeByte(143)
       super.writeValue(value.toList())
-    } else if let value = value as? HealthResearchTaskRequest {
+    } else if let value = value as? ProcessingTaskRequest {
       super.writeByte(144)
       super.writeValue(value.toList())
-    } else if let value = value as? ContinuedProcessingTaskRequest {
+    } else if let value = value as? HealthResearchTaskRequest {
       super.writeByte(145)
+      super.writeValue(value.toList())
+    } else if let value = value as? ContinuedProcessingTaskRequest {
+      super.writeByte(146)
       super.writeValue(value.toList())
     } else {
       super.writeValue(value)
@@ -1243,7 +1271,7 @@ class WorkmanagerHostApiSetup {
 /// Generated protocol from Pigeon that represents Flutter messages that can be called from Swift.
 protocol WorkmanagerFlutterApiProtocol {
   func backgroundChannelInitialized(completion: @escaping (Result<Void, PigeonError>) -> Void)
-  func executeTask(taskName taskNameArg: String, inputData inputDataArg: [String?: Any?]?, completion: @escaping (Result<Bool, PigeonError>) -> Void)
+  func executeTask(taskName taskNameArg: String, inputData inputDataArg: [String?: Any?]?, completion: @escaping (Result<BackgroundTaskResult, PigeonError>) -> Void)
   /// Notifies the Dart callback that a running task was stopped by the
   /// platform before it finished (cancelled, timed out, preempted, ...).
   ///
@@ -1281,7 +1309,7 @@ class WorkmanagerFlutterApi: WorkmanagerFlutterApiProtocol {
       }
     }
   }
-  func executeTask(taskName taskNameArg: String, inputData inputDataArg: [String?: Any?]?, completion: @escaping (Result<Bool, PigeonError>) -> Void) {
+  func executeTask(taskName taskNameArg: String, inputData inputDataArg: [String?: Any?]?, completion: @escaping (Result<BackgroundTaskResult, PigeonError>) -> Void) {
     let channelName: String = "dev.flutter.pigeon.workmanager_platform_interface.WorkmanagerFlutterApi.executeTask\(messageChannelSuffix)"
     let channel = FlutterBasicMessageChannel(name: channelName, binaryMessenger: binaryMessenger, codec: codec)
     channel.sendMessage([taskNameArg, inputDataArg] as [Any?]) { response in
@@ -1297,7 +1325,7 @@ class WorkmanagerFlutterApi: WorkmanagerFlutterApiProtocol {
       } else if listResponse[0] == nil {
         completion(.failure(PigeonError(code: "null-error", message: "Flutter api returned null value for non-null return value.", details: "")))
       } else {
-        let result = listResponse[0] as! Bool
+        let result = listResponse[0] as! BackgroundTaskResult
         completion(.success(result))
       }
     }

--- a/workmanager_apple/ios/workmanager_apple/Sources/workmanager_apple/pigeon/WorkmanagerApi.g.swift
+++ b/workmanager_apple/ios/workmanager_apple/Sources/workmanager_apple/pigeon/WorkmanagerApi.g.swift
@@ -199,25 +199,6 @@ enum TaskStatus: Int {
   case rescheduled = 6
 }
 
-/// Result of a background task execution.
-///
-/// Replaces the previous `bool` return value of the task handler. Maps to
-/// platform-specific semantics:
-/// - [success]: Android `Result.success()`, iOS `UIBackgroundFetchResult.newData`.
-/// - [retry]: Android `Result.retry()` (transient failure, backoff applies).
-///   iOS has no automatic retry — the task finishes as `.failed` and you can
-///   re-schedule it yourself.
-/// - [failure]: Android `Result.failure()` (permanent failure, dependent work
-///   stops and the task is not retried). iOS `UIBackgroundFetchResult.failed`.
-enum BackgroundTaskResult: Int {
-  /// The task completed successfully.
-  case success = 0
-  /// The task failed transiently and should be retried (Android only).
-  case retry = 1
-  /// The task failed permanently and must not be retried.
-  case failure = 2
-}
-
 /// An enumeration of various network types that can be used as Constraints for work.
 ///
 /// Fully supported on Android.
@@ -327,6 +308,25 @@ enum ForegroundServiceType: Int {
   /// Used for short, critical work that the user is aware of and that must
   /// complete quickly (a few minutes at most).
   case shortService = 1
+}
+
+/// Result of a background task execution.
+///
+/// Replaces the previous `bool` return value of the task handler. Maps to
+/// platform-specific semantics:
+/// - [success]: Android `Result.success()`, iOS `UIBackgroundFetchResult.newData`.
+/// - [retry]: Android `Result.retry()` (transient failure, backoff applies).
+///   iOS has no automatic retry — the task finishes as `.failed` and you can
+///   re-schedule it yourself.
+/// - [failure]: Android `Result.failure()` (permanent failure, dependent work
+///   stops and the task is not retried). iOS `UIBackgroundFetchResult.failed`.
+enum BackgroundTaskResult: Int {
+  /// The task completed successfully.
+  case success = 0
+  /// The task failed transiently and should be retried (Android only).
+  case retry = 1
+  /// The task failed permanently and must not be retried.
+  case failure = 2
 }
 
 /// Android-only configuration that promotes a worker to a foreground service
@@ -920,43 +920,43 @@ private class WorkmanagerApiPigeonCodecReader: FlutterStandardReader {
     case 130:
       let enumResultAsInt: Int? = nilOrValue(self.readValue() as! Int?)
       if let enumResultAsInt = enumResultAsInt {
-        return BackgroundTaskResult(rawValue: enumResultAsInt)
+        return NetworkType(rawValue: enumResultAsInt)
       }
       return nil
     case 131:
       let enumResultAsInt: Int? = nilOrValue(self.readValue() as! Int?)
       if let enumResultAsInt = enumResultAsInt {
-        return NetworkType(rawValue: enumResultAsInt)
+        return BackoffPolicy(rawValue: enumResultAsInt)
       }
       return nil
     case 132:
       let enumResultAsInt: Int? = nilOrValue(self.readValue() as! Int?)
       if let enumResultAsInt = enumResultAsInt {
-        return BackoffPolicy(rawValue: enumResultAsInt)
+        return ExistingWorkPolicy(rawValue: enumResultAsInt)
       }
       return nil
     case 133:
       let enumResultAsInt: Int? = nilOrValue(self.readValue() as! Int?)
       if let enumResultAsInt = enumResultAsInt {
-        return ExistingWorkPolicy(rawValue: enumResultAsInt)
+        return ExistingPeriodicWorkPolicy(rawValue: enumResultAsInt)
       }
       return nil
     case 134:
       let enumResultAsInt: Int? = nilOrValue(self.readValue() as! Int?)
       if let enumResultAsInt = enumResultAsInt {
-        return ExistingPeriodicWorkPolicy(rawValue: enumResultAsInt)
+        return OutOfQuotaPolicy(rawValue: enumResultAsInt)
       }
       return nil
     case 135:
       let enumResultAsInt: Int? = nilOrValue(self.readValue() as! Int?)
       if let enumResultAsInt = enumResultAsInt {
-        return OutOfQuotaPolicy(rawValue: enumResultAsInt)
+        return ForegroundServiceType(rawValue: enumResultAsInt)
       }
       return nil
     case 136:
       let enumResultAsInt: Int? = nilOrValue(self.readValue() as! Int?)
       if let enumResultAsInt = enumResultAsInt {
-        return ForegroundServiceType(rawValue: enumResultAsInt)
+        return BackgroundTaskResult(rawValue: enumResultAsInt)
       }
       return nil
     case 137:
@@ -990,25 +990,25 @@ private class WorkmanagerApiPigeonCodecWriter: FlutterStandardWriter {
     if let value = value as? TaskStatus {
       super.writeByte(129)
       super.writeValue(value.rawValue)
-    } else if let value = value as? BackgroundTaskResult {
+    } else if let value = value as? NetworkType {
       super.writeByte(130)
       super.writeValue(value.rawValue)
-    } else if let value = value as? NetworkType {
+    } else if let value = value as? BackoffPolicy {
       super.writeByte(131)
       super.writeValue(value.rawValue)
-    } else if let value = value as? BackoffPolicy {
+    } else if let value = value as? ExistingWorkPolicy {
       super.writeByte(132)
       super.writeValue(value.rawValue)
-    } else if let value = value as? ExistingWorkPolicy {
+    } else if let value = value as? ExistingPeriodicWorkPolicy {
       super.writeByte(133)
       super.writeValue(value.rawValue)
-    } else if let value = value as? ExistingPeriodicWorkPolicy {
+    } else if let value = value as? OutOfQuotaPolicy {
       super.writeByte(134)
       super.writeValue(value.rawValue)
-    } else if let value = value as? OutOfQuotaPolicy {
+    } else if let value = value as? ForegroundServiceType {
       super.writeByte(135)
       super.writeValue(value.rawValue)
-    } else if let value = value as? ForegroundServiceType {
+    } else if let value = value as? BackgroundTaskResult {
       super.writeByte(136)
       super.writeValue(value.rawValue)
     } else if let value = value as? ForegroundServiceConfig {

--- a/workmanager_platform_interface/lib/src/pigeon/workmanager_api.g.dart
+++ b/workmanager_platform_interface/lib/src/pigeon/workmanager_api.g.dart
@@ -128,25 +128,6 @@ enum TaskStatus {
   rescheduled,
 }
 
-/// Result of a background task execution.
-///
-/// Replaces the previous `bool` return value of the task handler. Maps to
-/// platform-specific semantics:
-/// - [success]: Android `Result.success()`, iOS `UIBackgroundFetchResult.newData`.
-/// - [retry]: Android `Result.retry()` (transient failure, backoff applies).
-///   iOS has no automatic retry — the task finishes as `.failed` and you can
-///   re-schedule it yourself.
-/// - [failure]: Android `Result.failure()` (permanent failure, dependent work
-///   stops and the task is not retried). iOS `UIBackgroundFetchResult.failed`.
-enum BackgroundTaskResult {
-  /// The task completed successfully.
-  success,
-  /// The task failed transiently and should be retried (Android only).
-  retry,
-  /// The task failed permanently and must not be retried.
-  failure,
-}
-
 /// An enumeration of various network types that can be used as Constraints for work.
 ///
 /// Fully supported on Android.
@@ -256,6 +237,25 @@ enum ForegroundServiceType {
   /// Used for short, critical work that the user is aware of and that must
   /// complete quickly (a few minutes at most).
   shortService,
+}
+
+/// Result of a background task execution.
+///
+/// Replaces the previous `bool` return value of the task handler. Maps to
+/// platform-specific semantics:
+/// - [success]: Android `Result.success()`, iOS `UIBackgroundFetchResult.newData`.
+/// - [retry]: Android `Result.retry()` (transient failure, backoff applies).
+///   iOS has no automatic retry — the task finishes as `.failed` and you can
+///   re-schedule it yourself.
+/// - [failure]: Android `Result.failure()` (permanent failure, dependent work
+///   stops and the task is not retried). iOS `UIBackgroundFetchResult.failed`.
+enum BackgroundTaskResult {
+  /// The task completed successfully.
+  success,
+  /// The task failed transiently and should be retried (Android only).
+  retry,
+  /// The task failed permanently and must not be retried.
+  failure,
 }
 
 /// Android-only configuration that promotes a worker to a foreground service
@@ -936,25 +936,25 @@ class _PigeonCodec extends StandardMessageCodec {
     }    else if (value is TaskStatus) {
       buffer.putUint8(129);
       writeValue(buffer, value.index);
-    }    else if (value is BackgroundTaskResult) {
+    }    else if (value is NetworkType) {
       buffer.putUint8(130);
       writeValue(buffer, value.index);
-    }    else if (value is NetworkType) {
+    }    else if (value is BackoffPolicy) {
       buffer.putUint8(131);
       writeValue(buffer, value.index);
-    }    else if (value is BackoffPolicy) {
+    }    else if (value is ExistingWorkPolicy) {
       buffer.putUint8(132);
       writeValue(buffer, value.index);
-    }    else if (value is ExistingWorkPolicy) {
+    }    else if (value is ExistingPeriodicWorkPolicy) {
       buffer.putUint8(133);
       writeValue(buffer, value.index);
-    }    else if (value is ExistingPeriodicWorkPolicy) {
+    }    else if (value is OutOfQuotaPolicy) {
       buffer.putUint8(134);
       writeValue(buffer, value.index);
-    }    else if (value is OutOfQuotaPolicy) {
+    }    else if (value is ForegroundServiceType) {
       buffer.putUint8(135);
       writeValue(buffer, value.index);
-    }    else if (value is ForegroundServiceType) {
+    }    else if (value is BackgroundTaskResult) {
       buffer.putUint8(136);
       writeValue(buffer, value.index);
     }    else if (value is ForegroundServiceConfig) {
@@ -1000,25 +1000,25 @@ class _PigeonCodec extends StandardMessageCodec {
         return value == null ? null : TaskStatus.values[value];
       case 130:
         final value = readValue(buffer) as int?;
-        return value == null ? null : BackgroundTaskResult.values[value];
+        return value == null ? null : NetworkType.values[value];
       case 131:
         final value = readValue(buffer) as int?;
-        return value == null ? null : NetworkType.values[value];
+        return value == null ? null : BackoffPolicy.values[value];
       case 132:
         final value = readValue(buffer) as int?;
-        return value == null ? null : BackoffPolicy.values[value];
+        return value == null ? null : ExistingWorkPolicy.values[value];
       case 133:
         final value = readValue(buffer) as int?;
-        return value == null ? null : ExistingWorkPolicy.values[value];
+        return value == null ? null : ExistingPeriodicWorkPolicy.values[value];
       case 134:
         final value = readValue(buffer) as int?;
-        return value == null ? null : ExistingPeriodicWorkPolicy.values[value];
+        return value == null ? null : OutOfQuotaPolicy.values[value];
       case 135:
         final value = readValue(buffer) as int?;
-        return value == null ? null : OutOfQuotaPolicy.values[value];
+        return value == null ? null : ForegroundServiceType.values[value];
       case 136:
         final value = readValue(buffer) as int?;
-        return value == null ? null : ForegroundServiceType.values[value];
+        return value == null ? null : BackgroundTaskResult.values[value];
       case 137:
         return ForegroundServiceConfig.decode(readValue(buffer)!);
       case 138:

--- a/workmanager_platform_interface/lib/src/pigeon/workmanager_api.g.dart
+++ b/workmanager_platform_interface/lib/src/pigeon/workmanager_api.g.dart
@@ -128,6 +128,25 @@ enum TaskStatus {
   rescheduled,
 }
 
+/// Result of a background task execution.
+///
+/// Replaces the previous `bool` return value of the task handler. Maps to
+/// platform-specific semantics:
+/// - [success]: Android `Result.success()`, iOS `UIBackgroundFetchResult.newData`.
+/// - [retry]: Android `Result.retry()` (transient failure, backoff applies).
+///   iOS has no automatic retry — the task finishes as `.failed` and you can
+///   re-schedule it yourself.
+/// - [failure]: Android `Result.failure()` (permanent failure, dependent work
+///   stops and the task is not retried). iOS `UIBackgroundFetchResult.failed`.
+enum BackgroundTaskResult {
+  /// The task completed successfully.
+  success,
+  /// The task failed transiently and should be retried (Android only).
+  retry,
+  /// The task failed permanently and must not be retried.
+  failure,
+}
+
 /// An enumeration of various network types that can be used as Constraints for work.
 ///
 /// Fully supported on Android.
@@ -917,53 +936,56 @@ class _PigeonCodec extends StandardMessageCodec {
     }    else if (value is TaskStatus) {
       buffer.putUint8(129);
       writeValue(buffer, value.index);
-    }    else if (value is NetworkType) {
+    }    else if (value is BackgroundTaskResult) {
       buffer.putUint8(130);
       writeValue(buffer, value.index);
-    }    else if (value is BackoffPolicy) {
+    }    else if (value is NetworkType) {
       buffer.putUint8(131);
       writeValue(buffer, value.index);
-    }    else if (value is ExistingWorkPolicy) {
+    }    else if (value is BackoffPolicy) {
       buffer.putUint8(132);
       writeValue(buffer, value.index);
-    }    else if (value is ExistingPeriodicWorkPolicy) {
+    }    else if (value is ExistingWorkPolicy) {
       buffer.putUint8(133);
       writeValue(buffer, value.index);
-    }    else if (value is OutOfQuotaPolicy) {
+    }    else if (value is ExistingPeriodicWorkPolicy) {
       buffer.putUint8(134);
       writeValue(buffer, value.index);
-    }    else if (value is ForegroundServiceType) {
+    }    else if (value is OutOfQuotaPolicy) {
       buffer.putUint8(135);
       writeValue(buffer, value.index);
-    }    else if (value is ForegroundServiceConfig) {
+    }    else if (value is ForegroundServiceType) {
       buffer.putUint8(136);
-      writeValue(buffer, value.encode());
-    }    else if (value is Constraints) {
+      writeValue(buffer, value.index);
+    }    else if (value is ForegroundServiceConfig) {
       buffer.putUint8(137);
       writeValue(buffer, value.encode());
-    }    else if (value is ContentUriTrigger) {
+    }    else if (value is Constraints) {
       buffer.putUint8(138);
       writeValue(buffer, value.encode());
-    }    else if (value is BackoffPolicyConfig) {
+    }    else if (value is ContentUriTrigger) {
       buffer.putUint8(139);
       writeValue(buffer, value.encode());
-    }    else if (value is InitializeRequest) {
+    }    else if (value is BackoffPolicyConfig) {
       buffer.putUint8(140);
       writeValue(buffer, value.encode());
-    }    else if (value is OneOffTaskRequest) {
+    }    else if (value is InitializeRequest) {
       buffer.putUint8(141);
       writeValue(buffer, value.encode());
-    }    else if (value is PeriodicTaskRequest) {
+    }    else if (value is OneOffTaskRequest) {
       buffer.putUint8(142);
       writeValue(buffer, value.encode());
-    }    else if (value is ProcessingTaskRequest) {
+    }    else if (value is PeriodicTaskRequest) {
       buffer.putUint8(143);
       writeValue(buffer, value.encode());
-    }    else if (value is HealthResearchTaskRequest) {
+    }    else if (value is ProcessingTaskRequest) {
       buffer.putUint8(144);
       writeValue(buffer, value.encode());
-    }    else if (value is ContinuedProcessingTaskRequest) {
+    }    else if (value is HealthResearchTaskRequest) {
       buffer.putUint8(145);
+      writeValue(buffer, value.encode());
+    }    else if (value is ContinuedProcessingTaskRequest) {
+      buffer.putUint8(146);
       writeValue(buffer, value.encode());
     } else {
       super.writeValue(buffer, value);
@@ -978,41 +1000,44 @@ class _PigeonCodec extends StandardMessageCodec {
         return value == null ? null : TaskStatus.values[value];
       case 130:
         final value = readValue(buffer) as int?;
-        return value == null ? null : NetworkType.values[value];
+        return value == null ? null : BackgroundTaskResult.values[value];
       case 131:
         final value = readValue(buffer) as int?;
-        return value == null ? null : BackoffPolicy.values[value];
+        return value == null ? null : NetworkType.values[value];
       case 132:
         final value = readValue(buffer) as int?;
-        return value == null ? null : ExistingWorkPolicy.values[value];
+        return value == null ? null : BackoffPolicy.values[value];
       case 133:
         final value = readValue(buffer) as int?;
-        return value == null ? null : ExistingPeriodicWorkPolicy.values[value];
+        return value == null ? null : ExistingWorkPolicy.values[value];
       case 134:
         final value = readValue(buffer) as int?;
-        return value == null ? null : OutOfQuotaPolicy.values[value];
+        return value == null ? null : ExistingPeriodicWorkPolicy.values[value];
       case 135:
         final value = readValue(buffer) as int?;
-        return value == null ? null : ForegroundServiceType.values[value];
+        return value == null ? null : OutOfQuotaPolicy.values[value];
       case 136:
-        return ForegroundServiceConfig.decode(readValue(buffer)!);
+        final value = readValue(buffer) as int?;
+        return value == null ? null : ForegroundServiceType.values[value];
       case 137:
-        return Constraints.decode(readValue(buffer)!);
+        return ForegroundServiceConfig.decode(readValue(buffer)!);
       case 138:
-        return ContentUriTrigger.decode(readValue(buffer)!);
+        return Constraints.decode(readValue(buffer)!);
       case 139:
-        return BackoffPolicyConfig.decode(readValue(buffer)!);
+        return ContentUriTrigger.decode(readValue(buffer)!);
       case 140:
-        return InitializeRequest.decode(readValue(buffer)!);
+        return BackoffPolicyConfig.decode(readValue(buffer)!);
       case 141:
-        return OneOffTaskRequest.decode(readValue(buffer)!);
+        return InitializeRequest.decode(readValue(buffer)!);
       case 142:
-        return PeriodicTaskRequest.decode(readValue(buffer)!);
+        return OneOffTaskRequest.decode(readValue(buffer)!);
       case 143:
-        return ProcessingTaskRequest.decode(readValue(buffer)!);
+        return PeriodicTaskRequest.decode(readValue(buffer)!);
       case 144:
-        return HealthResearchTaskRequest.decode(readValue(buffer)!);
+        return ProcessingTaskRequest.decode(readValue(buffer)!);
       case 145:
+        return HealthResearchTaskRequest.decode(readValue(buffer)!);
+      case 146:
         return ContinuedProcessingTaskRequest.decode(readValue(buffer)!);
       default:
         return super.readValueOfType(type, buffer);
@@ -1239,7 +1264,7 @@ abstract class WorkmanagerFlutterApi {
 
   Future<void> backgroundChannelInitialized();
 
-  Future<bool> executeTask(String taskName, Map<String?, Object?>? inputData);
+  Future<BackgroundTaskResult> executeTask(String taskName, Map<String?, Object?>? inputData);
 
   /// Notifies the Dart callback that a running task was stopped by the
   /// platform before it finished (cancelled, timed out, preempted, ...).
@@ -1283,7 +1308,7 @@ abstract class WorkmanagerFlutterApi {
           final String arg_taskName = args[0]! as String;
           final Map<String?, Object?>? arg_inputData = (args[1] as Map<Object?, Object?>?)?.cast<String?, Object?>();
           try {
-            final bool output = await api.executeTask(arg_taskName, arg_inputData);
+            final BackgroundTaskResult output = await api.executeTask(arg_taskName, arg_inputData);
             return wrapResponse(result: output);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);

--- a/workmanager_platform_interface/pigeons/workmanager_api.dart
+++ b/workmanager_platform_interface/pigeons/workmanager_api.dart
@@ -41,6 +41,27 @@ enum TaskStatus {
   rescheduled,
 }
 
+/// Result of a background task execution.
+///
+/// Replaces the previous `bool` return value of the task handler. Maps to
+/// platform-specific semantics:
+/// - [success]: Android `Result.success()`, iOS `UIBackgroundFetchResult.newData`.
+/// - [retry]: Android `Result.retry()` (transient failure, backoff applies).
+///   iOS has no automatic retry — the task finishes as `.failed` and you can
+///   re-schedule it yourself.
+/// - [failure]: Android `Result.failure()` (permanent failure, dependent work
+///   stops and the task is not retried). iOS `UIBackgroundFetchResult.failed`.
+enum BackgroundTaskResult {
+  /// The task completed successfully.
+  success,
+
+  /// The task failed transiently and should be retried (Android only).
+  retry,
+
+  /// The task failed permanently and must not be retried.
+  failure,
+}
+
 /// An enumeration of various network types that can be used as Constraints for work.
 ///
 /// Fully supported on Android.
@@ -444,7 +465,7 @@ abstract class WorkmanagerFlutterApi {
   void backgroundChannelInitialized();
 
   @async
-  bool executeTask(String taskName, Map<String?, Object?>? inputData);
+  BackgroundTaskResult executeTask(String taskName, Map<String?, Object?>? inputData);
 
   /// Notifies the Dart callback that a running task was stopped by the
   /// platform before it finished (cancelled, timed out, preempted, ...).

--- a/workmanager_platform_interface/pigeons/workmanager_api.dart
+++ b/workmanager_platform_interface/pigeons/workmanager_api.dart
@@ -465,7 +465,8 @@ abstract class WorkmanagerFlutterApi {
   void backgroundChannelInitialized();
 
   @async
-  BackgroundTaskResult executeTask(String taskName, Map<String?, Object?>? inputData);
+  BackgroundTaskResult executeTask(
+      String taskName, Map<String?, Object?>? inputData);
 
   /// Notifies the Dart callback that a running task was stopped by the
   /// platform before it finished (cancelled, timed out, preempted, ...).

--- a/workmanager_platform_interface/pigeons/workmanager_api.dart
+++ b/workmanager_platform_interface/pigeons/workmanager_api.dart
@@ -41,27 +41,6 @@ enum TaskStatus {
   rescheduled,
 }
 
-/// Result of a background task execution.
-///
-/// Replaces the previous `bool` return value of the task handler. Maps to
-/// platform-specific semantics:
-/// - [success]: Android `Result.success()`, iOS `UIBackgroundFetchResult.newData`.
-/// - [retry]: Android `Result.retry()` (transient failure, backoff applies).
-///   iOS has no automatic retry — the task finishes as `.failed` and you can
-///   re-schedule it yourself.
-/// - [failure]: Android `Result.failure()` (permanent failure, dependent work
-///   stops and the task is not retried). iOS `UIBackgroundFetchResult.failed`.
-enum BackgroundTaskResult {
-  /// The task completed successfully.
-  success,
-
-  /// The task failed transiently and should be retried (Android only).
-  retry,
-
-  /// The task failed permanently and must not be retried.
-  failure,
-}
-
 /// An enumeration of various network types that can be used as Constraints for work.
 ///
 /// Fully supported on Android.
@@ -477,4 +456,25 @@ abstract class WorkmanagerFlutterApi {
   /// platforms without an equivalent concept.
   @async
   void onTaskStopped(String taskName, int stopReason);
+}
+
+/// Result of a background task execution.
+///
+/// Replaces the previous `bool` return value of the task handler. Maps to
+/// platform-specific semantics:
+/// - [success]: Android `Result.success()`, iOS `UIBackgroundFetchResult.newData`.
+/// - [retry]: Android `Result.retry()` (transient failure, backoff applies).
+///   iOS has no automatic retry — the task finishes as `.failed` and you can
+///   re-schedule it yourself.
+/// - [failure]: Android `Result.failure()` (permanent failure, dependent work
+///   stops and the task is not retried). iOS `UIBackgroundFetchResult.failed`.
+enum BackgroundTaskResult {
+  /// The task completed successfully.
+  success,
+
+  /// The task failed transiently and should be retried (Android only).
+  retry,
+
+  /// The task failed permanently and must not be retried.
+  failure,
 }


### PR DESCRIPTION
## What

Replaces the `Future<bool>` task handler result with a `BackgroundTaskResult` enum: **success / retry / failure** (issue #23, open since 2019).

The real gap this closes: on Android, `false` always mapped to `Result.retry()` — there was **no way to signal a permanent failure**. A task with a broken API key or invalid config was retried forever. Now:

| Dart | Android | iOS |
|---|---|---|
| `BackgroundTaskResult.success` | `Result.success()` | `.newData` |
| `BackgroundTaskResult.retry` | `Result.retry()` (backoff) | `.failed` (no auto-retry; re-schedule yourself) |
| `BackgroundTaskResult.failure` | `Result.failure()` (permanent, chain stops) | `.failed` |

## Design notes

- **Enum over sealed class**: const values, trivially serializable, matches the issue's original proposal. Name `BackgroundTaskResult` (not `Result`) to avoid clashes with user imports.
- **Breaking change** (0.10.1 → 0.11.0, pre-1.0 so fine). Migration is mechanical: `return true;` → `return BackgroundTaskResult.success;`, `return false;` → `return BackgroundTaskResult.retry;` (or `.failure` for permanent errors).
- **Web unchanged**: the handler result has no OS semantics on web, and the worker bundle must stay Flutter-free (`dart compile js`), so importing the pigeon-generated enum (which pulls `flutter/services`) isn't possible. Web keeps `Future<bool>`.
- **iOS retry**: no auto-reschedule — iOS' documented pattern is re-registering the task yourself. Auto-reschedule on `retry` could be a follow-up enhancement.

## Verified

- `dart analyze` clean (all packages + example)
- 19 Dart VM tests pass (incl. updated in-process execution round-trip)
- 78 Android unit tests pass (debug/profile/release)
- `flutter build ios --debug --no-codesign` compiles (Swift mapping incl. the in-process one-off path)
- SwiftLint clean (only pre-existing warnings)

## Migration

Docs updated (README, debugging, customization, task-status) with the new enum and an updated error-handling strategy table.
## Migration

- New `docs/migrating-to-background-task-result.mdx` migration guide (+ sidebar entry). The change is mechanical and the type system surfaces every site (handler return type is now `Future<BackgroundTaskResult>`, so each un-migrated `return true/false` is a compile error). Mapping: `true` -> `BackgroundTaskResult.success`, `false` -> `BackgroundTaskResult.retry` (preserving pre-0.11 Android behavior), `.failure` for permanent errors.
- Docs updated (README, debugging, customization, task-status) with the new enum and an updated error-handling strategy table.
