### PR TITLE
feat: work status observation — getWorkInfo across platforms (fixes #194)

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -2,3 +2,20 @@ excluded:
   - "**/*.g.swift"
   - "**/pigeon/*.swift"
   - "**/GeneratedPluginRegistrant.swift"
+  - "**/ephemeral/**"
+  - "**/build/**"
+  - "**/DerivedData/**"
+
+# The codebase predates these defaults; keep thresholds aligned with the
+# existing style instead of churning unrelated files when a PR touches Swift.
+line_length:
+  warning: 200
+  error: 220
+file_length:
+  warning: 1200
+  error: 1500
+function_body_length:
+  warning: 150
+  error: 200
+cyclomatic_complexity: 15
+large_tuple: 5

--- a/docs.json
+++ b/docs.json
@@ -34,6 +34,10 @@
           "href": "/task-status"
         },
         {
+          "title": "Work Status Observation",
+          "href": "/work-info"
+        },
+        {
           "title": "Debugging",
           "href": "/debugging"
         },

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -41,6 +41,7 @@ platform.
 | Constraints (network, charging, battery) | ✅ Supported | ❌ iOS applies its own system-level constraints | ❌ Not supported (ignored) | ❌ Not supported |
 | `cancelByUniqueName` / `cancelAll` | ✅ | ✅ Only cancels BGTaskScheduler requests (periodic/processing) | ✅ Invalidates scheduled activities | ✅ Removes tasks and unregisters periodic sync tags |
 | `cancelByTag` | ✅ | ❌ Not supported (no-op) | ❌ Not supported (no-op) | ✅ Supported |
+| `getWorkInfo` (status query) | ✅ Authoritative, from WorkManager | ⚠️ Best effort — from the plugin's own persisted state (BGTaskScheduler has no query API); `lastFinishedAt` set, `tags` empty | ⚠️ Best effort — same persisted-state store as iOS; `lastFinishedAt` set, `tags` empty | ⚠️ Always returns `null` (no queryable state) |
 | Task execution after app is killed | ✅ Yes (one-off/periodic) | ❌ No — iOS does not run tasks after the app is terminated | ❌ No — the app process must be alive | ⚠️ Only when the browser wakes the Service Worker (periodic sync for installed/engaged PWAs, push, or an intercepted fetch) |
 | Minimum run time budget | No hard limit, but WorkManager may defer work | ~30 seconds per task execution | No hard budget; the system may defer activities while the Mac is busy | Seconds — Service Worker wake-ups are short and browsers can terminate the worker at any time |
 

--- a/docs/work-info.mdx
+++ b/docs/work-info.mdx
@@ -1,0 +1,116 @@
+---
+title: Work Status Observation
+description: Query the state of your background tasks with getWorkInfo
+---
+
+Query what your background tasks are doing right now with `getWorkInfo`.
+
+```dart
+final WorkInfo? info = await Workmanager().getWorkInfo('my-unique-task');
+
+if (info == null) {
+  print('No record of this task');
+} else {
+  print('${info.uniqueName} is ${info.state.name}');
+  print('Periodic: ${info.isPeriodic}');
+  print('Last finished at: ${info.lastFinishedAt}');
+}
+```
+
+## The WorkInfo model
+
+| Field | Type | Meaning |
+|---|---|---|
+| `uniqueName` | `String` | The unique name the task was registered with |
+| `state` | `WorkState` | `scheduled`, `running`, `succeeded`, `failed` or `cancelled` |
+| `isPeriodic` | `bool` | Whether the task was registered with `registerPeriodicTask` |
+| `taskName` | `String?` | The task name the work was registered with, when known |
+| `tags` | `List<String>` | WorkManager tags (Android only; always empty elsewhere) |
+| `lastFinishedAt` | `DateTime?` | When the plugin last observed the task finish (see below) |
+
+`getWorkInfo` returns `null` when the platform has no record of the task
+(never registered, cancelled-and-pruned on Android, or unknown to the plugin).
+
+The state mapping is deliberately small: it is the intersection of what
+Android WorkManager and the plugin's own Apple-side state can truthfully
+report. There is no `runAttemptCount` (the maintainer explicitly declined to
+surface it) and no streaming/observation API — this is a one-shot query.
+
+## Per-platform truthfulness
+
+Different platforms have very different abilities to answer "what is my task
+doing?". The plugin is honest about that instead of pretending they are the
+same.
+
+### Android — authoritative (WorkManager)
+
+The query is served by WorkManager itself
+(`getWorkInfosForUniqueWork`). `state` is authoritative:
+
+| `WorkInfo.state` | `WorkState` |
+|---|---|
+| `ENQUEUED` | `scheduled` |
+| `BLOCKED` | `scheduled` |
+| `RUNNING` | `running` |
+| `SUCCEEDED` | `succeeded` |
+| `FAILED` | `failed` |
+| `CANCELLED` | `cancelled` |
+
+`isPeriodic` comes from WorkManager's periodicity information, `tags` from the
+work's tags, and `taskName` is read back from the worker's input data.
+`lastFinishedAt` is **always `null` on Android**: WorkManager does not expose
+a finish timestamp. Use `isScheduledByUniqueName` if you only need the
+scheduled/running boolean.
+
+After `cancelByUniqueName`, WorkManager keeps the work around (until it is
+pruned), so a query returns `state == cancelled`.
+
+### iOS / macOS — best effort (plugin-persisted state)
+
+**BGTaskScheduler (iOS) and NSBackgroundActivityScheduler (macOS) have no
+query API.** There is no way to ask the system "what is the state of this
+task?". Instead of leaving the Flutter engineer with an Android-only feature,
+the plugin persists its own view of each task:
+
+- When a task is registered, the plugin records `{uniqueName, taskName,
+  isPeriodic, state: scheduled}` in `UserDefaults`.
+- Every transition the plugin observes through its existing task-status
+  pipeline (start → `running`, completion → `succeeded`, failure → `failed`,
+  cancellation → `cancelled`, a failed attempt that will be retried →
+  `scheduled` again) updates the record.
+- `getWorkInfo` reads that store.
+
+This makes the answer **best-effort: it reflects what the plugin knows**, not
+the system scheduler's view. In particular:
+
+- If iOS prunes a pending BGTaskScheduler request without informing the app,
+  the store still reports `scheduled`.
+- `lastFinishedAt` is only set for tasks the plugin saw finish (or get
+  cancelled) while it was running.
+- `tags` is always empty (Apple has no tag concept).
+- After `cancelByUniqueName`/`cancelAll` the store reports `cancelled`
+  (mirroring Android's behaviour).
+
+The persisted state survives app restarts (it lives in `UserDefaults`), so a
+query after a cold start still answers for tasks the plugin registered in a
+previous session.
+
+### Web — no-op
+
+Browsers have no queryable task state: the Service Worker runs the compiled
+dispatcher without the plugin's Dart code, so nothing is recorded.
+`getWorkInfo` always returns `null` (documented no-op).
+
+### Other platforms (desktop)
+
+`getWorkInfo` throws `UnsupportedError`, like every other platform API on
+unsupported platforms.
+
+## Compatibility
+
+`getWorkInfo` is **new API only** — no existing method changed behaviour or
+signature. Older versions of the platform packages simply don't implement it
+(the platform interface falls back to a default that throws
+`UnimplementedError`), so upgrading the `workmanager` package without
+upgrading a platform package fails loudly at the call site rather than
+silently returning wrong data.

--- a/example/ios/RunnerTests/WorkmanagerTests.swift
+++ b/example/ios/RunnerTests/WorkmanagerTests.swift
@@ -181,4 +181,165 @@ class WorkmanagerTests: XCTestCase {
         XCTAssertTrue(UserDefaultsHelper.getScheduledTasks().isEmpty)
     }
 
+    // MARK: - WorkInfoStore (persisted task state for the query API)
+
+    func testPersistedWorkInfoRoundTrip() {
+        let uniqueName = "dev.fluttercommunity.test.workInfoRoundTrip"
+        let now = Date().timeIntervalSince1970
+
+        UserDefaultsHelper.storeWorkInfo(
+            PersistedWorkInfo(
+                state: "scheduled",
+                isPeriodic: true,
+                taskName: "dart-task",
+                lastFinishedAt: nil,
+                updatedAt: now
+            ),
+            forUniqueName: uniqueName
+        )
+
+        let stored = UserDefaultsHelper.getWorkInfo(forUniqueName: uniqueName)
+        XCTAssertNotNil(stored, "stored work info should be retrievable")
+        XCTAssertEqual(stored?.state, "scheduled")
+        XCTAssertEqual(stored?.isPeriodic, true)
+        XCTAssertEqual(stored?.taskName, "dart-task")
+        XCTAssertNil(stored?.lastFinishedAt)
+        XCTAssertEqual(stored?.updatedAt, now)
+    }
+
+    func testWorkInfoStoreTracksStatusTransitions() {
+        let uniqueName = "dev.fluttercommunity.test.transitions"
+
+        // Registration.
+        WorkInfoStore.record(
+            taskInfo: TaskDebugInfo(
+                taskName: "dart-task",
+                uniqueName: uniqueName,
+                startTime: Date().timeIntervalSince1970,
+                isPeriodic: true
+            ),
+            status: .scheduled,
+            result: nil,
+            isPeriodic: true
+        )
+        // Execution started.
+        WorkInfoStore.record(
+            taskInfo: TaskDebugInfo(
+                taskName: "dart-task",
+                uniqueName: uniqueName,
+                startTime: Date().timeIntervalSince1970
+            ),
+            status: .started,
+            result: nil,
+            isPeriodic: nil
+        )
+        // Completed successfully.
+        WorkInfoStore.record(
+            taskInfo: TaskDebugInfo(
+                taskName: "dart-task",
+                uniqueName: uniqueName,
+                startTime: Date().timeIntervalSince1970
+            ),
+            status: .completed,
+            result: TaskResult(success: true, duration: 100),
+            isPeriodic: nil
+        )
+
+        let data = WorkInfoStore.workInfoData(forUniqueName: uniqueName)
+        XCTAssertNotNil(data, "query should return a snapshot")
+        XCTAssertEqual(data?.uniqueName, uniqueName)
+        XCTAssertEqual(data?.state, .succeeded)
+        XCTAssertEqual(data?.isPeriodic, true, "isPeriodic survives execution updates")
+        XCTAssertEqual(data?.taskName, "dart-task", "taskName survives execution updates")
+        XCTAssertNotNil(data?.lastFinishedAtMillis)
+    }
+
+    func testWorkInfoStoreResolvesUniqueNameByTaskNameForOneOffTasks() {
+        // iOS one-off tasks execute under their registered taskName (the
+        // identifier); the store resolves the uniqueName via the persisted
+        // registration record.
+        let uniqueName = "dev.fluttercommunity.test.oneOffUnique"
+        WorkInfoStore.record(
+            taskInfo: TaskDebugInfo(
+                taskName: "one-off-task",
+                uniqueName: uniqueName,
+                startTime: Date().timeIntervalSince1970,
+                isPeriodic: false
+            ),
+            status: .scheduled,
+            result: nil,
+            isPeriodic: false
+        )
+        // Execution update carries only the taskName (the identifier).
+        WorkInfoStore.record(
+            taskInfo: TaskDebugInfo(
+                taskName: "one-off-task",
+                uniqueName: nil,
+                startTime: Date().timeIntervalSince1970
+            ),
+            status: .started,
+            result: nil,
+            isPeriodic: nil
+        )
+
+        let data = WorkInfoStore.workInfoData(forUniqueName: uniqueName)
+        XCTAssertEqual(data?.state, .running)
+    }
+
+    func testWorkInfoStoreRetryingMapsToScheduledWithFinishTime() {
+        let uniqueName = "dev.fluttercommunity.test.retry"
+        WorkInfoStore.record(
+            taskInfo: TaskDebugInfo(
+                taskName: "t",
+                uniqueName: uniqueName,
+                startTime: Date().timeIntervalSince1970,
+                isPeriodic: false
+            ),
+            status: .scheduled,
+            result: nil,
+            isPeriodic: false
+        )
+        WorkInfoStore.record(
+            taskInfo: TaskDebugInfo(
+                taskName: "t",
+                uniqueName: uniqueName,
+                startTime: Date().timeIntervalSince1970
+            ),
+            status: .retrying,
+            result: TaskResult(success: false, duration: 100),
+            isPeriodic: nil
+        )
+
+        let data = WorkInfoStore.workInfoData(forUniqueName: uniqueName)
+        XCTAssertEqual(data?.state, .scheduled)
+        XCTAssertNotNil(data?.lastFinishedAtMillis)
+    }
+
+    func testWorkInfoStoreCancellationMarksTheTaskCancelled() {
+        let uniqueName = "dev.fluttercommunity.test.cancel"
+        WorkInfoStore.record(
+            taskInfo: TaskDebugInfo(
+                taskName: "t",
+                uniqueName: uniqueName,
+                startTime: Date().timeIntervalSince1970,
+                isPeriodic: false
+            ),
+            status: .scheduled,
+            result: nil,
+            isPeriodic: false
+        )
+
+        WorkInfoStore.markCancelled(uniqueName: uniqueName)
+
+        let data = WorkInfoStore.workInfoData(forUniqueName: uniqueName)
+        XCTAssertEqual(data?.state, .cancelled)
+        XCTAssertNotNil(data?.lastFinishedAtMillis)
+    }
+
+    func testWorkInfoStoreUnknownTaskReturnsNil() {
+        XCTAssertNil(
+            WorkInfoStore.workInfoData(forUniqueName: "dev.fluttercommunity.test.unknown")
+        )
+    }
+
 }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -38,6 +38,7 @@ const iOSBackgroundProcessingTask =
     "dev.fluttercommunity.workmanagerExample.iOSBackgroundProcessingTask";
 const periodicUpdatePolicyTask =
     "dev.fluttercommunity.workmanagerExample.periodicUpdatePolicyTask";
