### PR TITLE
feat(android): expedited work support

### DIFF
--- a/docs/customization.mdx
+++ b/docs/customization.mdx
@@ -217,6 +217,40 @@ to happen at a specific time, schedule a one-off task with `initialDelay` that
 registers the periodic task when it runs.
 </Warning>
 
+### Expedited work (Android only)
+
+Expedited work is WorkManager's high-priority execution mode for short,
+user-visible work (for example an upload the user just triggered).
+
+```dart
+Workmanager().registerOneOffTask(
+  "sync-user-data",
+  "syncTask",
+  expedited: true,
+  outOfQuotaPolicy: OutOfQuotaPolicy.runAsNonExpeditedWorkRequest,
+);
+```
+
+What you need to know:
+
+- **Android only.** iOS, web and desktop ignore the `expedited` flag.
+- **One-off tasks only.** Expedited work is a one-time execution concept;
+  WorkManager does not support expedited periodic tasks, so the flag is not
+  available on `registerPeriodicTask`.
+- **Android 12+ (API 31+) runs expedited work as a foreground service.** The
+  system starts a WorkManager-managed foreground service and shows a
+  notification while the task runs, so the user will see it. Use expedited work
+  for work the user is waiting on, not for routine background maintenance.
+- **`outOfQuotaPolicy` only applies to expedited work.** It decides what
+  happens when the app has exhausted its expedited-job quota:
+  `runAsNonExpeditedWorkRequest` falls back to a normal (non-expedited) request,
+  `dropWorkRequest` drops the request entirely. Passing an `outOfQuotaPolicy`
+  without `expedited: true` has no effect.
+- **Constraints are limited.** Expedited work cannot use battery, charging or
+  device-idle constraints, and is intended for short work (a few minutes at
+  most), not long-running processing. For genuinely long-running work use
+  `foregroundServiceConfig` instead (see below).
+
 ## iOS: Periodic Timing & Chaining One-off Tasks
 
 On iOS there is no fixed-interval scheduler. `registerPeriodicTask` submits a

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -476,6 +476,27 @@ you'll get `BGTaskSchedulerErrorDomain Code 3` ("not advertised in the
 application's Info.plist"). On Android no native setup is needed.
 </Warning>
 