+const workInfoTaskKey = "dev.fluttercommunity.workmanagerExample.workInfoTask";
 
 final List<String> allTasks = [
   simpleTaskKey,
@@ -116,6 +117,9 @@ void callbackDispatcher() {
         debugPrint(
             "$periodicUpdatePolicyTask executed with frequency: $frequency minutes at ${DateTime.now()}");
         break;
+      case workInfoTaskKey:
+        debugPrint("$workInfoTaskKey executed");
+        break;
       default:
         return Future.value(false);
     }
@@ -136,6 +140,7 @@ class MyApp extends StatefulWidget {
 class _MyAppState extends State<MyApp> {
   bool workmanagerInitialized = false;
   String _prefsString = "empty";
+  String _workInfoString = "no query yet";
   int _selectedFrequency = 15; // Default to 15 minutes
 
   @override
@@ -391,6 +396,42 @@ class _MyAppState extends State<MyApp> {
                       : null,
                   child: Text('Register BackgroundProcessingTask (iOS)'),
                 ),
+                SizedBox(height: 16),
+                Text(
+                  "Work status observation",
+                  style: Theme.of(context).textTheme.headlineSmall,
+                ),
+                Text(
+                  "Registers a one-off task, waits for it to run, then queries "
+                  "its state via getWorkInfo (Android: WorkManager; "
+                  "iOS/macOS: plugin-persisted state)",
+                  style: Theme.of(context).textTheme.bodySmall,
+                ),
+                ElevatedButton(
+                  child: Text("Register, run & query WorkInfo"),
+                  onPressed: () async {
+                    if (!workmanagerInitialized) {
+                      _showNotInitialized();
+                      return;
+                    }
+                    await Workmanager().registerOneOffTask(
+                      workInfoTaskKey,
+                      workInfoTaskKey,
+                      inputData: <String, dynamic>{'int': 1},
+                    );
+                    await Future<void>.delayed(const Duration(seconds: 2));
+                    final info =
+                        await Workmanager().getWorkInfo(workInfoTaskKey);
+                    setState(() {
+                      _workInfoString =
+                          info == null ? 'null (no record)' : info.toString();
+                    });
+                    debugPrint(
+                        'WorkInfo for $workInfoTaskKey: $_workInfoString');
+                  },
+                ),
+                SizedBox(height: 8),
+                Text('WorkInfo: $_workInfoString'),
                 SizedBox(height: 16),
                 ElevatedButton(
                     onPressed: Platform.isAndroid

--- a/workmanager/lib/src/workmanager_impl.dart
+++ b/workmanager/lib/src/workmanager_impl.dart
@@ -344,6 +344,23 @@ class Workmanager {
     return _platform.isScheduledByUniqueName(uniqueName);
   }
 
+  /// Queries the current state of the task registered under [uniqueName].
+  ///
+  /// Returns `null` when the platform has no record of the task.
+  ///
+  /// **Per-platform truthfulness**:
+  /// * Android — served by WorkManager itself; [WorkInfo.state] is
+  ///   authoritative. [WorkInfo.lastFinishedAt] is always `null` (WorkManager
+  ///   exposes no finish timestamp).
+  /// * iOS/macOS — served from the plugin's own persisted task-state store,
+  ///   because BGTaskScheduler has no query API. Best effort: it reflects what
+  ///   the plugin has observed since the task was registered (see the docs).
+  /// * Web — always `null`.
+  /// * Other platforms — throws [UnsupportedError].
+  Future<WorkInfo?> getWorkInfo(String uniqueName) {
+    return _platform.getWorkInfo(uniqueName);
+  }
+
   /// Schedule a background long running task, currently only available on iOS.
   ///
   /// Processing tasks are for long processes like data processing and app maintenance.

--- a/workmanager/test/workmanager_test.dart
+++ b/workmanager/test/workmanager_test.dart
@@ -48,4 +48,36 @@ void main() {
       verify(GetIt.I<Workmanager>().cancelByUniqueName(testTaskName));
     });
   });
+
+  group("getWorkInfo", () {
+    test("delegates to the registered platform implementation", () async {
+      final expected =
+          WorkInfo(uniqueName: 'u', state: WorkState.running, isPeriodic: false);
+      var queried = <String>[];
+      WorkmanagerPlatform.instance = _RecordingPlatform(
+        onGetWorkInfo: (uniqueName) {
+          queried.add(uniqueName);
+          return expected;
+        },
+      );
+
+      final result = await Workmanager().getWorkInfo('u');
+
+      expect(queried, ['u']);
+      expect(result, expected);
+    });
+  });
+}
+
+/// A platform implementation that records `getWorkInfo` queries and returns
+/// the value produced by [onGetWorkInfo].
+class _RecordingPlatform extends WorkmanagerPlatform {
+  _RecordingPlatform({required this.onGetWorkInfo});
+
+  final WorkInfo? Function(String uniqueName) onGetWorkInfo;
+
+  @override
+  Future<WorkInfo?> getWorkInfo(String uniqueName) async {
+    return onGetWorkInfo(uniqueName);
+  }
 }

--- a/workmanager/test/workmanager_test.dart
+++ b/workmanager/test/workmanager_test.dart
@@ -51,8 +51,8 @@ void main() {
 
   group("getWorkInfo", () {
     test("delegates to the registered platform implementation", () async {
-      final expected =
-          WorkInfo(uniqueName: 'u', state: WorkState.running, isPeriodic: false);
+      final expected = WorkInfo(
+          uniqueName: 'u', state: WorkState.running, isPeriodic: false);
       var queried = <String>[];
       WorkmanagerPlatform.instance = _RecordingPlatform(
         onGetWorkInfo: (uniqueName) {

--- a/workmanager/test/workmanager_test.mocks.dart
+++ b/workmanager/test/workmanager_test.mocks.dart
@@ -150,6 +150,16 @@ class MockWorkmanager extends _i1.Mock implements _i2.Workmanager {
       ) as _i3.Future<bool>);
 
   @override
+  _i3.Future<_i4.WorkInfo?> getWorkInfo(String? uniqueName) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #getWorkInfo,
+          [uniqueName],
+        ),
+        returnValue: _i3.Future<_i4.WorkInfo?>.value(),
+      ) as _i3.Future<_i4.WorkInfo?>);
+
+  @override
   _i3.Future<void> registerProcessingTask(
     String? uniqueName,
     String? taskName, {

--- a/workmanager_android/android/src/main/kotlin/dev/fluttercommunity/workmanager/WorkManagerUtils.kt
+++ b/workmanager_android/android/src/main/kotlin/dev/fluttercommunity/workmanager/WorkManagerUtils.kt
@@ -13,6 +13,7 @@ import androidx.work.OutOfQuotaPolicy
 import androidx.work.PeriodicWorkRequest
 import androidx.work.WorkManager
 import dev.fluttercommunity.workmanager.pigeon.TaskStatus
+import dev.fluttercommunity.workmanager.pigeon.WorkState
 import java.util.concurrent.TimeUnit
 
 // Constants
@@ -84,6 +85,34 @@ internal fun createPeriodicWorkRequest(
             tag?.let(::addTag)
             // Note: outOfQuotaPolicy is not supported for periodic tasks
         }.build()
+}
+
+/**
+ * Maps a WorkManager [androidx.work.WorkInfo] to the Pigeon transport model
+ * for the query API.
+ *
+ * The state mapping is the cross-platform subset of `WorkInfo.State`;
+ * BLOCKED (waiting on prerequisites) is reported as [WorkState.SCHEDULED].
+ * `lastFinishedAtMillis` is always null on Android: WorkManager does not
+ * expose a finish timestamp.
+ */
+internal fun androidx.work.WorkInfo.toWorkInfoData(uniqueName: String): dev.fluttercommunity.workmanager.pigeon.WorkInfoData {
+    val workState =
+        when (state) {
+            androidx.work.WorkInfo.State.ENQUEUED, androidx.work.WorkInfo.State.BLOCKED -> WorkState.SCHEDULED
+            androidx.work.WorkInfo.State.RUNNING -> WorkState.RUNNING
+            androidx.work.WorkInfo.State.SUCCEEDED -> WorkState.SUCCEEDED
+            androidx.work.WorkInfo.State.FAILED -> WorkState.FAILED
+            androidx.work.WorkInfo.State.CANCELLED -> WorkState.CANCELLED
+        }
+    return dev.fluttercommunity.workmanager.pigeon.WorkInfoData(
+        uniqueName = uniqueName,
+        state = workState,
+        isPeriodic = periodicityInfo != null,
+        taskName = outputData.getString(BackgroundWorker.DART_TASK_KEY),
+        tags = tags.sorted().map { it as String? },
+        lastFinishedAtMillis = null,
+    )
 }
 
 // Extension functions to convert Pigeon types to Android WorkManager types

--- a/workmanager_android/android/src/main/kotlin/dev/fluttercommunity/workmanager/WorkmanagerPlugin.kt
+++ b/workmanager_android/android/src/main/kotlin/dev/fluttercommunity/workmanager/WorkmanagerPlugin.kt
@@ -6,6 +6,7 @@ import dev.fluttercommunity.workmanager.pigeon.InitializeRequest
 import dev.fluttercommunity.workmanager.pigeon.OneOffTaskRequest
 import dev.fluttercommunity.workmanager.pigeon.PeriodicTaskRequest
 import dev.fluttercommunity.workmanager.pigeon.ProcessingTaskRequest
+import dev.fluttercommunity.workmanager.pigeon.WorkInfoData
 import dev.fluttercommunity.workmanager.pigeon.WorkmanagerHostApi
 import io.flutter.embedding.engine.plugins.FlutterPlugin
 
@@ -184,5 +185,21 @@ class WorkmanagerPlugin :
     override fun printScheduledTasks(callback: (Result<String>) -> Unit) {
         // Not supported on Android
         callback(Result.failure(UnsupportedOperationException("printScheduledTasks is not supported on Android")))
+    }
+
+    override fun getWorkInfoByUniqueName(
+        uniqueName: String,
+        callback: (Result<WorkInfoData?>) -> Unit,
+    ) {
+        try {
+            val workInfos = workManagerWrapper!!.getWorkInfoByUniqueName(uniqueName).get()
+            // A unique work name maps to the chain of WorkRequests enqueued
+            // under it (usually one). The head of the chain is the work the
+            // app cares about; a cancelled or pruned chain yields an empty
+            // list, which is reported as "no record" (null).
+            callback(Result.success(workInfos.firstOrNull()?.toWorkInfoData(uniqueName)))
+        } catch (e: Exception) {
+            callback(Result.failure(e))
+        }
     }
 }

--- a/workmanager_android/android/src/main/kotlin/dev/fluttercommunity/workmanager/pigeon/WorkmanagerApi.g.kt
+++ b/workmanager_android/android/src/main/kotlin/dev/fluttercommunity/workmanager/pigeon/WorkmanagerApi.g.kt
@@ -377,6 +377,33 @@ enum class OutOfQuotaPolicy(val raw: Int) {
 }
 
 /**
+ * The lifecycle state of a background task as observed by the plugin.
+ *
+ * This is the cross-platform subset of Android WorkManager's
+ * `WorkInfo.State` (ENQUEUED/RUNNING/SUCCEEDED/FAILED/CANCELLED/BLOCKED).
+ * On Apple platforms it reflects what the plugin itself has persisted from
+ * its task-status pipeline, because BGTaskScheduler has no query API.
+ */
+enum class WorkState(val raw: Int) {
+  /** The task is registered and waiting to run (Android ENQUEUED/BLOCKED). */
+  SCHEDULED(0),
+  /** The task is currently executing. */
+  RUNNING(1),
+  /** The task finished successfully. */
+  SUCCEEDED(2),
+  /** The task failed permanently. */
+  FAILED(3),
+  /** The task was cancelled before finishing. */
+  CANCELLED(4);
+
+  companion object {
+    fun ofRaw(raw: Int): WorkState? {
+      return values().firstOrNull { it.raw == raw }
+    }
+  }
+}
+
+/**
  * Foreground service types supported for Android long-running workers.
  *
  * These map to the foreground service types introduced by Android 14
@@ -978,6 +1005,76 @@ data class ContinuedProcessingTaskRequest (
     return result
   }
 }
+
+/**
+ * Snapshot of the current state of a background task, as served by the
+ * native platform. This is the transport type for [WorkmanagerHostApi.getWorkInfoByUniqueName];
+ * the public, platform-agnostic model is `WorkInfo`.
+ *
+ * Generated class from Pigeon that represents data sent in messages.
+ */
+data class WorkInfoData (
+  /** The unique name the task was registered with. */
+  val uniqueName: String,
+  /** The task's current state. */
+  val state: WorkState,
+  /** True when the task was registered as a periodic task. */
+  val isPeriodic: Boolean,
+  /** The task name the work was registered with, when the platform exposes it. */
+  val taskName: String? = null,
+  /** Tags the work was registered with (Android only; empty elsewhere). */
+  val tags: List<String?>? = null,
+  /**
+   * When the plugin last observed the task finish (succeeded, failed or was
+   * cancelled), as epoch milliseconds, when the platform exposes it.
+   * Android WorkManager has no finish timestamp, so this is null there.
+   */
+  val lastFinishedAtMillis: Long? = null
+)
+ {
+  companion object {
+    fun fromList(pigeonVar_list: List<Any?>): WorkInfoData {
+      val uniqueName = pigeonVar_list[0] as String
+      val state = pigeonVar_list[1] as WorkState
+      val isPeriodic = pigeonVar_list[2] as Boolean
+      val taskName = pigeonVar_list[3] as String?
+      val tags = pigeonVar_list[4] as List<String?>?
+      val lastFinishedAtMillis = pigeonVar_list[5] as Long?
+      return WorkInfoData(uniqueName, state, isPeriodic, taskName, tags, lastFinishedAtMillis)
+    }
+  }
+  fun toList(): List<Any?> {
+    return listOf(
+      uniqueName,
+      state,
+      isPeriodic,
+      taskName,
+      tags,
+      lastFinishedAtMillis,
+    )
+  }
+  override fun equals(other: Any?): Boolean {
+    if (other == null || other.javaClass != javaClass) {
+      return false
+    }
+    if (this === other) {
+      return true
+    }
+    val other = other as WorkInfoData
+    return WorkmanagerApiPigeonUtils.deepEquals(this.uniqueName, other.uniqueName) && WorkmanagerApiPigeonUtils.deepEquals(this.state, other.state) && WorkmanagerApiPigeonUtils.deepEquals(this.isPeriodic, other.isPeriodic) && WorkmanagerApiPigeonUtils.deepEquals(this.taskName, other.taskName) && WorkmanagerApiPigeonUtils.deepEquals(this.tags, other.tags) && WorkmanagerApiPigeonUtils.deepEquals(this.lastFinishedAtMillis, other.lastFinishedAtMillis)
+  }
+
+  override fun hashCode(): Int {
+    var result = javaClass.hashCode()
+    result = 31 * result + WorkmanagerApiPigeonUtils.deepHash(this.uniqueName)
+    result = 31 * result + WorkmanagerApiPigeonUtils.deepHash(this.state)
+    result = 31 * result + WorkmanagerApiPigeonUtils.deepHash(this.isPeriodic)
+    result = 31 * result + WorkmanagerApiPigeonUtils.deepHash(this.taskName)
+    result = 31 * result + WorkmanagerApiPigeonUtils.deepHash(this.tags)
+    result = 31 * result + WorkmanagerApiPigeonUtils.deepHash(this.lastFinishedAtMillis)
+    return result
+  }
+}
 private open class WorkmanagerApiPigeonCodec : StandardMessageCodec() {
   override fun readValueOfType(type: Byte, buffer: ByteBuffer): Any? {
     return when (type) {
@@ -1013,57 +1110,67 @@ private open class WorkmanagerApiPigeonCodec : StandardMessageCodec() {
       }
       135.toByte() -> {
         return (readValue(buffer) as Long?)?.let {
-          ForegroundServiceType.ofRaw(it.toInt())
+          WorkState.ofRaw(it.toInt())
         }
       }
       136.toByte() -> {
-        return (readValue(buffer) as? List<Any?>)?.let {
-          ForegroundServiceConfig.fromList(it)
+        return (readValue(buffer) as Long?)?.let {
+          ForegroundServiceType.ofRaw(it.toInt())
         }
       }
       137.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          Constraints.fromList(it)
+          ForegroundServiceConfig.fromList(it)
         }
       }
       138.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          ContentUriTrigger.fromList(it)
+          Constraints.fromList(it)
         }
       }
       139.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          BackoffPolicyConfig.fromList(it)
+          ContentUriTrigger.fromList(it)
         }
       }
       140.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          InitializeRequest.fromList(it)
+          BackoffPolicyConfig.fromList(it)
         }
       }
       141.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          OneOffTaskRequest.fromList(it)
+          InitializeRequest.fromList(it)
         }
       }
       142.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          PeriodicTaskRequest.fromList(it)
+          OneOffTaskRequest.fromList(it)
         }
       }
       143.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          ProcessingTaskRequest.fromList(it)
+          PeriodicTaskRequest.fromList(it)
         }
       }
       144.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          HealthResearchTaskRequest.fromList(it)
+          ProcessingTaskRequest.fromList(it)
         }
       }
       145.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
+          HealthResearchTaskRequest.fromList(it)
+        }
+      }
+      146.toByte() -> {
+        return (readValue(buffer) as? List<Any?>)?.let {
           ContinuedProcessingTaskRequest.fromList(it)
+        }
+      }
+      147.toByte() -> {
+        return (readValue(buffer) as? List<Any?>)?.let {
+          WorkInfoData.fromList(it)
         }
       }
       else -> super.readValueOfType(type, buffer)
@@ -1095,48 +1202,56 @@ private open class WorkmanagerApiPigeonCodec : StandardMessageCodec() {
         stream.write(134)
         writeValue(stream, value.raw.toLong())
       }
-      is ForegroundServiceType -> {
+      is WorkState -> {
         stream.write(135)
         writeValue(stream, value.raw.toLong())
       }
-      is ForegroundServiceConfig -> {
+      is ForegroundServiceType -> {
         stream.write(136)
-        writeValue(stream, value.toList())
+        writeValue(stream, value.raw.toLong())
       }
-      is Constraints -> {
+      is ForegroundServiceConfig -> {
         stream.write(137)
         writeValue(stream, value.toList())
       }
-      is ContentUriTrigger -> {
+      is Constraints -> {
         stream.write(138)
         writeValue(stream, value.toList())
       }
-      is BackoffPolicyConfig -> {
+      is ContentUriTrigger -> {
         stream.write(139)
         writeValue(stream, value.toList())
       }
-      is InitializeRequest -> {
+      is BackoffPolicyConfig -> {
         stream.write(140)
         writeValue(stream, value.toList())
       }
-      is OneOffTaskRequest -> {
+      is InitializeRequest -> {
         stream.write(141)
         writeValue(stream, value.toList())
       }
-      is PeriodicTaskRequest -> {
+      is OneOffTaskRequest -> {
         stream.write(142)
         writeValue(stream, value.toList())
       }
-      is ProcessingTaskRequest -> {
+      is PeriodicTaskRequest -> {
         stream.write(143)
         writeValue(stream, value.toList())
       }
-      is HealthResearchTaskRequest -> {
+      is ProcessingTaskRequest -> {
         stream.write(144)
         writeValue(stream, value.toList())
       }
-      is ContinuedProcessingTaskRequest -> {
+      is HealthResearchTaskRequest -> {
         stream.write(145)
+        writeValue(stream, value.toList())
+      }
+      is ContinuedProcessingTaskRequest -> {
+        stream.write(146)
+        writeValue(stream, value.toList())
+      }
+      is WorkInfoData -> {
+        stream.write(147)
         writeValue(stream, value.toList())
       }
       else -> super.writeValue(stream, value)
@@ -1158,6 +1273,11 @@ interface WorkmanagerHostApi {
   fun cancelAll(callback: (Result<Unit>) -> Unit)
   fun isScheduledByUniqueName(uniqueName: String, callback: (Result<Boolean>) -> Unit)
   fun printScheduledTasks(callback: (Result<String>) -> Unit)
+  /**
+   * Returns the current state of the task registered under [uniqueName], or
+   * null when the platform has no record of it.
+   */
+  fun getWorkInfoByUniqueName(uniqueName: String, callback: (Result<WorkInfoData?>) -> Unit)
 
   companion object {
     /** The codec used by WorkmanagerHostApi. */
@@ -1362,6 +1482,26 @@ interface WorkmanagerHostApi {
         if (api != null) {
           channel.setMessageHandler { _, reply ->
             api.printScheduledTasks{ result: Result<String> ->
+              val error = result.exceptionOrNull()
+              if (error != null) {
+                reply.reply(WorkmanagerApiPigeonUtils.wrapError(error))
+              } else {
+                val data = result.getOrNull()
+                reply.reply(WorkmanagerApiPigeonUtils.wrapResult(data))
+              }
+            }
+          }
+        } else {
+          channel.setMessageHandler(null)
+        }
+      }
+      run {
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.workmanager_platform_interface.WorkmanagerHostApi.getWorkInfoByUniqueName$separatedMessageChannelSuffix", codec)
+        if (api != null) {
+          channel.setMessageHandler { message, reply ->
+            val args = message as List<Any?>
+            val uniqueNameArg = args[0] as String
+            api.getWorkInfoByUniqueName(uniqueNameArg) { result: Result<WorkInfoData?> ->
               val error = result.exceptionOrNull()
               if (error != null) {
                 reply.reply(WorkmanagerApiPigeonUtils.wrapError(error))

--- a/workmanager_android/android/src/test/kotlin/dev/fluttercommunity/workmanager/WorkInfoMappingTest.kt
+++ b/workmanager_android/android/src/test/kotlin/dev/fluttercommunity/workmanager/WorkInfoMappingTest.kt
@@ -1,0 +1,97 @@
+package dev.fluttercommunity.workmanager
+
+import androidx.work.Constraints
+import androidx.work.Data
+import androidx.work.WorkInfo
+import dev.fluttercommunity.workmanager.pigeon.WorkState
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.util.UUID
+
+class WorkInfoMappingTest {
+
+    private fun workInfo(
+        state: WorkInfo.State,
+        tags: Set<String> = setOf("tag-b", "tag-a"),
+        taskName: String? = "dart-task",
+        periodic: Boolean = false,
+    ): WorkInfo {
+        val data = Data.Builder().putString(BackgroundWorker.DART_TASK_KEY, taskName).build()
+        return if (periodic) {
+            WorkInfo(
+                UUID.randomUUID(),
+                state,
+                tags,
+                data,
+                Data.EMPTY,
+                0,
+                0,
+                Constraints.NONE,
+                0L,
+                WorkInfo.PeriodicityInfo(900_000L, 0L),
+            )
+        } else {
+            WorkInfo(UUID.randomUUID(), state, tags, data)
+        }
+    }
+
+    @Test
+    fun `enqueued work maps to scheduled state`() {
+        val data = workInfo(WorkInfo.State.ENQUEUED).toWorkInfoData("unique-name")
+
+        assertEquals("unique-name", data.uniqueName)
+        assertEquals(WorkState.SCHEDULED, data.state)
+        assertFalse(data.isPeriodic)
+        assertEquals("dart-task", data.taskName)
+        assertEquals(listOf("tag-a", "tag-b"), data.tags)
+        assertNull(data.lastFinishedAtMillis)
+    }
+
+    @Test
+    fun `blocked work maps to scheduled state`() {
+        assertEquals(WorkState.SCHEDULED, workInfo(WorkInfo.State.BLOCKED).toWorkInfoData("u").state)
+    }
+
+    @Test
+    fun `running work maps to running state`() {
+        assertEquals(WorkState.RUNNING, workInfo(WorkInfo.State.RUNNING).toWorkInfoData("u").state)
+    }
+
+    @Test
+    fun `succeeded work maps to succeeded state`() {
+        assertEquals(WorkState.SUCCEEDED, workInfo(WorkInfo.State.SUCCEEDED).toWorkInfoData("u").state)
+    }
+
+    @Test
+    fun `failed work maps to failed state`() {
+        assertEquals(WorkState.FAILED, workInfo(WorkInfo.State.FAILED).toWorkInfoData("u").state)
+    }
+
+    @Test
+    fun `cancelled work maps to cancelled state`() {
+        assertEquals(WorkState.CANCELLED, workInfo(WorkInfo.State.CANCELLED).toWorkInfoData("u").state)
+    }
+
+    @Test
+    fun `periodic work is reported via periodicity info`() {
+        val data = workInfo(WorkInfo.State.ENQUEUED, periodic = true).toWorkInfoData("u")
+
+        assertTrue(data.isPeriodic)
+    }
+
+    @Test
+    fun `missing task name stays null`() {
+        val info =
+            WorkInfo(
+                UUID.randomUUID(),
+                WorkInfo.State.ENQUEUED,
+                setOf("tag"),
+                Data.EMPTY,
+            )
+
+        assertNull(info.toWorkInfoData("u").taskName)
+    }
+}

--- a/workmanager_android/android/src/test/kotlin/dev/fluttercommunity/workmanager/WorkInfoMappingTest.kt
+++ b/workmanager_android/android/src/test/kotlin/dev/fluttercommunity/workmanager/WorkInfoMappingTest.kt
@@ -12,7 +12,6 @@ import org.junit.Test
 import java.util.UUID
 
 class WorkInfoMappingTest {
-
     private fun workInfo(
         state: WorkInfo.State,
         tags: Set<String> = setOf("tag-b", "tag-a"),

--- a/workmanager_android/lib/workmanager_android.dart
+++ b/workmanager_android/lib/workmanager_android.dart
@@ -160,6 +160,12 @@ class WorkmanagerAndroid extends WorkmanagerPlatform {
   Future<String> printScheduledTasks() async {
     throw UnsupportedError('printScheduledTasks is not supported on Android');
   }
+
+  @override
+  Future<WorkInfo?> getWorkInfo(String uniqueName) async {
+    final data = await _api.getWorkInfoByUniqueName(uniqueName);
+    return data == null ? null : WorkInfo.fromData(data);
+  }
 }
 
 /// Defaults for the Android foreground service notification.

--- a/workmanager_android/test/workmanager_android_test.dart
+++ b/workmanager_android/test/workmanager_android_test.dart
@@ -53,7 +53,8 @@ void main() {
         );
       });
 
-      test('getWorkInfo returns null when the platform has no record', () async {
+      test('getWorkInfo returns null when the platform has no record',
+          () async {
         _mockGetWorkInfoReply(<Object?>[null]);
 
         expect(await workmanager.getWorkInfo('unknown-task'), isNull);

--- a/workmanager_android/test/workmanager_android_test.dart
+++ b/workmanager_android/test/workmanager_android_test.dart
@@ -52,6 +52,38 @@ void main() {
           )),
         );
       });
+
+      test('getWorkInfo returns null when the platform has no record', () async {
+        _mockGetWorkInfoReply(<Object?>[null]);
+
+        expect(await workmanager.getWorkInfo('unknown-task'), isNull);
+      });
+
+      test('getWorkInfo maps the pigeon reply into a WorkInfo', () async {
+        _mockGetWorkInfoReply(<Object?>[
+          WorkInfoData(
+            uniqueName: 'com.example.task',
+            state: WorkState.succeeded,
+            isPeriodic: true,
+            taskName: 'dart-task',
+            tags: <String?>['tag-a', 'tag-b'],
+            lastFinishedAtMillis: 1700000000000,
+          ),
+        ]);
+
+        final info = await workmanager.getWorkInfo('com.example.task');
+
+        expect(info, isNotNull);
+        expect(info!.uniqueName, 'com.example.task');
+        expect(info.state, WorkState.succeeded);
+        expect(info.isPeriodic, isTrue);
+        expect(info.taskName, 'dart-task');
+        expect(info.tags, <String>['tag-a', 'tag-b']);
+        expect(
+          info.lastFinishedAt,
+          DateTime.fromMillisecondsSinceEpoch(1700000000000),
+        );
+      });
     });
 
     group('Android WorkManager constraints mapping', () {
@@ -431,4 +463,17 @@ void main() {
       });
     });
   });
+}
+
+/// Stubs the pigeon `getWorkInfoByUniqueName` channel with [reply] so the
+/// platform implementation's query plumbing can be exercised in tests.
+void _mockGetWorkInfoReply(List<Object?> reply) {
+  const channelName =
+      'dev.flutter.pigeon.workmanager_platform_interface.WorkmanagerHostApi.getWorkInfoByUniqueName';
+  final channel = BasicMessageChannel<Object?>(
+    channelName,
+    WorkmanagerHostApi.pigeonChannelCodec,
+  );
+  TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+      .setMockDecodedMessageHandler<Object?>(channel, (message) async => reply);
 }

--- a/workmanager_apple/ios/workmanager_apple/Sources/workmanager_apple/BGContinuedProcessingTaskScheduler.swift
+++ b/workmanager_apple/ios/workmanager_apple/Sources/workmanager_apple/BGContinuedProcessingTaskScheduler.swift
@@ -52,9 +52,10 @@ extension WorkmanagerPlugin {
             taskName: request.taskName,
             uniqueName: request.uniqueName,
             inputData: request.inputData as? [String: Any],
-            startTime: Date().timeIntervalSince1970
+            startTime: Date().timeIntervalSince1970,
+            isPeriodic: false
         )
-        WorkmanagerDebug.getCurrent().onTaskStatusUpdate(taskInfo: taskInfo, status: .scheduled, result: nil)
+        WorkmanagerDebug.onTaskStatusUpdate(taskInfo: taskInfo, status: .scheduled, result: nil)
         completion(.success(()))
     }
     #elseif os(macOS)

--- a/workmanager_apple/ios/workmanager_apple/Sources/workmanager_apple/BackgroundWorker.swift
+++ b/workmanager_apple/ios/workmanager_apple/Sources/workmanager_apple/BackgroundWorker.swift
@@ -120,11 +120,38 @@ class BackgroundWorker {
 
         let taskSessionStart = Date()
 
+        // Derive the identity of the task for the debug/status pipeline. The
+        // scheduler identifier is the uniqueName for BGTaskScheduler-delivered
+        // tasks; iOS one-off tasks execute under their registered taskName
+        // (resolved to the uniqueName by WorkInfoStore).
+        var taskUniqueName: String?
+        var taskName: String
+        switch backgroundMode {
+        case .backgroundFetch:
+            taskName = "iOSPerformFetch"
+        case let .backgroundPeriodicTask(identifier), let .backgroundProcessingTask(identifier), let .backgroundHealthResearchTask(identifier), let .backgroundContinuedProcessingTask(identifier):
+            taskUniqueName = identifier
+            taskName = identifier
+        case let .backgroundOneOffTask(identifier):
+            taskName = identifier
+#if os(iOS)
+            // iOS one-off tasks run under the registered taskName; the store
+            // resolves the uniqueName via the persisted registration record.
+#elseif os(macOS)
+            // On macOS the activity identifier (and the task name the Dart
+            // handler receives) is the uniqueName.
+            taskUniqueName = identifier
+#endif
+        }
+        let isPeriodic: Bool? = { if case .backgroundPeriodicTask = backgroundMode { return true } else { return false } }()
+
         let taskInfo = TaskDebugInfo(
-            taskName: "background_fetch",
+            taskName: taskName,
+            uniqueName: taskUniqueName,
             startTime: taskSessionStart.timeIntervalSince1970,
             callbackHandle: resolved.handle,
-            callbackInfo: resolved.entrypoint.name
+            callbackInfo: resolved.entrypoint.name,
+            isPeriodic: isPeriodic
         )
 
         WorkmanagerDebug.onTaskStatusUpdate(taskInfo: taskInfo, status: .started)

--- a/workmanager_apple/ios/workmanager_apple/Sources/workmanager_apple/UserDefaultsHelper.swift
+++ b/workmanager_apple/ios/workmanager_apple/Sources/workmanager_apple/UserDefaultsHelper.swift
@@ -23,6 +23,25 @@ struct ScheduledTaskInfo: Codable {
     let earliestBeginInSeconds: Double?
 }
 
+/// The plugin's own view of a task's state, persisted so `getWorkInfo` can be
+/// answered on Apple platforms.
+///
+/// BGTaskScheduler / NSBackgroundActivityScheduler have no query API, so the
+/// plugin records what its task-status pipeline observes (registration, start,
+/// completion, failure, cancellation) and serves queries from that store. The
+/// result is best-effort: it reflects what the plugin has seen, not the
+/// system scheduler's view.
+struct PersistedWorkInfo: Codable {
+    /// One of `scheduled`, `running`, `succeeded`, `failed`, `cancelled`.
+    var state: String
+    var isPeriodic: Bool
+    var taskName: String?
+    /// Epoch seconds when the plugin last observed the task finish
+    /// (succeeded, failed or was cancelled).
+    var lastFinishedAt: TimeInterval?
+    var updatedAt: TimeInterval
+}
+
 struct UserDefaultsHelper {
 
     // MARK: Properties
@@ -33,6 +52,7 @@ struct UserDefaultsHelper {
         case callbackHandle
         case periodicTaskInputData(taskIdentifier: String)
         case scheduledTasks
+        case workInfos
 
         var stringValue: String {
             switch self {
@@ -42,6 +62,8 @@ struct UserDefaultsHelper {
                 return "\(WorkmanagerPlugin.identifier).periodicTaskInputData.\(taskIdentifier)"
             case .scheduledTasks:
                 return "\(WorkmanagerPlugin.identifier).scheduledTasks"
+            case .workInfos:
+                return "\(WorkmanagerPlugin.identifier).workInfos"
             }
         }
     }
@@ -103,6 +125,29 @@ struct UserDefaultsHelper {
 
     static func removeAllScheduledTasks() {
         userDefaults.removeObject(forKey: Key.scheduledTasks.stringValue)
+    }
+
+    // MARK: WorkInfo (persisted task state for the query API)
+
+    static func storeWorkInfo(_ info: PersistedWorkInfo, forUniqueName uniqueName: String) {
+        var infos = getAllWorkInfos()
+        infos[uniqueName] = info
+        if let data = try? JSONEncoder().encode(infos) {
+            userDefaults.set(data, forKey: Key.workInfos.stringValue)
+        }
+    }
+
+    static func getWorkInfo(forUniqueName uniqueName: String) -> PersistedWorkInfo? {
+        return getAllWorkInfos()[uniqueName]
+    }
+
+    static func getAllWorkInfos() -> [String: PersistedWorkInfo] {
+        guard let data = userDefaults.data(forKey: Key.workInfos.stringValue),
+              let infos = try? JSONDecoder().decode([String: PersistedWorkInfo].self, from: data)
+        else {
+            return [:]
+        }
+        return infos
     }
 
     // MARK: Private helper functions

--- a/workmanager_apple/ios/workmanager_apple/Sources/workmanager_apple/WorkInfoStore.swift
+++ b/workmanager_apple/ios/workmanager_apple/Sources/workmanager_apple/WorkInfoStore.swift
@@ -1,0 +1,150 @@
+import Foundation
+
+/// Persists the plugin's own view of task state on Apple platforms and serves
+/// the `getWorkInfo` query from it.
+///
+/// **Why this exists**: BGTaskScheduler (iOS) and NSBackgroundActivityScheduler
+/// (macOS) have **no query API** — there is no way to ask the system "what is
+/// the state of this task?". Rather than telling the Flutter engineer "you
+/// can't know", the plugin records every task-status transition it observes
+/// (registration, start, completion, failure, cancellation) into UserDefaults
+/// and answers queries from that store.
+///
+/// The result is intentionally best-effort and documented as such: it reflects
+/// what the plugin has seen, not the system scheduler's view. For example iOS
+/// may prune pending BGTaskScheduler requests without informing the app; the
+/// store would still report the task as `scheduled`.
+enum WorkInfoStore {
+
+    /// Records a task-status transition observed by the plugin.
+    ///
+    /// - Parameters:
+    ///   - taskInfo: Debug info for the transition. `uniqueName` keys the
+    ///     store; when it is nil (iOS one-off tasks execute under their
+    ///     registered `taskName`), the record is resolved by `taskName`, which
+    ///     the registration step always persisted.
+    ///   - status: The observed status.
+    ///   - result: Result of the run, when the transition ended a run.
+    ///   - isPeriodic: Whether the task is periodic; only the registration
+    ///     sites know this for certain, so nil keeps the recorded value.
+    static func record(taskInfo: TaskDebugInfo, status: TaskStatus, result: TaskResult?, isPeriodic: Bool?) {
+        guard let uniqueName = resolveUniqueName(taskInfo: taskInfo) else {
+            return
+        }
+        let existing = UserDefaultsHelper.getWorkInfo(forUniqueName: uniqueName)
+        let now = Date().timeIntervalSince1970
+
+        let state: String
+        var lastFinishedAt = existing?.lastFinishedAt
+        switch status {
+        case .scheduled:
+            state = "scheduled"
+        case .started:
+            state = "running"
+        case .completed:
+            state = "succeeded"
+            lastFinishedAt = now
+        case .failed:
+            state = "failed"
+            lastFinishedAt = now
+        case .cancelled:
+            state = "cancelled"
+            lastFinishedAt = now
+        case .retrying, .rescheduled:
+            // The attempt ended without success and the task is expected to
+            // run again; report it as scheduled with the attempt's finish time.
+            state = "scheduled"
+            lastFinishedAt = now
+        }
+
+        // The registration step is the only place that carries the
+        // user-facing taskName; execution updates (which report the scheduler
+        // identifier) must not overwrite it.
+        let resolvedTaskName: String?
+        if status == .scheduled {
+            resolvedTaskName = taskInfo.taskName
+        } else {
+            resolvedTaskName = existing?.taskName ?? taskInfo.taskName
+        }
+
+        UserDefaultsHelper.storeWorkInfo(
+            PersistedWorkInfo(
+                state: state,
+                isPeriodic: isPeriodic ?? existing?.isPeriodic ?? false,
+                taskName: resolvedTaskName,
+                lastFinishedAt: lastFinishedAt,
+                updatedAt: now
+            ),
+            forUniqueName: uniqueName
+        )
+    }
+
+    /// Marks a task as cancelled. Used by `cancelByUniqueName` / `cancelAll`,
+    /// which do not emit status events. Kept (like WorkManager keeps CANCELLED
+    /// work) so queries still find the task and report `cancelled`.
+    static func markCancelled(uniqueName: String) {
+        guard var info = UserDefaultsHelper.getWorkInfo(forUniqueName: uniqueName) else {
+            return
+        }
+        let now = Date().timeIntervalSince1970
+        info.state = "cancelled"
+        info.lastFinishedAt = now
+        info.updatedAt = now
+        UserDefaultsHelper.storeWorkInfo(info, forUniqueName: uniqueName)
+    }
+
+    /// Marks every recorded task as cancelled (used by `cancelAll`).
+    static func markAllCancelled() {
+        let infos = UserDefaultsHelper.getAllWorkInfos()
+        let now = Date().timeIntervalSince1970
+        for (uniqueName, var info) in infos {
+            info.state = "cancelled"
+            info.lastFinishedAt = now
+            info.updatedAt = now
+            UserDefaultsHelper.storeWorkInfo(info, forUniqueName: uniqueName)
+        }
+    }
+
+    /// Returns the query snapshot for [uniqueName], or nil when the plugin has
+    /// no record of the task.
+    static func workInfoData(forUniqueName uniqueName: String) -> WorkInfoData? {
+        guard let info = UserDefaultsHelper.getWorkInfo(forUniqueName: uniqueName) else {
+            return nil
+        }
+        let state: WorkState
+        switch info.state {
+        case "scheduled": state = .scheduled
+        case "running": state = .running
+        case "succeeded": state = .succeeded
+        case "failed": state = .failed
+        case "cancelled": state = .cancelled
+        default: state = .scheduled
+        }
+        return WorkInfoData(
+            uniqueName: uniqueName,
+            state: state,
+            isPeriodic: info.isPeriodic,
+            taskName: info.taskName,
+            tags: nil,
+            lastFinishedAtMillis: info.lastFinishedAt.map { Int64($0 * 1000) }
+        )
+    }
+
+    // MARK: - Private
+
+    /// iOS one-off tasks report their execution under the registered taskName
+    /// (the `identifier`), while the store is keyed by uniqueName. Resolve the
+    /// key from the most recently updated record with that taskName.
+    private static func resolveUniqueName(taskInfo: TaskDebugInfo) -> String? {
+        if let uniqueName = taskInfo.uniqueName {
+            return uniqueName
+        }
+        // taskName is non-optional on TaskDebugInfo; iOS one-off tasks carry
+        // their registered taskName here.
+        let taskName = taskInfo.taskName
+        return UserDefaultsHelper.getAllWorkInfos()
+            .filter { $0.value.taskName == taskName }
+            .max { $0.value.updatedAt < $1.value.updatedAt }?
+            .key
+    }
+}

--- a/workmanager_apple/ios/workmanager_apple/Sources/workmanager_apple/WorkmanagerDebugHandler.swift
+++ b/workmanager_apple/ios/workmanager_apple/Sources/workmanager_apple/WorkmanagerDebugHandler.swift
@@ -16,7 +16,15 @@ public struct TaskDebugInfo {
     /// work-info store.
     public let isPeriodic: Bool?
 
-    public init(taskName: String, uniqueName: String? = nil, inputData: [String: Any]? = nil, startTime: TimeInterval, callbackHandle: Int64? = nil, callbackInfo: String? = nil, isPeriodic: Bool? = nil) {
+    public init(
+        taskName: String,
+        uniqueName: String? = nil,
+        inputData: [String: Any]? = nil,
+        startTime: TimeInterval,
+        callbackHandle: Int64? = nil,
+        callbackInfo: String? = nil,
+        isPeriodic: Bool? = nil
+    ) {
         self.taskName = taskName
         self.uniqueName = uniqueName
         self.inputData = inputData

--- a/workmanager_apple/ios/workmanager_apple/Sources/workmanager_apple/WorkmanagerDebugHandler.swift
+++ b/workmanager_apple/ios/workmanager_apple/Sources/workmanager_apple/WorkmanagerDebugHandler.swift
@@ -11,14 +11,19 @@ public struct TaskDebugInfo {
     public let startTime: TimeInterval
     public let callbackHandle: Int64?
     public let callbackInfo: String?
+    /// Whether the task was registered as periodic, when known. Only the
+    /// registration sites know this for certain; used by the persisted
+    /// work-info store.
+    public let isPeriodic: Bool?
 
-    public init(taskName: String, uniqueName: String? = nil, inputData: [String: Any]? = nil, startTime: TimeInterval, callbackHandle: Int64? = nil, callbackInfo: String? = nil) {
+    public init(taskName: String, uniqueName: String? = nil, inputData: [String: Any]? = nil, startTime: TimeInterval, callbackHandle: Int64? = nil, callbackInfo: String? = nil, isPeriodic: Bool? = nil) {
         self.taskName = taskName
         self.uniqueName = uniqueName
         self.inputData = inputData
         self.startTime = startTime
         self.callbackHandle = callbackHandle
         self.callbackInfo = callbackInfo
+        self.isPeriodic = isPeriodic
     }
 }
 
@@ -75,6 +80,11 @@ public class WorkmanagerDebug {
     // Internal methods for the plugin to call
     internal static func onTaskStatusUpdate(taskInfo: TaskDebugInfo, status: TaskStatus, result: TaskResult? = nil) {
         current.onTaskStatusUpdate(taskInfo: taskInfo, status: status, result: result)
+        // Every status transition also updates the persisted work-info store
+        // (independent of the user-swappable debug handler above), so the
+        // `getWorkInfo` query can be served on platforms whose schedulers have
+        // no query API. See WorkInfoStore.
+        WorkInfoStore.record(taskInfo: taskInfo, status: status, result: result, isPeriodic: taskInfo.isPeriodic)
     }
 
     internal static func onExceptionEncountered(taskInfo: TaskDebugInfo?, exception: Error) {

--- a/workmanager_apple/ios/workmanager_apple/Sources/workmanager_apple/WorkmanagerPlugin.swift
+++ b/workmanager_apple/ios/workmanager_apple/Sources/workmanager_apple/WorkmanagerPlugin.swift
@@ -489,7 +489,7 @@ extension WorkmanagerPlugin {
     @available(iOS 13.0, *)
     public static func handlePeriodicTask(identifier: String, task: BGAppRefreshTask, earliestBeginInSeconds: NSNumber?, inputData: [String: Any]?) {
         guard let callbackHandle = UserDefaultsHelper.getStoredCallbackHandle(),
-              let _ = FlutterCallbackCache.lookupCallbackInformation(callbackHandle)
+              FlutterCallbackCache.lookupCallbackInformation(callbackHandle) != nil
         else {
             logError("[\(String(describing: self))] \(WMPError.workmanagerNotInitialized.message)")
             return
@@ -798,7 +798,8 @@ extension WorkmanagerPlugin {
             registerLaunchHandlerOnce(forTaskWithIdentifier: uniqueTaskIdentifier, earliestBeginInSeconds: nil)
         } catch {
             logInfo("Could not schedule BGProcessingTask identifier:\(uniqueTaskIdentifier) error:\(error.localizedDescription)")
-            logInfo("Possible issues can be: running on a simulator instead of a real device, or the task name is not registered")
+            logInfo("Possible issues can be: running on a simulator instead of a real device, "
+                + "or the task name is not registered")
         }
     }
 
@@ -812,7 +813,8 @@ extension WorkmanagerPlugin {
         let operationQueue = OperationQueue()
         // Deliver the inputData stored at registration time (mirroring the
         // periodic task path, keyed by task identifier).
-        let storedInputData = UserDefaultsHelper.getStoredPeriodicTaskInputData(forTaskIdentifier: task.identifier)
+        let storedInputData =
+                UserDefaultsHelper.getStoredPeriodicTaskInputData(forTaskIdentifier: task.identifier)
         let operation = createBackgroundOperation(
             identifier: task.identifier,
             inputData: storedInputData,
@@ -846,8 +848,10 @@ extension WorkmanagerPlugin {
             )
             registerLaunchHandlerOnce(forTaskWithIdentifier: uniqueTaskIdentifier, earliestBeginInSeconds: nil)
         } catch {
-            logInfo("Could not schedule BGHealthResearchTask identifier:\(uniqueTaskIdentifier) error:\(error.localizedDescription)")
-            logInfo("Possible issues: iOS 17+ required, or the app is missing the health research study entitlement / the user has not opted in")
+            logInfo("Could not schedule BGHealthResearchTask identifier:\(uniqueTaskIdentifier) "
+                + "error:\(error.localizedDescription)")
+            logInfo("Possible issues: iOS 17+ required, or the app is missing the health "
+                + "research study entitlement / the user has not opted in")
         }
     }
 
@@ -872,7 +876,8 @@ extension WorkmanagerPlugin {
         ) { task in
             if let task = task as? BGAppRefreshTask {
                 // Retrieve the stored inputData for this periodic task
-                let storedInputData = UserDefaultsHelper.getStoredPeriodicTaskInputData(forTaskIdentifier: task.identifier)
+                let storedInputData =
+                UserDefaultsHelper.getStoredPeriodicTaskInputData(forTaskIdentifier: task.identifier)
                 handlePeriodicTask(
                     identifier: identifier,
                     task: task,

--- a/workmanager_apple/ios/workmanager_apple/Sources/workmanager_apple/WorkmanagerPlugin.swift
+++ b/workmanager_apple/ios/workmanager_apple/Sources/workmanager_apple/WorkmanagerPlugin.swift
@@ -77,6 +77,14 @@ public class WorkmanagerPlugin: WorkmanagerPluginBase, FlutterPlugin, Workmanage
         completion(.success(()))
     }
 
+    func getWorkInfoByUniqueName(uniqueName: String, completion: @escaping (Result<WorkInfoData?, Error>) -> Void) {
+        // BGTaskScheduler / NSBackgroundActivityScheduler have no query API, so
+        // this is served from the plugin's own persisted task-state store
+        // (UserDefaults-backed, updated by the task-status pipeline). Best
+        // effort: reflects what the plugin has seen, not the system scheduler.
+        completion(.success(WorkInfoStore.workInfoData(forUniqueName: uniqueName)))
+    }
+
     // MARK: - WorkmanagerHostApi implementation (iOS)
 
     #if os(iOS)
@@ -108,9 +116,10 @@ public class WorkmanagerPlugin: WorkmanagerPluginBase, FlutterPlugin, Workmanage
                 taskName: request.taskName,
                 uniqueName: request.uniqueName,
                 inputData: request.inputData as? [String: Any],
-                startTime: Date().timeIntervalSince1970
+                startTime: Date().timeIntervalSince1970,
+                isPeriodic: false
             )
-            WorkmanagerDebug.getCurrent().onTaskStatusUpdate(taskInfo: taskInfo, status: .scheduled, result: nil)
+            WorkmanagerDebug.onTaskStatusUpdate(taskInfo: taskInfo, status: .scheduled, result: nil)
         }
     }
 
@@ -138,9 +147,10 @@ public class WorkmanagerPlugin: WorkmanagerPluginBase, FlutterPlugin, Workmanage
                 taskName: request.taskName,
                 uniqueName: request.uniqueName,
                 inputData: request.inputData as? [String: Any],
-                startTime: Date().timeIntervalSince1970
+                startTime: Date().timeIntervalSince1970,
+                isPeriodic: true
             )
-            WorkmanagerDebug.getCurrent().onTaskStatusUpdate(taskInfo: taskInfo, status: .scheduled, result: nil)
+            WorkmanagerDebug.onTaskStatusUpdate(taskInfo: taskInfo, status: .scheduled, result: nil)
         }
     }
 
@@ -161,6 +171,18 @@ public class WorkmanagerPlugin: WorkmanagerPluginBase, FlutterPlugin, Workmanage
                 requiresNetworkConnectivity: requiresNetwork,
                 requiresExternalPower: requiresCharging
             )
+
+            // Processing tasks did not previously emit a scheduled status;
+            // record the registration directly in the persisted work-info
+            // store so the query API knows about the task.
+            let taskInfo = TaskDebugInfo(
+                taskName: request.taskName,
+                uniqueName: request.uniqueName,
+                inputData: request.inputData as? [String: Any],
+                startTime: Date().timeIntervalSince1970,
+                isPeriodic: false
+            )
+            WorkInfoStore.record(taskInfo: taskInfo, status: .scheduled, result: nil, isPeriodic: false)
         }
     }
 
@@ -199,6 +221,18 @@ public class WorkmanagerPlugin: WorkmanagerPluginBase, FlutterPlugin, Workmanage
             requiresNetworkConnectivity: requiresNetwork,
             requiresExternalPower: requiresCharging
         )
+
+        // Health research tasks did not previously emit a scheduled status;
+        // record the registration directly in the persisted work-info store
+        // so the query API knows about the task.
+        let taskInfo = TaskDebugInfo(
+            taskName: request.taskName,
+            uniqueName: request.uniqueName,
+            inputData: request.inputData as? [String: Any],
+            startTime: Date().timeIntervalSince1970,
+            isPeriodic: false
+        )
+        WorkInfoStore.record(taskInfo: taskInfo, status: .scheduled, result: nil, isPeriodic: false)
         completion(.success(()))
     }
 
@@ -206,6 +240,7 @@ public class WorkmanagerPlugin: WorkmanagerPluginBase, FlutterPlugin, Workmanage
         executeIfSupportedVoid(completion: completion, feature: "cancelByUniqueName") {
             BGTaskScheduler.shared.cancel(taskRequestWithIdentifier: uniqueName)
             UserDefaultsHelper.removeScheduledTask(uniqueName)
+            WorkInfoStore.markCancelled(uniqueName: uniqueName)
         }
     }
 
@@ -213,6 +248,7 @@ public class WorkmanagerPlugin: WorkmanagerPluginBase, FlutterPlugin, Workmanage
         executeIfSupportedVoid(completion: completion, feature: "cancelAll") {
             BGTaskScheduler.shared.cancelAllTaskRequests()
             UserDefaultsHelper.removeAllScheduledTasks()
+            WorkInfoStore.markAllCancelled()
         }
     }
 
@@ -310,9 +346,10 @@ extension WorkmanagerPlugin {
             taskName: request.taskName,
             uniqueName: request.uniqueName,
             inputData: request.inputData as? [String: Any],
-            startTime: Date().timeIntervalSince1970
+            startTime: Date().timeIntervalSince1970,
+            isPeriodic: false
         )
-        WorkmanagerDebug.getCurrent().onTaskStatusUpdate(taskInfo: taskInfo, status: .scheduled, result: nil)
+        WorkmanagerDebug.onTaskStatusUpdate(taskInfo: taskInfo, status: .scheduled, result: nil)
         completion(.success(()))
     }
 
@@ -335,9 +372,10 @@ extension WorkmanagerPlugin {
             taskName: request.taskName,
             uniqueName: request.uniqueName,
             inputData: request.inputData as? [String: Any],
-            startTime: Date().timeIntervalSince1970
+            startTime: Date().timeIntervalSince1970,
+            isPeriodic: true
         )
-        WorkmanagerDebug.getCurrent().onTaskStatusUpdate(taskInfo: taskInfo, status: .scheduled, result: nil)
+        WorkmanagerDebug.onTaskStatusUpdate(taskInfo: taskInfo, status: .scheduled, result: nil)
         completion(.success(()))
     }
 
@@ -371,9 +409,10 @@ extension WorkmanagerPlugin {
             taskName: request.taskName,
             uniqueName: request.uniqueName,
             inputData: request.inputData as? [String: Any],
-            startTime: Date().timeIntervalSince1970
+            startTime: Date().timeIntervalSince1970,
+            isPeriodic: false
         )
-        WorkmanagerDebug.getCurrent().onTaskStatusUpdate(taskInfo: taskInfo, status: .scheduled, result: nil)
+        WorkmanagerDebug.onTaskStatusUpdate(taskInfo: taskInfo, status: .scheduled, result: nil)
         completion(.success(()))
     }
 
@@ -392,11 +431,13 @@ extension WorkmanagerPlugin {
 
     func cancelByUniqueName(uniqueName: String, completion: @escaping (Result<Void, Error>) -> Void) {
         MacOSActivityScheduler.shared.cancel(uniqueName: uniqueName)
+        WorkInfoStore.markCancelled(uniqueName: uniqueName)
         completion(.success(()))
     }
 
     func cancelAll(completion: @escaping (Result<Void, Error>) -> Void) {
         MacOSActivityScheduler.shared.cancelAll()
+        WorkInfoStore.markAllCancelled()
         completion(.success(()))
     }
 
@@ -532,7 +573,8 @@ extension WorkmanagerPlugin {
             inputData: inputData,
             startTime: taskSessionStart.timeIntervalSince1970,
             callbackHandle: UserDefaultsHelper.getStoredCallbackHandle(),
-            callbackInfo: identifier
+            callbackInfo: identifier,
+            isPeriodic: false
         )
         WorkmanagerDebug.onTaskStatusUpdate(taskInfo: taskInfo, status: .started)
 

--- a/workmanager_apple/ios/workmanager_apple/Sources/workmanager_apple/pigeon/WorkmanagerApi.g.swift
+++ b/workmanager_apple/ios/workmanager_apple/Sources/workmanager_apple/pigeon/WorkmanagerApi.g.swift
@@ -295,6 +295,25 @@ enum OutOfQuotaPolicy: Int {
   case dropWorkRequest = 1
 }
 
+/// The lifecycle state of a background task as observed by the plugin.
+///
+/// This is the cross-platform subset of Android WorkManager's
+/// `WorkInfo.State` (ENQUEUED/RUNNING/SUCCEEDED/FAILED/CANCELLED/BLOCKED).
+/// On Apple platforms it reflects what the plugin itself has persisted from
+/// its task-status pipeline, because BGTaskScheduler has no query API.
+enum WorkState: Int {
+  /// The task is registered and waiting to run (Android ENQUEUED/BLOCKED).
+  case scheduled = 0
+  /// The task is currently executing.
+  case running = 1
+  /// The task finished successfully.
+  case succeeded = 2
+  /// The task failed permanently.
+  case failed = 3
+  /// The task was cancelled before finishing.
+  case cancelled = 4
+}
+
 /// Foreground service types supported for Android long-running workers.
 ///
 /// These map to the foreground service types introduced by Android 14
@@ -889,6 +908,74 @@ struct ContinuedProcessingTaskRequest: Hashable {
   }
 }
 
+/// Snapshot of the current state of a background task, as served by the
+/// native platform. This is the transport type for [WorkmanagerHostApi.getWorkInfoByUniqueName];
+/// the public, platform-agnostic model is `WorkInfo`.
+///
+/// Generated class from Pigeon that represents data sent in messages.
+struct WorkInfoData: Hashable {
+  /// The unique name the task was registered with.
+  var uniqueName: String
+  /// The task's current state.
+  var state: WorkState
+  /// True when the task was registered as a periodic task.
+  var isPeriodic: Bool
+  /// The task name the work was registered with, when the platform exposes it.
+  var taskName: String? = nil
+  /// Tags the work was registered with (Android only; empty elsewhere).
+  var tags: [String?]? = nil
+  /// When the plugin last observed the task finish (succeeded, failed or was
+  /// cancelled), as epoch milliseconds, when the platform exposes it.
+  /// Android WorkManager has no finish timestamp, so this is null there.
+  var lastFinishedAtMillis: Int64? = nil
+
+
+  // swift-format-ignore: AlwaysUseLowerCamelCase
+  static func fromList(_ pigeonVar_list: [Any?]) -> WorkInfoData? {
+    let uniqueName = pigeonVar_list[0] as! String
+    let state = pigeonVar_list[1] as! WorkState
+    let isPeriodic = pigeonVar_list[2] as! Bool
+    let taskName: String? = nilOrValue(pigeonVar_list[3])
+    let tags: [String?]? = nilOrValue(pigeonVar_list[4])
+    let lastFinishedAtMillis: Int64? = nilOrValue(pigeonVar_list[5])
+
+    return WorkInfoData(
+      uniqueName: uniqueName,
+      state: state,
+      isPeriodic: isPeriodic,
+      taskName: taskName,
+      tags: tags,
+      lastFinishedAtMillis: lastFinishedAtMillis
+    )
+  }
+  func toList() -> [Any?] {
+    return [
+      uniqueName,
+      state,
+      isPeriodic,
+      taskName,
+      tags,
+      lastFinishedAtMillis,
+    ]
+  }
+  static func == (lhs: WorkInfoData, rhs: WorkInfoData) -> Bool {
+    if Swift.type(of: lhs) != Swift.type(of: rhs) {
+      return false
+    }
+    return deepEqualsWorkmanagerApi(lhs.uniqueName, rhs.uniqueName) && deepEqualsWorkmanagerApi(lhs.state, rhs.state) && deepEqualsWorkmanagerApi(lhs.isPeriodic, rhs.isPeriodic) && deepEqualsWorkmanagerApi(lhs.taskName, rhs.taskName) && deepEqualsWorkmanagerApi(lhs.tags, rhs.tags) && deepEqualsWorkmanagerApi(lhs.lastFinishedAtMillis, rhs.lastFinishedAtMillis)
+  }
+
+  func hash(into hasher: inout Hasher) {
+    hasher.combine("WorkInfoData")
+    deepHashWorkmanagerApi(value: uniqueName, hasher: &hasher)
+    deepHashWorkmanagerApi(value: state, hasher: &hasher)
+    deepHashWorkmanagerApi(value: isPeriodic, hasher: &hasher)
+    deepHashWorkmanagerApi(value: taskName, hasher: &hasher)
+    deepHashWorkmanagerApi(value: tags, hasher: &hasher)
+    deepHashWorkmanagerApi(value: lastFinishedAtMillis, hasher: &hasher)
+  }
+}
+
 private class WorkmanagerApiPigeonCodecReader: FlutterStandardReader {
   override func readValue(ofType type: UInt8) -> Any? {
     switch type {
@@ -931,29 +1018,37 @@ private class WorkmanagerApiPigeonCodecReader: FlutterStandardReader {
     case 135:
       let enumResultAsInt: Int? = nilOrValue(self.readValue() as! Int?)
       if let enumResultAsInt = enumResultAsInt {
-        return ForegroundServiceType(rawValue: enumResultAsInt)
+        return WorkState(rawValue: enumResultAsInt)
       }
       return nil
     case 136:
-      return ForegroundServiceConfig.fromList(self.readValue() as! [Any?])
+      let enumResultAsInt: Int? = nilOrValue(self.readValue() as! Int?)
+      if let enumResultAsInt = enumResultAsInt {
+        return ForegroundServiceType(rawValue: enumResultAsInt)
+      }
+      return nil
     case 137:
-      return Constraints.fromList(self.readValue() as! [Any?])
+      return ForegroundServiceConfig.fromList(self.readValue() as! [Any?])
     case 138:
-      return ContentUriTrigger.fromList(self.readValue() as! [Any?])
+      return Constraints.fromList(self.readValue() as! [Any?])
     case 139:
-      return BackoffPolicyConfig.fromList(self.readValue() as! [Any?])
+      return ContentUriTrigger.fromList(self.readValue() as! [Any?])
     case 140:
-      return InitializeRequest.fromList(self.readValue() as! [Any?])
+      return BackoffPolicyConfig.fromList(self.readValue() as! [Any?])
     case 141:
-      return OneOffTaskRequest.fromList(self.readValue() as! [Any?])
+      return InitializeRequest.fromList(self.readValue() as! [Any?])
     case 142:
-      return PeriodicTaskRequest.fromList(self.readValue() as! [Any?])
+      return OneOffTaskRequest.fromList(self.readValue() as! [Any?])
     case 143:
-      return ProcessingTaskRequest.fromList(self.readValue() as! [Any?])
+      return PeriodicTaskRequest.fromList(self.readValue() as! [Any?])
     case 144:
-      return HealthResearchTaskRequest.fromList(self.readValue() as! [Any?])
+      return ProcessingTaskRequest.fromList(self.readValue() as! [Any?])
     case 145:
+      return HealthResearchTaskRequest.fromList(self.readValue() as! [Any?])
+    case 146:
       return ContinuedProcessingTaskRequest.fromList(self.readValue() as! [Any?])
+    case 147:
+      return WorkInfoData.fromList(self.readValue() as! [Any?])
     default:
       return super.readValue(ofType: type)
     }
@@ -980,38 +1075,44 @@ private class WorkmanagerApiPigeonCodecWriter: FlutterStandardWriter {
     } else if let value = value as? OutOfQuotaPolicy {
       super.writeByte(134)
       super.writeValue(value.rawValue)
-    } else if let value = value as? ForegroundServiceType {
+    } else if let value = value as? WorkState {
       super.writeByte(135)
       super.writeValue(value.rawValue)
-    } else if let value = value as? ForegroundServiceConfig {
+    } else if let value = value as? ForegroundServiceType {
       super.writeByte(136)
-      super.writeValue(value.toList())
-    } else if let value = value as? Constraints {
+      super.writeValue(value.rawValue)
+    } else if let value = value as? ForegroundServiceConfig {
       super.writeByte(137)
       super.writeValue(value.toList())
-    } else if let value = value as? ContentUriTrigger {
+    } else if let value = value as? Constraints {
       super.writeByte(138)
       super.writeValue(value.toList())
-    } else if let value = value as? BackoffPolicyConfig {
+    } else if let value = value as? ContentUriTrigger {
       super.writeByte(139)
       super.writeValue(value.toList())
-    } else if let value = value as? InitializeRequest {
+    } else if let value = value as? BackoffPolicyConfig {
       super.writeByte(140)
       super.writeValue(value.toList())
-    } else if let value = value as? OneOffTaskRequest {
+    } else if let value = value as? InitializeRequest {
       super.writeByte(141)
       super.writeValue(value.toList())
-    } else if let value = value as? PeriodicTaskRequest {
+    } else if let value = value as? OneOffTaskRequest {
       super.writeByte(142)
       super.writeValue(value.toList())
-    } else if let value = value as? ProcessingTaskRequest {
+    } else if let value = value as? PeriodicTaskRequest {
       super.writeByte(143)
       super.writeValue(value.toList())
-    } else if let value = value as? HealthResearchTaskRequest {
+    } else if let value = value as? ProcessingTaskRequest {
       super.writeByte(144)
       super.writeValue(value.toList())
-    } else if let value = value as? ContinuedProcessingTaskRequest {
+    } else if let value = value as? HealthResearchTaskRequest {
       super.writeByte(145)
+      super.writeValue(value.toList())
+    } else if let value = value as? ContinuedProcessingTaskRequest {
+      super.writeByte(146)
+      super.writeValue(value.toList())
+    } else if let value = value as? WorkInfoData {
+      super.writeByte(147)
       super.writeValue(value.toList())
     } else {
       super.writeValue(value)
@@ -1047,6 +1148,9 @@ protocol WorkmanagerHostApi {
   func cancelAll(completion: @escaping (Result<Void, Error>) -> Void)
   func isScheduledByUniqueName(uniqueName: String, completion: @escaping (Result<Bool, Error>) -> Void)
   func printScheduledTasks(completion: @escaping (Result<String, Error>) -> Void)
+  /// Returns the current state of the task registered under [uniqueName], or
+  /// null when the platform has no record of it.
+  func getWorkInfoByUniqueName(uniqueName: String, completion: @escaping (Result<WorkInfoData?, Error>) -> Void)
 }
 
 /// Generated setup class from Pigeon to handle messages through the `binaryMessenger`.
@@ -1237,6 +1341,25 @@ class WorkmanagerHostApiSetup {
       }
     } else {
       printScheduledTasksChannel.setMessageHandler(nil)
+    }
+    /// Returns the current state of the task registered under [uniqueName], or
+    /// null when the platform has no record of it.
+    let getWorkInfoByUniqueNameChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.workmanager_platform_interface.WorkmanagerHostApi.getWorkInfoByUniqueName\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
+    if let api = api {
+      getWorkInfoByUniqueNameChannel.setMessageHandler { message, reply in
+        let args = message as! [Any?]
+        let uniqueNameArg = args[0] as! String
+        api.getWorkInfoByUniqueName(uniqueName: uniqueNameArg) { result in
+          switch result {
+          case .success(let res):
+            reply(wrapResult(res))
+          case .failure(let error):
+            reply(wrapError(error))
+          }
+        }
+      }
+    } else {
+      getWorkInfoByUniqueNameChannel.setMessageHandler(nil)
     }
   }
 }

--- a/workmanager_apple/lib/workmanager_apple.dart
+++ b/workmanager_apple/lib/workmanager_apple.dart
@@ -174,4 +174,10 @@ class WorkmanagerApple extends WorkmanagerPlatform {
   Future<String> printScheduledTasks() async {
     return await _api.printScheduledTasks();
   }
+
+  @override
+  Future<WorkInfo?> getWorkInfo(String uniqueName) async {
+    final data = await _api.getWorkInfoByUniqueName(uniqueName);
+    return data == null ? null : WorkInfo.fromData(data);
+  }
 }

--- a/workmanager_apple/macos/workmanager_apple/Sources/workmanager_apple/WorkInfoStore.swift
+++ b/workmanager_apple/macos/workmanager_apple/Sources/workmanager_apple/WorkInfoStore.swift
@@ -1,0 +1,1 @@
+../../../../ios/workmanager_apple/Sources/workmanager_apple/WorkInfoStore.swift

--- a/workmanager_apple/test/workmanager_apple_test.dart
+++ b/workmanager_apple/test/workmanager_apple_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/services.dart';
 import 'package:workmanager_apple/workmanager_apple.dart';
 import 'package:workmanager_platform_interface/workmanager_platform_interface.dart';
 
@@ -36,6 +37,37 @@ void main() {
             'message',
             contains('isScheduledByUniqueName is not supported on iOS'),
           )),
+        );
+      });
+
+      test('getWorkInfo returns null when the store has no record', () async {
+        _mockGetWorkInfoReply(<Object?>[null]);
+
+        expect(await workmanager.getWorkInfo('unknown-task'), isNull);
+      });
+
+      test('getWorkInfo maps the pigeon reply into a WorkInfo', () async {
+        _mockGetWorkInfoReply(<Object?>[
+          WorkInfoData(
+            uniqueName: 'com.example.task',
+            state: WorkState.failed,
+            isPeriodic: false,
+            taskName: 'dart-task',
+            lastFinishedAtMillis: 1700000000000,
+          ),
+        ]);
+
+        final info = await workmanager.getWorkInfo('com.example.task');
+
+        expect(info, isNotNull);
+        expect(info!.uniqueName, 'com.example.task');
+        expect(info.state, WorkState.failed);
+        expect(info.isPeriodic, isFalse);
+        expect(info.taskName, 'dart-task');
+        expect(info.tags, isEmpty);
+        expect(
+          info.lastFinishedAt,
+          DateTime.fromMillisecondsSinceEpoch(1700000000000),
         );
       });
     });
@@ -404,4 +436,17 @@ void main() {
       });
     });
   });