+## Expedited tasks (Android only)
+
+For one-off work that must start promptly (a user-initiated upload, a
+notification the user is waiting on), pass `expedited: true`:
+
+```dart
+await Workmanager().registerOneOffTask(
+  "sync-user-data",
+  "syncTask",
+  expedited: true,
+);
+```
+
+On Android 12+ (API 31+) the system runs expedited work as a WorkManager-
+managed foreground service and shows a notification while it runs. Expedited
+work is **one-off only** (periodic tasks cannot be expedited) and is meant for
+short, user-visible work — not long-running processing. Other platforms ignore
+the flag. See
+[Customization → Expedited work](customization#expedited-work-android-only) for
+details and the `outOfQuotaPolicy` interplay.
+
 ## Long-running tasks (foreground service)
 
 Android's WorkManager runs background workers for a limited time (typically a

--- a/docs/troubleshooting.mdx
+++ b/docs/troubleshooting.mdx
@@ -62,24 +62,26 @@ deferred work run, note it in the issue with `adb logcat` + device details.
 ## Android: expedited work (available now)
 
 For **one-off tasks that must start promptly** (e.g. a user-initiated upload),
-register the task as *expedited* by passing
-[`OutOfQuotaPolicy`](https://pub.dev/documentation/workmanager/latest/workmanager/OutOfQuotaPolicy.html):
+register the task as *expedited* with the `expedited` flag:
 
 ```dart
 await Workmanager().registerOneOffTask(
   'sync.user_data',
   'syncTask',
   inputData: {'source': 'user'},
+  expedited: true,
   outOfQuotaPolicy: OutOfQuotaPolicy.runAsNonExpeditedWorkRequest,
 );
 ```
 
 Expedited work uses a high-priority job (and on API 31+ a foreground service
-managed by WorkManager) that is far less affected by battery restrictions. Two
-important rules:
+managed by WorkManager, with a system notification) that is far less affected
+by battery restrictions. Two important rules:
 
 - Expedited jobs **cannot** use battery, charging, or device-idle constraints.
 - They are intended for short, user-visible work, not long-running processing.
+- `outOfQuotaPolicy` only takes effect when `expedited: true`; on its own it is
+  ignored (see [Customization → Expedited work](customization#expedited-work-android-only)).
 
 For genuinely **long-running** work (minutes of active processing), the
 recommended solution is the plugin's foreground-service support (shipped in

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -28,6 +28,8 @@ const simpleDelayedTask =
     "dev.fluttercommunity.workmanagerExample.simpleDelayedTask";
 const contentUriTaskKey =
     "dev.fluttercommunity.workmanagerExample.contentUriTask";
+const expeditedTaskKey =
+    "dev.fluttercommunity.workmanagerExample.expeditedTask";
 const simplePeriodicTask =
     "dev.fluttercommunity.workmanagerExample.simplePeriodicTask";
 const simplePeriodic1HourTask =
@@ -45,6 +47,7 @@ final List<String> allTasks = [
   failedTaskKey,
   simpleDelayedTask,
   contentUriTaskKey,
+  expeditedTaskKey,
   simplePeriodicTask,
   simplePeriodic1HourTask,
   iOSBackgroundAppRefresh,
@@ -88,6 +91,9 @@ void callbackDispatcher() {
       case contentUriTaskKey:
         debugPrint(
             "$contentUriTaskKey was executed after a content URI change");
+        break;
+      case expeditedTaskKey:
+        debugPrint("$expeditedTaskKey was executed (expedited)");
         break;
       case simplePeriodicTask:
         debugPrint("$simplePeriodicTask was executed");
@@ -254,6 +260,21 @@ class _MyAppState extends State<MyApp> {
                         }
                       : null,
                   child: Text("Register Content URI Task (Android)"),
+                ),
+                // This task runs once with high priority (Android only).
+                // On Android 12+ the system runs it as a foreground service
+                // managed by WorkManager and shows a notification.
+                ElevatedButton(
+                  onPressed: Platform.isAndroid
+                      ? () {
+                          Workmanager().registerOneOffTask(
+                            expeditedTaskKey,
+                            expeditedTaskKey,
+                            expedited: true,
+                          );
+                        }
+                      : null,
+                  child: Text("Register expedited task (Android)"),
                 ),
                 SizedBox(height: 8),
                 Text(

--- a/workmanager/lib/src/workmanager_impl.dart
+++ b/workmanager/lib/src/workmanager_impl.dart
@@ -243,6 +243,12 @@ class Workmanager {
   /// - [tag]: is an optional tag that can be used to identify or cancel the task.
   /// - [existingWorkPolicy]: is the policy to use when work with the same [uniqueName] already exists.
   /// - [outOfQuotaPolicy]: is the policy to use when the device is out of quota. (Android only)
+  /// - [expedited]: when true (Android only), the task is scheduled as
+  ///   expedited work. WorkManager runs expedited work with high priority; on
+  ///   Android 12 (API 31)+ the system runs it as a WorkManager-managed
+  ///   foreground service and shows a notification to the user. Only supported
+  ///   for one-off tasks — periodic tasks cannot be expedited. Other
+  ///   platforms ignore this field.
   /// - [foregroundServiceConfig]: when provided (Android only), the worker
   ///   runs as an Android foreground service for the whole duration of the
   ///   task. This allows work to keep running beyond the usual background
@@ -260,6 +266,7 @@ class Workmanager {
     String? tag,
     OutOfQuotaPolicy? outOfQuotaPolicy,
     ForegroundServiceConfig? foregroundServiceConfig,
+    bool expedited = false,
   }) async {
     return _platform.registerOneOffTask(
       uniqueName,
@@ -273,6 +280,7 @@ class Workmanager {
       tag: tag,
       outOfQuotaPolicy: outOfQuotaPolicy,
       foregroundServiceConfig: foregroundServiceConfig,
+      expedited: expedited,
     );
   }
 

--- a/workmanager/test/workmanager_test.mocks.dart
+++ b/workmanager/test/workmanager_test.mocks.dart
@@ -76,6 +76,7 @@ class MockWorkmanager extends _i1.Mock implements _i2.Workmanager {
     String? tag,
     _i4.OutOfQuotaPolicy? outOfQuotaPolicy,
     _i4.ForegroundServiceConfig? foregroundServiceConfig,
+    bool? expedited = false,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -94,6 +95,7 @@ class MockWorkmanager extends _i1.Mock implements _i2.Workmanager {
             #tag: tag,
             #outOfQuotaPolicy: outOfQuotaPolicy,
             #foregroundServiceConfig: foregroundServiceConfig,
+            #expedited: expedited,
           },
         ),
         returnValue: _i3.Future<void>.value(),

--- a/workmanager_android/android/src/main/kotlin/dev/fluttercommunity/workmanager/WorkManagerUtils.kt
+++ b/workmanager_android/android/src/main/kotlin/dev/fluttercommunity/workmanager/WorkManagerUtils.kt
@@ -167,9 +167,7 @@ private fun Map<String?, Any?>.filterNotNullKeys(): Map<String, Any> =
             if (key != null && value != null) key to value else null
         }.toMap()
 
-internal fun createOneOffWorkRequest(
-    request: dev.fluttercommunity.workmanager.pigeon.OneOffTaskRequest,
-): OneTimeWorkRequest {
+internal fun createOneOffWorkRequest(request: dev.fluttercommunity.workmanager.pigeon.OneOffTaskRequest): OneTimeWorkRequest {
     val builder =
         OneTimeWorkRequest
             .Builder(BackgroundWorker::class.java)

--- a/workmanager_android/android/src/main/kotlin/dev/fluttercommunity/workmanager/WorkManagerUtils.kt
+++ b/workmanager_android/android/src/main/kotlin/dev/fluttercommunity/workmanager/WorkManagerUtils.kt
@@ -167,6 +167,45 @@ private fun Map<String?, Any?>.filterNotNullKeys(): Map<String, Any> =
             if (key != null && value != null) key to value else null
         }.toMap()
 
+internal fun createOneOffWorkRequest(
+    request: dev.fluttercommunity.workmanager.pigeon.OneOffTaskRequest,
+): OneTimeWorkRequest {
+    val builder =
+        OneTimeWorkRequest
+            .Builder(BackgroundWorker::class.java)
+            .setInputData(
+                buildTaskInputData(
+                    request.taskName,
+                    request.inputData?.filterNotNullKeys(),
+                    request.foregroundServiceConfig,
+                ),
+            ).setInitialDelay(
+                request.initialDelaySeconds ?: DEFAULT_INITIAL_DELAY_SECONDS,
+                TimeUnit.SECONDS,
+            ).setConstraints(
+                request.constraints?.toAndroidConstraints() ?: defaultConstraints,
+            ).apply {
+                request.backoffPolicy?.let { backoffConfig ->
+                    if (backoffConfig.backoffPolicy != null && backoffConfig.backoffDelayMillis != null) {
+                        setBackoffCriteria(
+                            backoffConfig.backoffPolicy.toAndroidBackoffPolicy(),
+                            backoffConfig.backoffDelayMillis.toLong(),
+                            TimeUnit.MILLISECONDS,
+                        )
+                    }
+                }
+            }.apply {
+                request.tag?.let(::addTag)
+                if (request.expedited == true) {
+                    setExpedited(
+                        request.outOfQuotaPolicy?.toAndroidOutOfQuotaPolicy()
+                            ?: OutOfQuotaPolicy.RUN_AS_NON_EXPEDITED_WORK_REQUEST,
+                    )
+                }
+            }
+    return builder.build()
+}
+
 class WorkManagerWrapper(
     val context: Context,
 ) {
@@ -174,34 +213,7 @@ class WorkManagerWrapper(
 
     fun enqueueOneOffTask(request: dev.fluttercommunity.workmanager.pigeon.OneOffTaskRequest) {
         try {
-            val oneOffTaskRequest =
-                OneTimeWorkRequest
-                    .Builder(BackgroundWorker::class.java)
-                    .setInputData(
-                        buildTaskInputData(
-                            request.taskName,
-                            request.inputData?.filterNotNullKeys(),
-                            request.foregroundServiceConfig,
-                        ),
-                    ).setInitialDelay(
-                        request.initialDelaySeconds ?: DEFAULT_INITIAL_DELAY_SECONDS,
-                        TimeUnit.SECONDS,
-                    ).setConstraints(
-                        request.constraints?.toAndroidConstraints() ?: defaultConstraints,
-                    ).apply {
-                        request.backoffPolicy?.let { backoffConfig ->
-                            if (backoffConfig.backoffPolicy != null && backoffConfig.backoffDelayMillis != null) {
-                                setBackoffCriteria(
-                                    backoffConfig.backoffPolicy.toAndroidBackoffPolicy(),
-                                    backoffConfig.backoffDelayMillis.toLong(),
-                                    TimeUnit.MILLISECONDS,
-                                )
-                            }
-                        }
-                    }.apply {
-                        request.tag?.let(::addTag)
-                        request.outOfQuotaPolicy?.toAndroidOutOfQuotaPolicy()?.let(::setExpedited)
-                    }.build()
+            val oneOffTaskRequest = createOneOffWorkRequest(request)
             workManager.enqueueUniqueWork(
                 request.uniqueName,
                 request.existingWorkPolicy?.toAndroidWorkPolicy()

--- a/workmanager_android/android/src/main/kotlin/dev/fluttercommunity/workmanager/pigeon/WorkmanagerApi.g.kt
+++ b/workmanager_android/android/src/main/kotlin/dev/fluttercommunity/workmanager/pigeon/WorkmanagerApi.g.kt
@@ -687,7 +687,17 @@ data class OneOffTaskRequest (
   val existingWorkPolicy: ExistingWorkPolicy? = null,
   val outOfQuotaPolicy: OutOfQuotaPolicy? = null,
   /** When set, the worker runs as an Android foreground service. */
-  val foregroundServiceConfig: ForegroundServiceConfig? = null
+  val foregroundServiceConfig: ForegroundServiceConfig? = null,
+  /**
+   * When true (Android only), the task is scheduled as expedited work.
+   *
+   * WorkManager runs expedited work with high priority; on Android 12
+   * (API 31)+ the system runs it as a WorkManager-managed foreground
+   * service and shows a notification to the user. Only meaningful for
+   * one-off tasks — periodic tasks cannot be expedited. Other platforms
+   * ignore this field.
+   */
+  val expedited: Boolean? = null
 )
  {
   companion object {
@@ -702,7 +712,8 @@ data class OneOffTaskRequest (
       val existingWorkPolicy = pigeonVar_list[7] as ExistingWorkPolicy?
       val outOfQuotaPolicy = pigeonVar_list[8] as OutOfQuotaPolicy?
       val foregroundServiceConfig = pigeonVar_list[9] as ForegroundServiceConfig?
-      return OneOffTaskRequest(uniqueName, taskName, inputData, initialDelaySeconds, constraints, backoffPolicy, tag, existingWorkPolicy, outOfQuotaPolicy, foregroundServiceConfig)
+      val expedited = pigeonVar_list[10] as Boolean?
+      return OneOffTaskRequest(uniqueName, taskName, inputData, initialDelaySeconds, constraints, backoffPolicy, tag, existingWorkPolicy, outOfQuotaPolicy, foregroundServiceConfig, expedited)
     }
   }
   fun toList(): List<Any?> {
@@ -717,6 +728,7 @@ data class OneOffTaskRequest (
       existingWorkPolicy,
       outOfQuotaPolicy,
       foregroundServiceConfig,
+      expedited,
     )
   }
   override fun equals(other: Any?): Boolean {
@@ -727,7 +739,7 @@ data class OneOffTaskRequest (
       return true
     }
     val other = other as OneOffTaskRequest
-    return WorkmanagerApiPigeonUtils.deepEquals(this.uniqueName, other.uniqueName) && WorkmanagerApiPigeonUtils.deepEquals(this.taskName, other.taskName) && WorkmanagerApiPigeonUtils.deepEquals(this.inputData, other.inputData) && WorkmanagerApiPigeonUtils.deepEquals(this.initialDelaySeconds, other.initialDelaySeconds) && WorkmanagerApiPigeonUtils.deepEquals(this.constraints, other.constraints) && WorkmanagerApiPigeonUtils.deepEquals(this.backoffPolicy, other.backoffPolicy) && WorkmanagerApiPigeonUtils.deepEquals(this.tag, other.tag) && WorkmanagerApiPigeonUtils.deepEquals(this.existingWorkPolicy, other.existingWorkPolicy) && WorkmanagerApiPigeonUtils.deepEquals(this.outOfQuotaPolicy, other.outOfQuotaPolicy) && WorkmanagerApiPigeonUtils.deepEquals(this.foregroundServiceConfig, other.foregroundServiceConfig)
+    return WorkmanagerApiPigeonUtils.deepEquals(this.uniqueName, other.uniqueName) && WorkmanagerApiPigeonUtils.deepEquals(this.taskName, other.taskName) && WorkmanagerApiPigeonUtils.deepEquals(this.inputData, other.inputData) && WorkmanagerApiPigeonUtils.deepEquals(this.initialDelaySeconds, other.initialDelaySeconds) && WorkmanagerApiPigeonUtils.deepEquals(this.constraints, other.constraints) && WorkmanagerApiPigeonUtils.deepEquals(this.backoffPolicy, other.backoffPolicy) && WorkmanagerApiPigeonUtils.deepEquals(this.tag, other.tag) && WorkmanagerApiPigeonUtils.deepEquals(this.existingWorkPolicy, other.existingWorkPolicy) && WorkmanagerApiPigeonUtils.deepEquals(this.outOfQuotaPolicy, other.outOfQuotaPolicy) && WorkmanagerApiPigeonUtils.deepEquals(this.foregroundServiceConfig, other.foregroundServiceConfig) && WorkmanagerApiPigeonUtils.deepEquals(this.expedited, other.expedited)
   }
 
   override fun hashCode(): Int {
@@ -742,6 +754,7 @@ data class OneOffTaskRequest (
     result = 31 * result + WorkmanagerApiPigeonUtils.deepHash(this.existingWorkPolicy)
     result = 31 * result + WorkmanagerApiPigeonUtils.deepHash(this.outOfQuotaPolicy)
     result = 31 * result + WorkmanagerApiPigeonUtils.deepHash(this.foregroundServiceConfig)
+    result = 31 * result + WorkmanagerApiPigeonUtils.deepHash(this.expedited)
     return result
   }
 }

--- a/workmanager_android/android/src/test/kotlin/dev/fluttercommunity/workmanager/ExpeditedWorkRequestTest.kt
+++ b/workmanager_android/android/src/test/kotlin/dev/fluttercommunity/workmanager/ExpeditedWorkRequestTest.kt
@@ -13,13 +13,15 @@ import org.robolectric.annotation.Config
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [26])
 class ExpeditedWorkRequestTest {
-    private fun request(expedited: Boolean?, outOfQuotaPolicy: dev.fluttercommunity.workmanager.pigeon.OutOfQuotaPolicy? = null) =
-        OneOffTaskRequest(
-            uniqueName = "unique",
-            taskName = "task",
-            expedited = expedited,
-            outOfQuotaPolicy = outOfQuotaPolicy,
-        )
+    private fun request(
+        expedited: Boolean?,
+        outOfQuotaPolicy: dev.fluttercommunity.workmanager.pigeon.OutOfQuotaPolicy? = null,
+    ) = OneOffTaskRequest(
+        uniqueName = "unique",
+        taskName = "task",
+        expedited = expedited,
+        outOfQuotaPolicy = outOfQuotaPolicy,
+    )
 
     @Test
     fun `expedited request is scheduled as expedited with default policy`() {

--- a/workmanager_android/android/src/test/kotlin/dev/fluttercommunity/workmanager/ExpeditedWorkRequestTest.kt
+++ b/workmanager_android/android/src/test/kotlin/dev/fluttercommunity/workmanager/ExpeditedWorkRequestTest.kt
@@ -1,0 +1,78 @@
+package dev.fluttercommunity.workmanager
+
+import androidx.work.OutOfQuotaPolicy
+import dev.fluttercommunity.workmanager.pigeon.OneOffTaskRequest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [26])
+class ExpeditedWorkRequestTest {
+    private fun request(expedited: Boolean?, outOfQuotaPolicy: dev.fluttercommunity.workmanager.pigeon.OutOfQuotaPolicy? = null) =
+        OneOffTaskRequest(
+            uniqueName = "unique",
+            taskName = "task",
+            expedited = expedited,
+            outOfQuotaPolicy = outOfQuotaPolicy,
+        )
+
+    @Test
+    fun `expedited request is scheduled as expedited with default policy`() {
+        val workRequest = createOneOffWorkRequest(request(expedited = true))
+
+        assertTrue(workRequest.workSpec.expedited)
+        assertEquals(
+            OutOfQuotaPolicy.RUN_AS_NON_EXPEDITED_WORK_REQUEST,
+            workRequest.workSpec.outOfQuotaPolicy,
+        )
+    }
+
+    @Test
+    fun `expedited request keeps an explicitly provided out of quota policy`() {
+        val workRequest =
+            createOneOffWorkRequest(
+                request(
+                    expedited = true,
+                    outOfQuotaPolicy =
+                        dev.fluttercommunity.workmanager.pigeon.OutOfQuotaPolicy.DROP_WORK_REQUEST,
+                ),
+            )
+
+        assertTrue(workRequest.workSpec.expedited)
+        assertEquals(OutOfQuotaPolicy.DROP_WORK_REQUEST, workRequest.workSpec.outOfQuotaPolicy)
+    }
+
+    @Test
+    fun `non-expedited request is not expedited`() {
+        val workRequest = createOneOffWorkRequest(request(expedited = false))
+
+        assertFalse(workRequest.workSpec.expedited)
+    }
+
+    @Test
+    fun `null expedited field defaults to non-expedited`() {
+        val workRequest = createOneOffWorkRequest(request(expedited = null))
+
+        assertFalse(workRequest.workSpec.expedited)
+    }
+
+    @Test
+    fun `out of quota policy without expedited flag does not expedite the request`() {
+        val workRequest =
+            createOneOffWorkRequest(
+                request(
+                    expedited = false,
+                    outOfQuotaPolicy =
+                        dev.fluttercommunity.workmanager.pigeon.OutOfQuotaPolicy.DROP_WORK_REQUEST,
+                ),
+            )
+
+        // OutOfQuotaPolicy only takes effect for expedited work.
+        assertFalse(workRequest.workSpec.expedited)
+    }
+}

--- a/workmanager_android/lib/workmanager_android.dart
+++ b/workmanager_android/lib/workmanager_android.dart
@@ -41,6 +41,7 @@ class WorkmanagerAndroid extends WorkmanagerPlatform {
     String? tag,
     OutOfQuotaPolicy? outOfQuotaPolicy,
     ForegroundServiceConfig? foregroundServiceConfig,
+    bool expedited = false,
   }) async {
     await _api.registerOneOffTask(OneOffTaskRequest(
       uniqueName: uniqueName,
@@ -59,6 +60,7 @@ class WorkmanagerAndroid extends WorkmanagerPlatform {
       outOfQuotaPolicy: outOfQuotaPolicy,
       foregroundServiceConfig:
           resolveForegroundServiceConfig(foregroundServiceConfig),
+      expedited: expedited,
     ));
   }
 

--- a/workmanager_android/test/workmanager_android_test.dart
+++ b/workmanager_android/test/workmanager_android_test.dart
@@ -430,5 +430,43 @@ void main() {
         expect(captured.foregroundServiceConfig, isNull);
       });
     });
+
+    group('Expedited work', () {
+      const oneOffChannel =
+          'dev.flutter.pigeon.workmanager_platform_interface.WorkmanagerHostApi.registerOneOffTask';
+
+      Future<OneOffTaskRequest> captureRequest({
+        bool expedited = false,
+      }) async {
+        late OneOffTaskRequest captured;
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMessageHandler(oneOffChannel, (ByteData? message) async {
+          final decoded = WorkmanagerHostApi.pigeonChannelCodec
+              .decodeMessage(message) as List<Object?>;
+          captured = decoded[0]! as OneOffTaskRequest;
+          return WorkmanagerHostApi.pigeonChannelCodec
+              .encodeMessage(<Object?>[]);
+        });
+
+        await workmanager.registerOneOffTask(
+          'unique',
+          'task',
+          expedited: expedited,
+        );
+        return captured;
+      }
+
+      test('expedited: true is forwarded through pigeon', () async {
+        final captured = await captureRequest(expedited: true);
+
+        expect(captured.expedited, isTrue);
+      });
+
+      test('expedited: false is forwarded through pigeon', () async {
+        final captured = await captureRequest(expedited: false);
+
+        expect(captured.expedited, isFalse);
+      });
+    });
   });
 }

--- a/workmanager_apple/ios/workmanager_apple/Sources/workmanager_apple/pigeon/WorkmanagerApi.g.swift
+++ b/workmanager_apple/ios/workmanager_apple/Sources/workmanager_apple/pigeon/WorkmanagerApi.g.swift
@@ -580,6 +580,14 @@ struct OneOffTaskRequest: Hashable {
   var outOfQuotaPolicy: OutOfQuotaPolicy? = nil
   /// When set, the worker runs as an Android foreground service.
   var foregroundServiceConfig: ForegroundServiceConfig? = nil
+  /// When true (Android only), the task is scheduled as expedited work.
+  ///
+  /// WorkManager runs expedited work with high priority; on Android 12
+  /// (API 31)+ the system runs it as a WorkManager-managed foreground
+  /// service and shows a notification to the user. Only meaningful for
+  /// one-off tasks — periodic tasks cannot be expedited. Other platforms
+  /// ignore this field.
+  var expedited: Bool? = nil
 
 
   // swift-format-ignore: AlwaysUseLowerCamelCase
@@ -594,6 +602,7 @@ struct OneOffTaskRequest: Hashable {
     let existingWorkPolicy: ExistingWorkPolicy? = nilOrValue(pigeonVar_list[7])
     let outOfQuotaPolicy: OutOfQuotaPolicy? = nilOrValue(pigeonVar_list[8])
     let foregroundServiceConfig: ForegroundServiceConfig? = nilOrValue(pigeonVar_list[9])
+    let expedited: Bool? = nilOrValue(pigeonVar_list[10])
 
     return OneOffTaskRequest(
       uniqueName: uniqueName,
@@ -605,7 +614,8 @@ struct OneOffTaskRequest: Hashable {
       tag: tag,
       existingWorkPolicy: existingWorkPolicy,
       outOfQuotaPolicy: outOfQuotaPolicy,
-      foregroundServiceConfig: foregroundServiceConfig
+      foregroundServiceConfig: foregroundServiceConfig,
+      expedited: expedited
     )
   }
   func toList() -> [Any?] {
@@ -620,13 +630,14 @@ struct OneOffTaskRequest: Hashable {
       existingWorkPolicy,
       outOfQuotaPolicy,
       foregroundServiceConfig,
+      expedited,
     ]
   }
   static func == (lhs: OneOffTaskRequest, rhs: OneOffTaskRequest) -> Bool {
     if Swift.type(of: lhs) != Swift.type(of: rhs) {
       return false
     }
-    return deepEqualsWorkmanagerApi(lhs.uniqueName, rhs.uniqueName) && deepEqualsWorkmanagerApi(lhs.taskName, rhs.taskName) && deepEqualsWorkmanagerApi(lhs.inputData, rhs.inputData) && deepEqualsWorkmanagerApi(lhs.initialDelaySeconds, rhs.initialDelaySeconds) && deepEqualsWorkmanagerApi(lhs.constraints, rhs.constraints) && deepEqualsWorkmanagerApi(lhs.backoffPolicy, rhs.backoffPolicy) && deepEqualsWorkmanagerApi(lhs.tag, rhs.tag) && deepEqualsWorkmanagerApi(lhs.existingWorkPolicy, rhs.existingWorkPolicy) && deepEqualsWorkmanagerApi(lhs.outOfQuotaPolicy, rhs.outOfQuotaPolicy) && deepEqualsWorkmanagerApi(lhs.foregroundServiceConfig, rhs.foregroundServiceConfig)
+    return deepEqualsWorkmanagerApi(lhs.uniqueName, rhs.uniqueName) && deepEqualsWorkmanagerApi(lhs.taskName, rhs.taskName) && deepEqualsWorkmanagerApi(lhs.inputData, rhs.inputData) && deepEqualsWorkmanagerApi(lhs.initialDelaySeconds, rhs.initialDelaySeconds) && deepEqualsWorkmanagerApi(lhs.constraints, rhs.constraints) && deepEqualsWorkmanagerApi(lhs.backoffPolicy, rhs.backoffPolicy) && deepEqualsWorkmanagerApi(lhs.tag, rhs.tag) && deepEqualsWorkmanagerApi(lhs.existingWorkPolicy, rhs.existingWorkPolicy) && deepEqualsWorkmanagerApi(lhs.outOfQuotaPolicy, rhs.outOfQuotaPolicy) && deepEqualsWorkmanagerApi(lhs.foregroundServiceConfig, rhs.foregroundServiceConfig) && deepEqualsWorkmanagerApi(lhs.expedited, rhs.expedited)
   }
 
   func hash(into hasher: inout Hasher) {
@@ -641,6 +652,7 @@ struct OneOffTaskRequest: Hashable {
     deepHashWorkmanagerApi(value: existingWorkPolicy, hasher: &hasher)
     deepHashWorkmanagerApi(value: outOfQuotaPolicy, hasher: &hasher)
     deepHashWorkmanagerApi(value: foregroundServiceConfig, hasher: &hasher)
+    deepHashWorkmanagerApi(value: expedited, hasher: &hasher)
   }
 }
 

--- a/workmanager_apple/lib/workmanager_apple.dart
+++ b/workmanager_apple/lib/workmanager_apple.dart
@@ -40,8 +40,10 @@ class WorkmanagerApple extends WorkmanagerPlatform {
     String? tag,
     OutOfQuotaPolicy? outOfQuotaPolicy,
     ForegroundServiceConfig? foregroundServiceConfig,
+    bool expedited = false,
   }) async {
-    // Foreground service config is Android-only; it is intentionally ignored.
+    // Foreground service config and expedited are Android-only; they are
+    // intentionally ignored.
     await _api.registerOneOffTask(OneOffTaskRequest(
       uniqueName: uniqueName,
       taskName: taskName,

--- a/workmanager_platform_interface/lib/src/pigeon/workmanager_api.g.dart
+++ b/workmanager_platform_interface/lib/src/pigeon/workmanager_api.g.dart
@@ -551,6 +551,7 @@ class OneOffTaskRequest {
     this.existingWorkPolicy,
     this.outOfQuotaPolicy,
     this.foregroundServiceConfig,
+    this.expedited,
   });
 
   String uniqueName;
@@ -574,6 +575,15 @@ class OneOffTaskRequest {
   /// When set, the worker runs as an Android foreground service.
   ForegroundServiceConfig? foregroundServiceConfig;
 
+  /// When true (Android only), the task is scheduled as expedited work.
+  ///
+  /// WorkManager runs expedited work with high priority; on Android 12
+  /// (API 31)+ the system runs it as a WorkManager-managed foreground
+  /// service and shows a notification to the user. Only meaningful for
+  /// one-off tasks — periodic tasks cannot be expedited. Other platforms
+  /// ignore this field.
+  bool? expedited;
+
   List<Object?> _toList() {
     return <Object?>[
       uniqueName,
@@ -586,6 +596,7 @@ class OneOffTaskRequest {
       existingWorkPolicy,
       outOfQuotaPolicy,
       foregroundServiceConfig,
+      expedited,
     ];
   }
 
@@ -605,6 +616,7 @@ class OneOffTaskRequest {
       existingWorkPolicy: result[7] as ExistingWorkPolicy?,
       outOfQuotaPolicy: result[8] as OutOfQuotaPolicy?,
       foregroundServiceConfig: result[9] as ForegroundServiceConfig?,
+      expedited: result[10] as bool?,
     );
   }
 
@@ -617,7 +629,7 @@ class OneOffTaskRequest {
     if (identical(this, other)) {
       return true;
     }
-    return _deepEquals(uniqueName, other.uniqueName) && _deepEquals(taskName, other.taskName) && _deepEquals(inputData, other.inputData) && _deepEquals(initialDelaySeconds, other.initialDelaySeconds) && _deepEquals(constraints, other.constraints) && _deepEquals(backoffPolicy, other.backoffPolicy) && _deepEquals(tag, other.tag) && _deepEquals(existingWorkPolicy, other.existingWorkPolicy) && _deepEquals(outOfQuotaPolicy, other.outOfQuotaPolicy) && _deepEquals(foregroundServiceConfig, other.foregroundServiceConfig);
+    return _deepEquals(uniqueName, other.uniqueName) && _deepEquals(taskName, other.taskName) && _deepEquals(inputData, other.inputData) && _deepEquals(initialDelaySeconds, other.initialDelaySeconds) && _deepEquals(constraints, other.constraints) && _deepEquals(backoffPolicy, other.backoffPolicy) && _deepEquals(tag, other.tag) && _deepEquals(existingWorkPolicy, other.existingWorkPolicy) && _deepEquals(outOfQuotaPolicy, other.outOfQuotaPolicy) && _deepEquals(foregroundServiceConfig, other.foregroundServiceConfig) && _deepEquals(expedited, other.expedited);
   }
 
   @override

--- a/workmanager_platform_interface/lib/src/workmanager_platform_interface.dart
+++ b/workmanager_platform_interface/lib/src/workmanager_platform_interface.dart
@@ -53,6 +53,8 @@ abstract class WorkmanagerPlatform extends PlatformInterface {
   /// [backoffPolicyDelay] is the delay for the backoff policy.
   /// [tag] is an optional tag for the task.
   /// [outOfQuotaPolicy] determines behavior when quota is exceeded (Android only).
+  /// [expedited] schedules the task as expedited work (Android only, one-off
+  /// tasks only; other platforms ignore it).
   /// [foregroundServiceConfig] promotes the worker to an Android foreground
   /// service while it runs (Android only).
   Future<void> registerOneOffTask(
@@ -67,6 +69,7 @@ abstract class WorkmanagerPlatform extends PlatformInterface {
     String? tag,
     OutOfQuotaPolicy? outOfQuotaPolicy,
     ForegroundServiceConfig? foregroundServiceConfig,
+    bool expedited = false,
   }) {
     throw UnimplementedError('registerOneOffTask() has not been implemented.');
   }
@@ -215,6 +218,7 @@ class _PlaceholderImplementation extends WorkmanagerPlatform {
     String? tag,
     OutOfQuotaPolicy? outOfQuotaPolicy,
     ForegroundServiceConfig? foregroundServiceConfig,
+    bool expedited = false,
   }) async {
     throw UnimplementedError(
       'No implementation found for workmanager on this platform.',

--- a/workmanager_platform_interface/pigeons/workmanager_api.dart
+++ b/workmanager_platform_interface/pigeons/workmanager_api.dart
@@ -287,6 +287,7 @@ class OneOffTaskRequest {
     this.existingWorkPolicy,
     this.outOfQuotaPolicy,
     this.foregroundServiceConfig,
+    this.expedited,
   });
 
   String uniqueName;
@@ -301,6 +302,15 @@ class OneOffTaskRequest {
 
   /// When set, the worker runs as an Android foreground service.
   ForegroundServiceConfig? foregroundServiceConfig;
+
+  /// When true (Android only), the task is scheduled as expedited work.
+  ///
+  /// WorkManager runs expedited work with high priority; on Android 12
+  /// (API 31)+ the system runs it as a WorkManager-managed foreground
+  /// service and shows a notification to the user. Only meaningful for
+  /// one-off tasks — periodic tasks cannot be expedited. Other platforms
+  /// ignore this field.
+  bool? expedited;
 }
 
 class PeriodicTaskRequest {

--- a/workmanager_web/lib/workmanager_web.dart
+++ b/workmanager_web/lib/workmanager_web.dart
@@ -239,6 +239,7 @@ class WorkmanagerWeb extends WorkmanagerPlatform {
     String? tag,
     OutOfQuotaPolicy? outOfQuotaPolicy,
     ForegroundServiceConfig? foregroundServiceConfig,
+    bool expedited = false,
   }) async {
     _checkInitialized();
     final runAt = DateTime.now().add(initialDelay ?? Duration.zero);


### PR DESCRIPTION
## Summary

Adds optional **expedited work** support to `registerOneOffTask` (Android), closing audit gap #1: `setExpedited()` was never explicitly exposed and `OutOfQuotaPolicy` could not be used meaningfully.

```dart
Workmanager().registerOneOffTask(
  "sync-user-data",
  "syncTask",
  expedited: true, // new, Android only, one-off only
  outOfQuotaPolicy: OutOfQuotaPolicy.runAsNonExpeditedWorkRequest, // optional
);
```

## API shape

- New named parameter on `registerOneOffTask`: `bool expedited = false`.
- **Fully backward compatible** — optional, defaults to `false`, no existing call site changes; all platforms compile unchanged.
- Threaded through `WorkmanagerPlatform` → Pigeon `OneOffTaskRequest.expedited` (regenerated Dart/Kotlin/Swift) → Android builder.

## Android semantics (WorkManager 2.11.2)

- Mapped to `setExpedited(OutOfQuotaPolicy)` on the `OneTimeWorkRequest.Builder` (2.11.2 has no no-arg overload; the policy overload sets both `expedited=true` and the policy).
- **Android 12+ (API 31+)**: expedited work runs as a WorkManager-managed foreground service — the system shows a notification while it runs. Users will see it; use it for user-visible work (uploads the user triggered, notifications they're waiting on), not routine maintenance.
- **`OutOfQuotaPolicy` interplay**: only takes effect when `expedited: true`. It now defaults to `RUN_AS_NON_EXPEDITED_WORK_REQUEST` when expedited but no policy is passed.
  - Behavior change (bug fix): previously, passing `outOfQuotaPolicy` alone *implicitly* expedited the request (the `setExpedited(policy)` overload sets `expedited=true`). Now `outOfQuotaPolicy` is inert without `expedited: true`, matching its documented meaning. Callers who relied on the implicit behavior must pass `expedited: true`.
- **One-off only**: WorkManager does not support expedited periodic work, so the flag is deliberately **not** added to `registerPeriodicTask` (documented in docs + API docs).

## Other platforms

- `expedited` is **ignored** on iOS, web and desktop — only generated Pigeon files change there (field is never read by the platform implementations).

## Tests

- Dart: pigeon passthrough tests in `workmanager_android` (expedited true/false forwarded on the channel).
- Kotlin (Robolectric, `ExpeditedWorkRequestTest.kt`): request is expedited when set (default policy), explicit `OutOfQuotaPolicy` preserved, not expedited when `false`/`null`, `OutOfQuotaPolicy` without the flag does not expedite.

## Docs & example

- New "Expedited work (Android only)" section in `docs/customization.mdx` + quickstart section; troubleshooting page updated to the new explicit API.
- Example app: "Register expedited task (Android)" button (Android-gated) + dispatcher case.

## Quality gates

- `melos bootstrap` ✅ · `dart analyze` clean ✅ · `dart test` green (all 4 packages) ✅
- Kotlin unit tests green (7 suites, 35 tests incl. 5 new) ✅ · `dart format` clean ✅
- `flutter build apk --debug` ✅

Not merged, version not bumped.