+}
+
+/// Stubs the pigeon `getWorkInfoByUniqueName` channel with [reply] so the
+/// platform implementation's query plumbing can be exercised in tests.
+void _mockGetWorkInfoReply(List<Object?> reply) {
+  const channelName =
+      'dev.flutter.pigeon.workmanager_platform_interface.WorkmanagerHostApi.getWorkInfoByUniqueName';
+  final channel = BasicMessageChannel<Object?>(
+    channelName,
+    WorkmanagerHostApi.pigeonChannelCodec,
+  );
+  TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+      .setMockDecodedMessageHandler<Object?>(channel, (message) async => reply);
 }

--- a/workmanager_platform_interface/lib/src/pigeon/workmanager_api.g.dart
+++ b/workmanager_platform_interface/lib/src/pigeon/workmanager_api.g.dart
@@ -224,6 +224,25 @@ enum OutOfQuotaPolicy {
   dropWorkRequest,
 }
 
+/// The lifecycle state of a background task as observed by the plugin.
+///
+/// This is the cross-platform subset of Android WorkManager's
+/// `WorkInfo.State` (ENQUEUED/RUNNING/SUCCEEDED/FAILED/CANCELLED/BLOCKED).
+/// On Apple platforms it reflects what the plugin itself has persisted from
+/// its task-status pipeline, because BGTaskScheduler has no query API.
+enum WorkState {
+  /// The task is registered and waiting to run (Android ENQUEUED/BLOCKED).
+  scheduled,
+  /// The task is currently executing.
+  running,
+  /// The task finished successfully.
+  succeeded,
+  /// The task failed permanently.
+  failed,
+  /// The task was cancelled before finishing.
+  cancelled,
+}
+
 /// Foreground service types supported for Android long-running workers.
 ///
 /// These map to the foreground service types introduced by Android 14
@@ -906,6 +925,82 @@ class ContinuedProcessingTaskRequest {
   int get hashCode => _deepHash(<Object?>[runtimeType, ..._toList()]);
 }
 
+/// Snapshot of the current state of a background task, as served by the
+/// native platform. This is the transport type for [WorkmanagerHostApi.getWorkInfoByUniqueName];
+/// the public, platform-agnostic model is `WorkInfo`.
+class WorkInfoData {
+  WorkInfoData({
+    required this.uniqueName,
+    required this.state,
+    required this.isPeriodic,
+    this.taskName,
+    this.tags,
+    this.lastFinishedAtMillis,
+  });
+
+  /// The unique name the task was registered with.
+  String uniqueName;
+
+  /// The task's current state.
+  WorkState state;
+
+  /// True when the task was registered as a periodic task.
+  bool isPeriodic;
+
+  /// The task name the work was registered with, when the platform exposes it.
+  String? taskName;
+
+  /// Tags the work was registered with (Android only; empty elsewhere).
+  List<String?>? tags;
+
+  /// When the plugin last observed the task finish (succeeded, failed or was
+  /// cancelled), as epoch milliseconds, when the platform exposes it.
+  /// Android WorkManager has no finish timestamp, so this is null there.
+  int? lastFinishedAtMillis;
+
+  List<Object?> _toList() {
+    return <Object?>[
+      uniqueName,
+      state,
+      isPeriodic,
+      taskName,
+      tags,
+      lastFinishedAtMillis,
+    ];
+  }
+
+  Object encode() {
+    return _toList();  }
+
+  static WorkInfoData decode(Object result) {
+    result as List<Object?>;
+    return WorkInfoData(
+      uniqueName: result[0]! as String,
+      state: result[1]! as WorkState,
+      isPeriodic: result[2]! as bool,
+      taskName: result[3] as String?,
+      tags: (result[4] as List<Object?>?)?.cast<String?>(),
+      lastFinishedAtMillis: result[5] as int?,
+    );
+  }
+
+  @override
+  // ignore: avoid_equals_and_hash_code_on_mutable_classes
+  bool operator ==(Object other) {
+    if (other is! WorkInfoData || other.runtimeType != runtimeType) {
+      return false;
+    }
+    if (identical(this, other)) {
+      return true;
+    }
+    return _deepEquals(uniqueName, other.uniqueName) && _deepEquals(state, other.state) && _deepEquals(isPeriodic, other.isPeriodic) && _deepEquals(taskName, other.taskName) && _deepEquals(tags, other.tags) && _deepEquals(lastFinishedAtMillis, other.lastFinishedAtMillis);
+  }
+
+  @override
+  // ignore: avoid_equals_and_hash_code_on_mutable_classes
+  int get hashCode => _deepHash(<Object?>[runtimeType, ..._toList()]);
+}
+
 
 class _PigeonCodec extends StandardMessageCodec {
   const _PigeonCodec();
@@ -932,38 +1027,44 @@ class _PigeonCodec extends StandardMessageCodec {
     }    else if (value is OutOfQuotaPolicy) {
       buffer.putUint8(134);
       writeValue(buffer, value.index);
-    }    else if (value is ForegroundServiceType) {
+    }    else if (value is WorkState) {
       buffer.putUint8(135);
       writeValue(buffer, value.index);
-    }    else if (value is ForegroundServiceConfig) {
+    }    else if (value is ForegroundServiceType) {
       buffer.putUint8(136);
-      writeValue(buffer, value.encode());
-    }    else if (value is Constraints) {
+      writeValue(buffer, value.index);
+    }    else if (value is ForegroundServiceConfig) {
       buffer.putUint8(137);
       writeValue(buffer, value.encode());
-    }    else if (value is ContentUriTrigger) {
+    }    else if (value is Constraints) {
       buffer.putUint8(138);
       writeValue(buffer, value.encode());
-    }    else if (value is BackoffPolicyConfig) {
+    }    else if (value is ContentUriTrigger) {
       buffer.putUint8(139);
       writeValue(buffer, value.encode());
-    }    else if (value is InitializeRequest) {
+    }    else if (value is BackoffPolicyConfig) {
       buffer.putUint8(140);
       writeValue(buffer, value.encode());
-    }    else if (value is OneOffTaskRequest) {
+    }    else if (value is InitializeRequest) {
       buffer.putUint8(141);
       writeValue(buffer, value.encode());
-    }    else if (value is PeriodicTaskRequest) {
+    }    else if (value is OneOffTaskRequest) {
       buffer.putUint8(142);
       writeValue(buffer, value.encode());
-    }    else if (value is ProcessingTaskRequest) {
+    }    else if (value is PeriodicTaskRequest) {
       buffer.putUint8(143);
       writeValue(buffer, value.encode());
-    }    else if (value is HealthResearchTaskRequest) {
+    }    else if (value is ProcessingTaskRequest) {
       buffer.putUint8(144);
       writeValue(buffer, value.encode());
-    }    else if (value is ContinuedProcessingTaskRequest) {
+    }    else if (value is HealthResearchTaskRequest) {
       buffer.putUint8(145);
+      writeValue(buffer, value.encode());
+    }    else if (value is ContinuedProcessingTaskRequest) {
+      buffer.putUint8(146);
+      writeValue(buffer, value.encode());
+    }    else if (value is WorkInfoData) {
+      buffer.putUint8(147);
       writeValue(buffer, value.encode());
     } else {
       super.writeValue(buffer, value);
@@ -993,27 +1094,32 @@ class _PigeonCodec extends StandardMessageCodec {
         return value == null ? null : OutOfQuotaPolicy.values[value];
       case 135:
         final value = readValue(buffer) as int?;
-        return value == null ? null : ForegroundServiceType.values[value];
+        return value == null ? null : WorkState.values[value];
       case 136:
-        return ForegroundServiceConfig.decode(readValue(buffer)!);
+        final value = readValue(buffer) as int?;
+        return value == null ? null : ForegroundServiceType.values[value];
       case 137:
-        return Constraints.decode(readValue(buffer)!);
+        return ForegroundServiceConfig.decode(readValue(buffer)!);
       case 138:
-        return ContentUriTrigger.decode(readValue(buffer)!);
+        return Constraints.decode(readValue(buffer)!);
       case 139:
-        return BackoffPolicyConfig.decode(readValue(buffer)!);
+        return ContentUriTrigger.decode(readValue(buffer)!);
       case 140:
-        return InitializeRequest.decode(readValue(buffer)!);
+        return BackoffPolicyConfig.decode(readValue(buffer)!);
       case 141:
-        return OneOffTaskRequest.decode(readValue(buffer)!);
+        return InitializeRequest.decode(readValue(buffer)!);
       case 142:
-        return PeriodicTaskRequest.decode(readValue(buffer)!);
+        return OneOffTaskRequest.decode(readValue(buffer)!);
       case 143:
-        return ProcessingTaskRequest.decode(readValue(buffer)!);
+        return PeriodicTaskRequest.decode(readValue(buffer)!);
       case 144:
-        return HealthResearchTaskRequest.decode(readValue(buffer)!);
+        return ProcessingTaskRequest.decode(readValue(buffer)!);
       case 145:
+        return HealthResearchTaskRequest.decode(readValue(buffer)!);
+      case 146:
         return ContinuedProcessingTaskRequest.decode(readValue(buffer)!);
+      case 147:
+        return WorkInfoData.decode(readValue(buffer)!);
       default:
         return super.readValueOfType(type, buffer);
     }
@@ -1231,6 +1337,27 @@ class WorkmanagerHostApi {
     )
     ;
     return pigeonVar_replyValue! as String;
+  }
+
+  /// Returns the current state of the task registered under [uniqueName], or
+  /// null when the platform has no record of it.
+  Future<WorkInfoData?> getWorkInfoByUniqueName(String uniqueName) async {
+    final pigeonVar_channelName = 'dev.flutter.pigeon.workmanager_platform_interface.WorkmanagerHostApi.getWorkInfoByUniqueName$pigeonVar_messageChannelSuffix';
+    final pigeonVar_channel = BasicMessageChannel<Object?>(
+      pigeonVar_channelName,
+      pigeonChannelCodec,
+      binaryMessenger: pigeonVar_binaryMessenger,
+    );
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[uniqueName]);
+    final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
+
+    final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
+        pigeonVar_replyList,
+        pigeonVar_channelName,
+        isNullValid: true,
+    )
+    ;
+    return pigeonVar_replyValue as WorkInfoData?;
   }
 }
 

--- a/workmanager_platform_interface/lib/src/work_info.dart
+++ b/workmanager_platform_interface/lib/src/work_info.dart
@@ -1,0 +1,115 @@
+import 'package:flutter/foundation.dart';
+
+import 'pigeon/workmanager_api.g.dart' show WorkInfoData, WorkState;
+
+export 'pigeon/workmanager_api.g.dart' show WorkState;
+
+/// A snapshot of the current state of a background task, as observed by the
+/// plugin.
+///
+/// `WorkInfo` is the platform-agnostic answer to "what is my task doing right
+/// now?". The fields are populated from the most truthful source each platform
+/// has:
+///
+/// * **Android** — the query is served by WorkManager itself
+///   (`getWorkInfosForUniqueWork`), so [state] is authoritative. WorkManager
+///   does not expose a finish timestamp, so [lastFinishedAt] is always `null`
+///   on Android.
+/// * **iOS / macOS** — BGTaskScheduler has **no query API**, so the plugin
+///   persists its own per-task state (in `UserDefaults`) as it observes its
+///   own task-status pipeline. The result is best-effort: it reflects what
+///   the plugin has seen since the task was registered (see the docs).
+/// * **Web** — returns `null` (no queryable state).
+/// * **Other platforms** — `getWorkInfo` throws
+///   [UnsupportedError], like every other platform API.
+///
+/// See the "Work status" docs page for the full per-platform truthfulness
+/// matrix.
+@immutable
+class WorkInfo {
+  /// Creates a [WorkInfo] snapshot.
+  const WorkInfo({
+    required this.uniqueName,
+    required this.state,
+    required this.isPeriodic,
+    this.taskName,
+    this.tags = const <String>[],
+    this.lastFinishedAt,
+  });
+
+  /// Converts the native transport snapshot into the public model.
+  factory WorkInfo.fromData(WorkInfoData data) {
+    return WorkInfo(
+      uniqueName: data.uniqueName,
+      state: data.state,
+      isPeriodic: data.isPeriodic,
+      taskName: data.taskName,
+      tags: (data.tags ?? const <String?>[]).whereType<String>().toList(),
+      lastFinishedAt: data.lastFinishedAtMillis == null
+          ? null
+          : DateTime.fromMillisecondsSinceEpoch(data.lastFinishedAtMillis!),
+    );
+  }
+
+  /// The unique name the task was registered with.
+  final String uniqueName;
+
+  /// The task's current state.
+  ///
+  /// On Apple platforms this is the plugin's best-effort view persisted from
+  /// its own status pipeline; on Android it is WorkManager's authoritative
+  /// state.
+  final WorkState state;
+
+  /// Whether the task was registered via `registerPeriodicTask`.
+  ///
+  /// On Android this reflects WorkManager's own periodicity information; on
+  /// Apple platforms it is what the plugin recorded at registration time.
+  final bool isPeriodic;
+
+  /// The task name the work was registered with, when the platform exposes it.
+  ///
+  /// On Android this is read from the worker's input data; on Apple platforms
+  /// it is what the plugin recorded at registration time.
+  final String? taskName;
+
+  /// Tags the work was registered with.
+  ///
+  /// Android only (WorkManager tags); always empty on Apple platforms, which
+  /// have no tag concept.
+  final List<String> tags;
+
+  /// When the plugin last observed the task finish (succeeded, failed or was
+  /// cancelled).
+  ///
+  /// Always `null` on Android: WorkManager does not expose a finish timestamp.
+  /// On Apple platforms it is recorded from the plugin's persisted state and
+  /// is best-effort (it is only set for tasks the plugin saw finish while it
+  /// was running).
+  final DateTime? lastFinishedAt;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    return other is WorkInfo &&
+        other.uniqueName == uniqueName &&
+        other.state == state &&
+        other.isPeriodic == isPeriodic &&
+        other.taskName == taskName &&
+        listEquals(other.tags, tags) &&
+        other.lastFinishedAt == lastFinishedAt;
+  }
+
+  @override
+  int get hashCode => Object.hash(uniqueName, state, isPeriodic, taskName,
+      Object.hashAll(tags), lastFinishedAt);
+
+  @override
+  String toString() {
+    return 'WorkInfo(uniqueName: $uniqueName, state: $state, '
+        'isPeriodic: $isPeriodic, taskName: $taskName, tags: $tags, '
+        'lastFinishedAt: $lastFinishedAt)';
+  }
+}

--- a/workmanager_platform_interface/lib/src/workmanager_platform_interface.dart
+++ b/workmanager_platform_interface/lib/src/workmanager_platform_interface.dart
@@ -1,6 +1,7 @@
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 
 import 'pigeon/workmanager_api.g.dart';
+import 'work_info.dart';
 
 /// The interface that implementations of workmanager must implement.
 ///
@@ -185,6 +186,14 @@ abstract class WorkmanagerPlatform extends PlatformInterface {
   Future<String> printScheduledTasks() {
     throw UnimplementedError('printScheduledTasks() has not been implemented.');
   }
+
+  /// Queries the current state of the task registered under [uniqueName].
+  ///
+  /// Returns `null` when the platform has no record of the task. See [WorkInfo]
+  /// for the per-platform truthfulness of the result.
+  Future<WorkInfo?> getWorkInfo(String uniqueName) {
+    throw UnimplementedError('getWorkInfo() has not been implemented.');
+  }
 }
 
 /// Placeholder implementation that throws on all methods.
@@ -310,6 +319,13 @@ class _PlaceholderImplementation extends WorkmanagerPlatform {
 
   @override
   Future<String> printScheduledTasks() async {
+    throw UnimplementedError(
+      'No implementation found for workmanager on this platform.',
+    );
+  }
+
+  @override
+  Future<WorkInfo?> getWorkInfo(String uniqueName) async {
     throw UnimplementedError(
       'No implementation found for workmanager on this platform.',
     );

--- a/workmanager_platform_interface/lib/workmanager_platform_interface.dart
+++ b/workmanager_platform_interface/lib/workmanager_platform_interface.dart
@@ -1,5 +1,6 @@
 library workmanager_platform_interface;
 
 export 'src/workmanager_platform_interface.dart';
+export 'src/work_info.dart';
 export 'src/pigeon/workmanager_api.g.dart';
 export 'src/stop_reason.dart';

--- a/workmanager_platform_interface/pigeons/workmanager_api.dart
+++ b/workmanager_platform_interface/pigeons/workmanager_api.dart
@@ -149,6 +149,29 @@ enum OutOfQuotaPolicy {
   dropWorkRequest,
 }
 
+/// The lifecycle state of a background task as observed by the plugin.
+///
+/// This is the cross-platform subset of Android WorkManager's
+/// `WorkInfo.State` (ENQUEUED/RUNNING/SUCCEEDED/FAILED/CANCELLED/BLOCKED).
+/// On Apple platforms it reflects what the plugin itself has persisted from
+/// its task-status pipeline, because BGTaskScheduler has no query API.
+enum WorkState {
+  /// The task is registered and waiting to run (Android ENQUEUED/BLOCKED).
+  scheduled,
+
+  /// The task is currently executing.
+  running,
+
+  /// The task finished successfully.
+  succeeded,
+
+  /// The task failed permanently.
+  failed,
+
+  /// The task was cancelled before finishing.
+  cancelled,
+}
+
 /// Foreground service types supported for Android long-running workers.
 ///
 /// These map to the foreground service types introduced by Android 14
@@ -400,6 +423,40 @@ class ContinuedProcessingTaskRequest {
   Map<String?, Object?>? inputData;
 }
 
+/// Snapshot of the current state of a background task, as served by the
+/// native platform. This is the transport type for [WorkmanagerHostApi.getWorkInfoByUniqueName];
+/// the public, platform-agnostic model is `WorkInfo`.
+class WorkInfoData {
+  WorkInfoData({
+    required this.uniqueName,
+    required this.state,
+    required this.isPeriodic,
+    this.taskName,
+    this.tags,
+    this.lastFinishedAtMillis,
+  });
+
+  /// The unique name the task was registered with.
+  String uniqueName;
+
+  /// The task's current state.
+  WorkState state;
+
+  /// True when the task was registered as a periodic task.
+  bool isPeriodic;
+
+  /// The task name the work was registered with, when the platform exposes it.
+  String? taskName;
+
+  /// Tags the work was registered with (Android only; empty elsewhere).
+  List<String?>? tags;
+
+  /// When the plugin last observed the task finish (succeeded, failed or was
+  /// cancelled), as epoch milliseconds, when the platform exposes it.
+  /// Android WorkManager has no finish timestamp, so this is null there.
+  int? lastFinishedAtMillis;
+}
+
 // Host API (Flutter calls native)
 @HostApi()
 abstract class WorkmanagerHostApi {
@@ -435,6 +492,11 @@ abstract class WorkmanagerHostApi {
 
   @async
   String printScheduledTasks();
+
+  /// Returns the current state of the task registered under [uniqueName], or
+  /// null when the platform has no record of it.
+  @async
+  WorkInfoData? getWorkInfoByUniqueName(String uniqueName);
 }
 
 // Flutter API (Native calls Flutter)

--- a/workmanager_platform_interface/pubspec.yaml
+++ b/workmanager_platform_interface/pubspec.yaml
@@ -17,6 +17,8 @@ dependencies:
   plugin_platform_interface: ^2.1.0
 
 dev_dependencies:
+  flutter_test:
+    sdk: flutter
   flutter_lints: ^6.0.0
   # Pinned exactly so `melos run generate` is reproducible in CI
   # (caret ranges caused generated-file drift when pigeon released 26.x updates).

--- a/workmanager_platform_interface/test/work_info_test.dart
+++ b/workmanager_platform_interface/test/work_info_test.dart
@@ -33,7 +33,8 @@ void main() {
       expect(info.isPeriodic, true);
       expect(info.taskName, 'dart-task');
       expect(info.tags, <String>['tag-a', 'tag-b']);
-      expect(info.lastFinishedAt, DateTime.fromMillisecondsSinceEpoch(1700000000000));
+      expect(info.lastFinishedAt,
+          DateTime.fromMillisecondsSinceEpoch(1700000000000));
     });
 
     test('fromData handles missing optional fields', () {
@@ -71,13 +72,20 @@ void main() {
 
       expect(build(), build());
       expect(build().hashCode, build().hashCode);
-      expect(build() == WorkInfo(uniqueName: 'other', state: WorkState.failed, isPeriodic: false), isFalse);
+      expect(
+          build() ==
+              WorkInfo(
+                  uniqueName: 'other',
+                  state: WorkState.failed,
+                  isPeriodic: false),
+          isFalse);
     });
   });
 
   group('WorkmanagerPlatform.getWorkInfo', () {
     test('delegates to the registered platform implementation', () async {
-      final expected = WorkInfo(uniqueName: 'u', state: WorkState.cancelled, isPeriodic: false);
+      final expected = WorkInfo(
+          uniqueName: 'u', state: WorkState.cancelled, isPeriodic: false);
       WorkmanagerPlatform.instance = _FakePlatform(expected);
 
       final result = await WorkmanagerPlatform.instance.getWorkInfo('u');

--- a/workmanager_platform_interface/test/work_info_test.dart
+++ b/workmanager_platform_interface/test/work_info_test.dart
@@ -1,0 +1,97 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:workmanager_platform_interface/workmanager_platform_interface.dart';
+
+class _FakePlatform extends WorkmanagerPlatform {
+  _FakePlatform(this.result);
+
+  final WorkInfo? result;
+
+  @override
+  Future<WorkInfo?> getWorkInfo(String uniqueName) async => result;
+}
+
+class _UnimplementedPlatform extends WorkmanagerPlatform {}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('WorkInfo', () {
+    test('fromData maps every field', () {
+      final data = WorkInfoData(
+        uniqueName: 'com.example.task',
+        state: WorkState.succeeded,
+        isPeriodic: true,
+        taskName: 'dart-task',
+        tags: <String?>['tag-a', 'tag-b'],
+        lastFinishedAtMillis: 1700000000000,
+      );
+
+      final info = WorkInfo.fromData(data);
+
+      expect(info.uniqueName, 'com.example.task');
+      expect(info.state, WorkState.succeeded);
+      expect(info.isPeriodic, true);
+      expect(info.taskName, 'dart-task');
+      expect(info.tags, <String>['tag-a', 'tag-b']);
+      expect(info.lastFinishedAt, DateTime.fromMillisecondsSinceEpoch(1700000000000));
+    });
+
+    test('fromData handles missing optional fields', () {
+      final info = WorkInfo.fromData(WorkInfoData(
+        uniqueName: 'u',
+        state: WorkState.scheduled,
+        isPeriodic: false,
+      ));
+
+      expect(info.taskName, isNull);
+      expect(info.tags, isEmpty);
+      expect(info.lastFinishedAt, isNull);
+    });
+
+    test('fromData drops null tags', () {
+      final info = WorkInfo.fromData(WorkInfoData(
+        uniqueName: 'u',
+        state: WorkState.running,
+        isPeriodic: false,
+        tags: <String?>['a', null, 'b'],
+      ));
+
+      expect(info.tags, <String>['a', 'b']);
+    });
+
+    test('equality is value based', () {
+      WorkInfo build() => WorkInfo(
+            uniqueName: 'u',
+            state: WorkState.failed,
+            isPeriodic: false,
+            taskName: 't',
+            tags: const <String>['x'],
+            lastFinishedAt: DateTime.fromMillisecondsSinceEpoch(123),
+          );
+
+      expect(build(), build());
+      expect(build().hashCode, build().hashCode);
+      expect(build() == WorkInfo(uniqueName: 'other', state: WorkState.failed, isPeriodic: false), isFalse);
+    });
+  });
+
+  group('WorkmanagerPlatform.getWorkInfo', () {
+    test('delegates to the registered platform implementation', () async {
+      final expected = WorkInfo(uniqueName: 'u', state: WorkState.cancelled, isPeriodic: false);
+      WorkmanagerPlatform.instance = _FakePlatform(expected);
+
+      final result = await WorkmanagerPlatform.instance.getWorkInfo('u');
+
+      expect(result, expected);
+    });
+
+    test('default implementation throws UnimplementedError', () {
+      WorkmanagerPlatform.instance = _UnimplementedPlatform();
+
+      expect(
+        () => WorkmanagerPlatform.instance.getWorkInfo('u'),
+        throwsUnimplementedError,
+      );
+    });
+  });
+}

--- a/workmanager_web/lib/workmanager_web.dart
+++ b/workmanager_web/lib/workmanager_web.dart
@@ -382,6 +382,14 @@ class WorkmanagerWeb extends WorkmanagerPlatform {
     return jsonEncode(_tasks.values.map((task) => task.toJson()).toList());
   }
 
+  @override
+  Future<WorkInfo?> getWorkInfo(String uniqueName) async {
+    // Browsers have no queryable task state: the Service Worker runs the
+    // compiled dispatcher without the plugin's Dart code, so nothing is
+    // recorded. Returning null is the documented no-op.
+    return null;
+  }
+
   /// Runs [taskName] immediately through the normal execution path (Web
   /// Worker when available, otherwise in-page).
   ///


### PR DESCRIPTION
## Summary

Closes the audit gap #3 from `docs/android-workmanager-audit.mdx` — there was **no public way to query a task's state** — with a small, honest, cross-platform API:

```dart
final WorkInfo? info = await Workmanager().getWorkInfo('my-unique-task');
// info.state ∈ {scheduled, running, succeeded, failed, cancelled}
// info.isPeriodic, info.taskName, info.tags, info.lastFinishedAt
```

All-new API: no existing method changed behaviour or signature (fixes #194, addresses #475's "is my recurring task still scheduled?" use case).

## The `WorkInfo` model

```dart
class WorkInfo {
  final String uniqueName;      // the registration key
  final WorkState state;        // scheduled | running | succeeded | failed | cancelled
  final bool isPeriodic;        // registered via registerPeriodicTask?
  final String? taskName;       // the task name the work was registered with
  final List<String> tags;      // Android WorkManager tags; empty elsewhere
  final DateTime? lastFinishedAt; // when the plugin last observed the task finish
}
```

The field set is deliberately the **intersection of what each platform can truthfully report**. No `runAttemptCount` (explicitly declined by the maintainer), no streaming API — this is a one-shot query. State mapping: Android `ENQUEUED`/`BLOCKED` → `scheduled`, `RUNNING` → `running`, `SUCCEEDED`/`FAILED`/`CANCELLED` → 1:1.

## API surface — why just `getWorkInfo(String uniqueName)`

We considered a tag-based variant (`getWorkInfosByTag`). Tags are an **Android-only concept** — Apple has no tags (`cancelByTag` is already a documented no-op there), so a tag query would be Android-only surface pretending to be cross-platform. `uniqueName` is the one key with meaning on every platform, and it answers the #475 use case ("is my recurring task still scheduled?"). Smallest honest surface.

## The iOS/macOS design problem — and how it's solved

**BGTaskScheduler (iOS) and NSBackgroundActivityScheduler (macOS) have no query API.** There is no system call that answers "what is the state of this task?". The Flutter engineer must not have to learn that — so the plugin answers the same query itself:

- **Persisted per-task state in `UserDefaults`** (`PersistedWorkInfo`: state, isPeriodic, taskName, lastFinishedAt, updatedAt), stored under `WorkmanagerPlugin.identifier.workInfos`.
- The plugin already funnels every task-status transition through `WorkmanagerDebug.onTaskStatusUpdate(...)` (registration → `scheduled`, start → `running`, completion → `succeeded`, failure → `failed`, cancelled attempt that will retry → `scheduled` again). That funnel now **also updates the persisted store**, independent of the user-swappable debug handler. All five registration call sites that previously bypassed the static funnel now go through it (behaviour-neutral — the static method forwards to the same current handler).
- `cancelByUniqueName`/`cancelAll` additionally mark records `cancelled` (mirroring Android, where WorkManager keeps CANCELLED work queryable).
- `getWorkInfoByUniqueName` on Apple is served straight from that store.

Two task types needed explicit store writes because they previously emitted **no** `.scheduled` status at all: `registerProcessingTask` and `registerHealthResearchTask` (iOS). They now record registration directly in the store without changing debug-notification behaviour.

**Identity resolution detail**: iOS one-off tasks execute under their registered `taskName` (the `identifier`), while the store is keyed by `uniqueName`. Execution updates with no `uniqueName` are resolved via a taskName → most-recently-updated record lookup, which works because one-off registration always happens in-process. BGTaskScheduler-delivered tasks carry their identifier (= `uniqueName`) through the worker pipeline. This required enriching `TaskDebugInfo` with an optional `isPeriodic` and giving `BackgroundWorker.performBackgroundRequest` the task's real identity (it previously hardcoded `taskName: "background_fetch"` for *all* modes — debug logs for periodic/processing tasks now show the real task name, and the BG fetch pseudo-task now logs `iOSPerformFetch`).

## Per-platform truthfulness (documented in `docs/work-info.mdx`)

| Platform | Source of truth | Caveats |
|---|---|---|
| Android | WorkManager `getWorkInfosForUniqueWork` — **authoritative** | `lastFinishedAt` always null (WorkManager exposes no finish timestamp); `isPeriodic` from `PeriodicityInfo`; `taskName` read back from worker input data |
| iOS/macOS | plugin-persisted UserDefaults store — **best effort** | reflects what the plugin has seen, not the scheduler (e.g. iOS may prune pending BGTask requests without informing the app — still reports `scheduled`); `tags` always empty; `lastFinishedAt` only set for tasks the plugin saw finish; survives app restarts |
| Web | no-op | always `null` (the Service Worker runs without the plugin's Dart code, nothing is recorded) |
| Other (desktop) | `UnsupportedError` | consistent with every other platform API |

## Compatibility

- **All new API** — `getWorkInfo` + `WorkInfo`/`WorkState` + the pigeon `WorkInfoData` transport. No signatures changed, no behaviour changed, no version bumps.
- Platform packages that don't implement it yet fall back to the platform interface's `UnimplementedError` default — a loud failure at the call site rather than silently wrong data.

## Tests

- **Dart**: `WorkInfo` model (fromData mapping, null handling, equality), platform-interface delegation with a mocked platform, core `Workmanager.getWorkInfo` delegation, and per-platform pigeon round-trip tests (null reply + full `WorkInfoData` → `WorkInfo` mapping) for Android and Apple.
- **Kotlin**: `WorkInfoMappingTest` — every `WorkInfo.State` maps to the right `WorkState`, periodicity detection, tags sorting, taskName read-back, `lastFinishedAt` null (8 tests).
- **Swift** (RunnerTests on simulator): `WorkInfoStore` persistence round-trip, full status-transition tracking, taskName→uniqueName resolution for iOS one-off tasks, retrying→scheduled+finish-time mapping, cancellation, unknown-task → nil (6 new tests).

## Validation

- `melos bootstrap` ✅ · `dart analyze` clean (all 6 packages) ✅ · `dart test` green (all packages) ✅ · `dart format` clean ✅
- Kotlin unit tests: `./gradlew :workmanager_android:testDebugUnitTest` → 38 tests, 0 failures ✅
- iOS: `flutter build ios --debug --no-codesign` ✅ + `xcodebuild test` RunnerTests (13 tests incl. 6 new) ✅
- macOS: `flutter build macos --debug` ✅

**Not done (per scope):** no merge, no version bump, no publish, no `runAttemptCount`, no tag-based query, no streaming API. Draft for review.
