### PR TITLE
feat(android): progress updates for long-running tasks

### DIFF
--- a/docs/customization.mdx
+++ b/docs/customization.mdx
@@ -372,6 +372,85 @@ void callbackDispatcher() {
 }
 ```
 
+### Reporting Progress (Android only)
+
+Long-running tasks — in practice tasks that run as an Android foreground
+service via `foregroundServiceConfig` — can report progress back to the app.
+This is the missing half of the foreground-service story: the notification
+keeps the task alive, and progress reporting keeps the user (and the UI)
+informed about what it is actually doing.
+
+**Value case:** a foreground-service task that uploads a large file, downloads
+media, or syncs a database runs for minutes. Without progress reporting the
+UI only knows the task started (via `TaskStatus.started` debug events) and
+finished. With it, the app can show a real progress indicator, "3 of 12 files
+uploaded", or a live sync counter.
+
+**Where it does not help:**
+
+- **Short-lived workers.** A regular background worker that finishes in
+  seconds has nothing meaningful to report — the app will likely miss the
+  updates entirely.
+- **iOS, macOS, web and desktop.** There is no equivalent to WorkManager's
+  progress API on these platforms. `reportProgress` and
+  `setProgressListener` are documented no-ops there, so you can call them
+  from shared code without platform guards.
+
+Report progress from inside the task handler:
+
+```dart
+@pragma('vm:entry-point')
+void callbackDispatcher() {
+  Workmanager().executeTask((task, inputData) async {
+    switch (task) {
+      case 'big_upload':
+        final total = inputData!['totalBytes'] as int;
+        var uploaded = 0;
+        while (uploaded < total) {
+          // ... upload a chunk ...
+          uploaded += CHUNK_SIZE;
+          await Workmanager().reportProgress({
+            'progress': uploaded / total,
+            'uploadedBytes': uploaded,
+            'totalBytes': total,
+          });
+        }
+        return true;
+    }
+    return true;
+  });
+}
+```
+
+Observe progress from the app side. Register the listener once, right after
+`initialize`:
+
+```dart
+void main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  await Workmanager().initialize(callbackDispatcher);
+  Workmanager().setProgressListener((uniqueName, progress) {
+    print('$uniqueName is at ${progress['progress']} '
+        '(${progress['uploadedBytes']} of ${progress['totalBytes']} bytes)');
+  });
+  runApp(const MyApp());
+}
+```
+
+The listener receives the task's `uniqueName` (so you can correlate it with
+`isScheduledByUniqueName` / `cancelByUniqueName`) and the exact progress map
+the handler reported. Progress is stored through WorkManager's `setProgress`,
+so it is also visible to anything else that observes the task's `WorkInfo`.
+Pass `null` to `setProgressListener` to stop receiving updates.
+
+<Info>
+**Timing.** Progress updates are forwarded while the task is running. If the
+app starts while a task is already running (for example after a relaunch),
+the listener receives the latest progress with the task's next update. The
+value type is the same as for `inputData`: `int`, `bool`, `double`, `String`
+and their lists (nested maps are also accepted).
+</Info>
+
 ## Error Handling and Retries
 
 ```dart

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -41,7 +41,7 @@ const iOSBackgroundProcessingTask =
 const periodicUpdatePolicyTask =
     "dev.fluttercommunity.workmanagerExample.periodicUpdatePolicyTask";
 const workInfoTaskKey = "dev.fluttercommunity.workmanagerExample.workInfoTask";
-
+const progressTaskKey = "dev.fluttercommunity.workmanagerExample.progressTask";
 final List<String> allTasks = [
   simpleTaskKey,
   rescheduledTaskKey,
@@ -54,6 +54,7 @@ final List<String> allTasks = [
   iOSBackgroundAppRefresh,
   iOSBackgroundProcessingTask,
   periodicUpdatePolicyTask,
+  progressTaskKey,
 ];
 
 // Pragma is mandatory if the App is obfuscated or using Flutter 3.1+
@@ -125,7 +126,20 @@ void callbackDispatcher() {
         break;
       case workInfoTaskKey:
         debugPrint("$workInfoTaskKey executed");
-        break;
+      case progressTaskKey:
+        // Long-running foreground service task that reports progress. The app
+        // observes the updates through Workmanager().setProgressListener.
+        // Without the foreground service config WorkManager would stop this
+        // worker after ~10 minutes of execution.
+        for (var step = 0; step <= 10; step++) {
+          await Workmanager().reportProgress(<String, dynamic>{
+            'progress': step / 10,
+            'step': step,
+            'stage': step == 10 ? 'done' : 'working',
+          });
+          debugPrint("$progressTaskKey reported progress ${step / 10}");
+          await Future<void>.delayed(const Duration(seconds: 1));
+        }        break;
       default:
         return Future.value(false);
     }
@@ -180,6 +194,13 @@ class _MyAppState extends State<MyApp> {
                     if (!workmanagerInitialized) {
                       try {
                         await Workmanager().initialize(callbackDispatcher);
+                        // Observe progress updates from long-running tasks
+                        // (Android only; a no-op on other platforms).
+                        Workmanager()
+                            .setProgressListener((uniqueName, progress) {
+                          debugPrint(
+                              'Progress update for $uniqueName: $progress');
+                        });
                       } catch (e) {
                         debugPrint('Error initializing Workmanager: $e');
                         return;
@@ -280,6 +301,24 @@ class _MyAppState extends State<MyApp> {
                         }
                       : null,
                   child: Text("Register expedited task (Android)"),
+                ),
+                // Long-running task promoted to a foreground service. Reports
+                // progress every second; the app prints the updates via the
+                // progress listener (see the initialize button above).
+                ElevatedButton(
+                  onPressed: Platform.isAndroid
+                      ? () {
+                          Workmanager().registerOneOffTask(
+                            progressTaskKey,
+                            progressTaskKey,
+                            foregroundServiceConfig: ForegroundServiceConfig(
+                              notificationTitle: 'Progress demo',
+                              notificationText: 'Running with progress updates',
+                            ),
+                          );
+                        }
+                      : null,
+                  child: Text("Register Foreground Progress Task (Android)"),
                 ),
                 SizedBox(height: 8),
                 Text(

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -139,7 +139,8 @@ void callbackDispatcher() {
           });
           debugPrint("$progressTaskKey reported progress ${step / 10}");
           await Future<void>.delayed(const Duration(seconds: 1));
-        }        break;
+        }
+        break;
       default:
         return Future.value(false);
     }

--- a/workmanager/lib/src/workmanager_impl.dart
+++ b/workmanager/lib/src/workmanager_impl.dart
@@ -140,6 +140,7 @@ class Workmanager {
 
   static BackgroundTaskHandler? _backgroundTaskHandler;
   static BackgroundTaskStoppedHandler? _onTaskStoppedHandler;
+  static ProgressListener? _progressListener;
   static late final WorkmanagerFlutterApi _flutterApi;
 
   /// The callback dispatcher registered via [initialize], kept so in-process
@@ -518,6 +519,38 @@ class Workmanager {
   /// Currently only supported on iOS and only on iOS 13+.
   /// Returns a string containing the scheduled tasks information.
   Future<String> printScheduledTasks() async => _platform.printScheduledTasks();
+
+  /// Reports progress for the task that is currently running.
+  ///
+  /// Must be called from inside the [BackgroundTaskHandler]; the platform
+  /// resolves the running task's unique name from the calling context, so the
+  /// app-side listener receives it keyed by the task's [uniqueName]. The
+  /// progress map accepts the same value types as [inputData] (int, bool,
+  /// double, String and their lists).
+  ///
+  /// Only meaningful for long-running tasks — in practice tasks that run as an
+  /// Android foreground service (see [ForegroundServiceConfig]). Regular
+  /// background workers finish too quickly for progress to be useful.
+  ///
+  /// Android only: on other platforms this is a documented no-op, so portable
+  /// handlers can call it unconditionally.
+  Future<void> reportProgress(Map<String, dynamic> progress) async {
+    return _platform.reportProgress(progress);
+  }
+
+  /// Registers a listener that receives progress updates from running
+  /// background tasks.
+  ///
+  /// The listener is invoked with the task's [uniqueName] and the progress map
+  /// the task handler reported via [reportProgress]. Register it once at
+  /// startup (e.g. in `main()` right after [initialize]); pass `null` to stop
+  /// receiving updates.
+  ///
+  /// Android only: on other platforms the listener is never invoked.
+  Future<void> setProgressListener(ProgressListener? listener) async {
+    _progressListener = listener;
+    await _platform.setProgressListener(listener);
+  }
 }
 
 /// Converts inputData from Pigeon format, filtering out null keys and
@@ -610,6 +643,16 @@ class _WorkmanagerFlutterApiImpl extends WorkmanagerFlutterApi {
     final handler = Workmanager._onTaskStoppedHandler;
     if (handler != null) {
       await handler(taskName, StopReason.fromRawValue(stopReason));
+    }
+  }
+
+  @override
+  Future<void> onProgressUpdate(
+      String uniqueName, Map<String?, Object?>? progress) async {
+    final listener = Workmanager._progressListener;
+    if (listener != null) {
+      listener(uniqueName,
+          convertPigeonInputData(progress) ?? const <String, dynamic>{});
     }
   }
 }

--- a/workmanager/test/progress_updates_test.dart
+++ b/workmanager/test/progress_updates_test.dart
@@ -1,0 +1,128 @@
+import 'dart:typed_data';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:workmanager/workmanager.dart';
+import 'package:workmanager_apple/workmanager_apple.dart';
+
+const String _channelPrefix =
+    'dev.flutter.pigeon.workmanager_platform_interface.WorkmanagerFlutterApi.';
+
+/// Fake platform that records calls without touching real platform channels.
+/// Extends [WorkmanagerApple] so Workmanager's platform auto-selection (which
+/// runs on macOS/iOS/Android hosts) does not replace it.
+class _FakeApplePlatform extends WorkmanagerApple {
+  final reportedProgress = <Map<String, dynamic>>[];
+  final progressListenerCalls = <bool>[];
+
+  @override
+  Future<void> initialize(
+    Function callbackDispatcher, {
+    @Deprecated(
+        'Use WorkmanagerDebug handlers instead. This parameter has no effect.')
+    bool isInDebugMode = false,
+  }) async {}
+
+  @override
+  Future<void> reportProgress(Map<String, dynamic> progress) async {
+    reportedProgress.add(progress);
+  }
+
+  @override
+  Future<void> setProgressListener(ProgressListener? listener) async {
+    progressListenerCalls.add(listener != null);
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late _FakeApplePlatform platform;
+
+  setUp(() {
+    platform = _FakeApplePlatform();
+    WorkmanagerPlatform.instance = platform;
+  });
+
+  Future<void> sendProgressUpdate(
+    String uniqueName,
+    Map<String?, Object?>? progress,
+  ) async {
+    final messenger =
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+    final codec = WorkmanagerFlutterApi.pigeonChannelCodec;
+    ByteData? reply;
+    await messenger.handlePlatformMessage(
+      '${_channelPrefix}onProgressUpdate',
+      codec.encodeMessage(<Object?>[uniqueName, progress]),
+      (data) {
+        reply = data;
+      },
+    );
+    expect(reply, isNotNull);
+    expect(codec.decodeMessage(reply) as List<Object?>?, isEmpty);
+  }
+
+  test('reportProgress delegates to the platform with the given map', () async {
+    await Workmanager().reportProgress(<String, dynamic>{
+      'progress': 0.5,
+      'stage': 'uploading',
+    });
+
+    expect(platform.reportedProgress, [
+      <String, dynamic>{'progress': 0.5, 'stage': 'uploading'},
+    ]);
+  });
+
+  test('setProgressListener registers and unregisters the listener', () async {
+    final updates = <(String, Map<String, dynamic>)>[];
+
+    // initialize sets up the Flutter API receiver on the current isolate; the
+    // progress listener is then invoked by native-side onProgressUpdate
+    // messages without the dispatcher ever running.
+    await Workmanager().initialize(() {});
+
+    await Workmanager().setProgressListener(
+        (uniqueName, progress) => updates.add((uniqueName, progress)));
+
+    expect(platform.progressListenerCalls, [true]);
+
+    await sendProgressUpdate(
+      'dev.fluttercommunity.test.sync',
+      <String?, Object?>{
+        'progress': 0.25,
+        'nested': {'x': 1}
+      },
+    );
+
+    expect(updates, hasLength(1));
+    expect(updates.single.$1, 'dev.fluttercommunity.test.sync');
+    expect(updates.single.$2, <String, dynamic>{
+      'progress': 0.25,
+      'nested': <String, dynamic>{'x': 1},
+    });
+
+    // Unregistering stops delivery.
+    await Workmanager().setProgressListener(null);
+    expect(platform.progressListenerCalls, [true, false]);
+
+    await sendProgressUpdate(
+        'dev.fluttercommunity.test.sync', <String?, Object?>{'progress': 0.5});
+    expect(updates, hasLength(1));
+  });
+
+  test('no listener registered means updates are acknowledged and dropped',
+      () async {
+    final updates = <(String, Map<String, dynamic>)>[];
+
+    await Workmanager().initialize(() {});
+    await Workmanager().setProgressListener(
+        (uniqueName, progress) => updates.add((uniqueName, progress)));
+    await Workmanager().setProgressListener(null);
+
+    await sendProgressUpdate(
+        'dev.fluttercommunity.test.sync', <String?, Object?>{'progress': 1.0});
+
+    expect(updates, isEmpty);
+  });
+}

--- a/workmanager/test/workmanager_test.mocks.dart
+++ b/workmanager/test/workmanager_test.mocks.dart
@@ -281,4 +281,26 @@ class MockWorkmanager extends _i1.Mock implements _i2.Workmanager {
           ),
         )),
       ) as _i3.Future<String>);
+
+  @override
+  _i3.Future<void> reportProgress(Map<String, dynamic>? progress) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #reportProgress,
+          [progress],
+        ),
+        returnValue: _i3.Future<void>.value(),
+        returnValueForMissingStub: _i3.Future<void>.value(),
+      ) as _i3.Future<void>);
+
+  @override
+  _i3.Future<void> setProgressListener(_i4.ProgressListener? listener) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #setProgressListener,
+          [listener],
+        ),
+        returnValue: _i3.Future<void>.value(),
+        returnValueForMissingStub: _i3.Future<void>.value(),
+      ) as _i3.Future<void>);
 }

--- a/workmanager_android/android/src/main/kotlin/dev/fluttercommunity/workmanager/BackgroundWorker.kt
+++ b/workmanager_android/android/src/main/kotlin/dev/fluttercommunity/workmanager/BackgroundWorker.kt
@@ -42,9 +42,24 @@ class BackgroundWorker(
     private val dartTask
         get() = workerParams.inputData.getString(DART_TASK_KEY)
 
+    /**
+     * The unique name the task was registered with, persisted in the worker's
+     * [androidx.work.Data] at enqueue time. `null` only for tasks that were
+     * enqueued before the unique name was persisted (older plugin versions).
+     */
+    val uniqueName: String?
+        get() = workerParams.inputData.getString(UNIQUE_NAME_KEY)
+
     private val runAttemptCount = workerParams.runAttemptCount
     private val randomThreadIdentifier = SecureRandom().nextInt()
     private var engine: FlutterEngine? = null
+
+    /**
+     * The plugin instance attached to this worker's engine. The Dart task
+     * runs on that engine, so its `reportProgress` calls arrive at this
+     * plugin; binding the worker lets the plugin route them to us.
+     */
+    private var boundPlugin: WorkmanagerPlugin? = null
 
     private var startTime: Long = 0
 
@@ -84,6 +99,15 @@ class BackgroundWorker(
             Handler(Looper.getMainLooper()),
         ) {
             engine = FlutterEngine(applicationContext)
+            engine?.let { engine ->
+                // Bind this worker to the plugin instance attached to this
+                // worker's engine, so progress reported from the Dart task
+                // can be routed back to this worker.
+                (engine.plugins.get(WorkmanagerPlugin::class.java) as? WorkmanagerPlugin)?.let { plugin ->
+                    boundPlugin = plugin
+                    plugin.bindWorker(this)
+                }
+            }
             val callbackHandle = SharedPreferenceHelper.getCallbackHandle(applicationContext)
             val callbackInfo = FlutterCallbackInformation.lookupCallbackInformation(callbackHandle)
 
@@ -201,6 +225,32 @@ class BackgroundWorker(
         stopEngine(null, stopReason = stopReason)
     }
 
+    /**
+     * Persists [progress] for this task and makes it available to the app.
+     *
+     * Called by the plugin when the Dart task handler reports progress on
+     * this worker's engine. The progress is stored through WorkManager's
+     * `setProgressAsync` (so it is queryable via [androidx.work.WorkInfo])
+     * and picked up by [ProgressUpdateCoordinator], which forwards it to the
+     * app.
+     */
+    fun reportProgress(progress: Map<String?, Any?>?) {
+        val localUniqueName = uniqueName
+        if (localUniqueName == null) {
+            // Task was enqueued before the unique name was persisted in the
+            // worker data; there is no way to key the progress update.
+            WorkmanagerDebug.onExceptionEncountered(
+                applicationContext,
+                TaskDebugInfo(taskName = "unknown", startTime = startTime),
+                IllegalStateException("Cannot report progress for a task without a unique name"),
+            )
+            return
+        }
+
+        setProgressAsync(encodeProgressData(progress))
+        ProgressUpdateCoordinator.onProgressReported(applicationContext, localUniqueName)
+    }
+
     private fun stopEngine(
         result: Result?,
         errorMessage: String? = null,
@@ -248,6 +298,11 @@ class BackgroundWorker(
         if (result != null) {
             this.completer?.set(result)
         }
+
+        // Unbind from the plugin before the engine is torn down, so progress
+        // reported after the task finished is not routed to a dead worker.
+        boundPlugin?.unbindWorker(this)
+        boundPlugin = null
 
         // If stopEngine is called from `onStopped`, it may not be from the main thread.
         Handler(Looper.getMainLooper()).post {

--- a/workmanager_android/android/src/main/kotlin/dev/fluttercommunity/workmanager/InputDataUtils.kt
+++ b/workmanager_android/android/src/main/kotlin/dev/fluttercommunity/workmanager/InputDataUtils.kt
@@ -29,7 +29,19 @@ const val FOREGROUND_SERVICE_CONFIG_KEY =
     "dev.fluttercommunity.workmanager.FOREGROUND_SERVICE_CONFIG"
 
 /**
- * Serializes [dartTask] and [payload] into WorkManager [Data].
+ * Key under which the task's unique name is stored in WorkManager [Data].
+ *
+ * The unique name is only known at enqueue time, so it is persisted next to
+ * the Dart task name. The worker reads it back when it runs; it is used to
+ * key progress updates (WorkManager stores progress per unique work name)
+ * and to route progress events back to the app. It is never delivered to the
+ * Dart callback.
+ */
+const val UNIQUE_NAME_KEY = "dev.fluttercommunity.workmanager.UNIQUE_NAME"
+
+/**
+ * Serializes [dartTask], the task's [uniqueName] and [payload] into
+ * WorkManager [Data].
  *
  * - Scalars are stored natively under `payload_<key>` (same keys as before).
  * - Homogeneous lists are stored as typed primitive arrays under
@@ -39,39 +51,69 @@ const val FOREGROUND_SERVICE_CONFIG_KEY =
  *   `json_payload_<key>` and decoded again when the task runs.
  * - An optional [foregroundServiceConfig] is JSON-encoded under
  *   [FOREGROUND_SERVICE_CONFIG_KEY].
+ * - An optional [uniqueName] is stored under [UNIQUE_NAME_KEY].
  */
 fun buildTaskInputData(
     dartTask: String,
     payload: Map<String, Any?>?,
     foregroundServiceConfig: ForegroundServiceConfig? = null,
+    uniqueName: String? = null,
 ): Data {
     val builder = Data.Builder().putString(BackgroundWorker.DART_TASK_KEY, dartTask)
+
+    uniqueName?.let { builder.putString(UNIQUE_NAME_KEY, it) }
 
     foregroundServiceConfig?.let {
         builder.putString(FOREGROUND_SERVICE_CONFIG_KEY, encodeForegroundServiceConfig(it))
     }
 
     payload?.forEach { (key, value) ->
-        when (value) {
-            null -> builder.putJsonPayload(key, null)
-            is String -> builder.putString("$PAYLOAD_PREFIX$key", value)
-            is Boolean -> builder.putBoolean("$PAYLOAD_PREFIX$key", value)
-            is Int -> builder.putInt("$PAYLOAD_PREFIX$key", value)
-            is Long -> builder.putLong("$PAYLOAD_PREFIX$key", value)
-            is Float -> builder.putFloat("$PAYLOAD_PREFIX$key", value)
-            is Double -> builder.putDouble("$PAYLOAD_PREFIX$key", value)
-            is ByteArray -> builder.putByteArray("$PAYLOAD_PREFIX$key", value)
-            is List<*> -> builder.putListPayload(key, value)
-            is Map<*, *> -> builder.putJsonPayload(key, value)
-            else ->
-                throw IllegalArgumentException(
-                    "Unsupported payload type for key '$key': ${value::class.java.simpleName}. " +
-                        "Consider converting it to a supported type.",
-                )
-        }
+        builder.putPayloadValue(key, value)
     }
 
     return builder.build()
+}
+
+/**
+ * Encodes a progress map into WorkManager [Data] using the same encoding as
+ * the task payload (see [buildTaskInputData]), so the progress reported by a
+ * task round-trips through [decodePayload] unchanged.
+ *
+ * Keys that are null are skipped, mirroring how input data is normalized
+ * before it is stored.
+ */
+fun encodeProgressData(progress: Map<String?, Any?>?): Data {
+    val builder = Data.Builder()
+    progress?.forEach { (key, value) ->
+        if (key != null) {
+            builder.putPayloadValue(key, value)
+        }
+    }
+    return builder.build()
+}
+
+private fun Data.Builder.putPayloadValue(
+    key: String,
+    value: Any?,
+): Data.Builder {
+    when (value) {
+        null -> putJsonPayload(key, null)
+        is String -> putString("$PAYLOAD_PREFIX$key", value)
+        is Boolean -> putBoolean("$PAYLOAD_PREFIX$key", value)
+        is Int -> putInt("$PAYLOAD_PREFIX$key", value)
+        is Long -> putLong("$PAYLOAD_PREFIX$key", value)
+        is Float -> putFloat("$PAYLOAD_PREFIX$key", value)
+        is Double -> putDouble("$PAYLOAD_PREFIX$key", value)
+        is ByteArray -> putByteArray("$PAYLOAD_PREFIX$key", value)
+        is List<*> -> putListPayload(key, value)
+        is Map<*, *> -> putJsonPayload(key, value)
+        else ->
+            throw IllegalArgumentException(
+                "Unsupported payload type for key '$key': ${value::class.java.simpleName}. " +
+                    "Consider converting it to a supported type.",
+            )
+    }
+    return this
 }
 
 /** Encodes a [ForegroundServiceConfig] as a JSON string for WorkManager [Data]. */

--- a/workmanager_android/android/src/main/kotlin/dev/fluttercommunity/workmanager/ProgressUpdateCoordinator.kt
+++ b/workmanager_android/android/src/main/kotlin/dev/fluttercommunity/workmanager/ProgressUpdateCoordinator.kt
@@ -1,0 +1,95 @@
+package dev.fluttercommunity.workmanager
+
+import android.content.Context
+import android.os.Handler
+import android.os.Looper
+import androidx.work.WorkInfo
+import androidx.work.WorkManager
+import dev.fluttercommunity.workmanager.pigeon.WorkmanagerFlutterApi
+import io.flutter.plugin.common.BinaryMessenger
+import java.util.Collections
+
+/**
+ * Routes progress updates from running background tasks back to the app.
+ *
+ * The write side is the running [BackgroundWorker]: it calls
+ * `setProgressAsync(...)` (so the progress is persisted in WorkManager and
+ * queryable through [WorkInfo]) and then reports the unique name here.
+ *
+ * The read side observes WorkManager's `getWorkInfosForUniqueWorkLiveData`
+ * for that unique name and forwards every progress change to the app through
+ * [WorkmanagerFlutterApi.onProgressUpdate] on the app-facing messenger.
+ *
+ * Observation is deliberately driven by [WorkManager]'s own work-info
+ * database rather than by forwarding the reported map directly: the app then
+ * receives exactly what WorkManager stores, and the first observation
+ * delivers the latest progress even for a task that was already running when
+ * the app (re)started.
+ *
+ * Android-only: on other platforms there is no native equivalent and this
+ * coordinator is never wired up.
+ */
+object ProgressUpdateCoordinator {
+    /**
+     * The messenger of the engine the app talks to (the engine that called
+     * `initialize` or `setProgressListener`). Progress events are forwarded
+     * on this messenger; `null` means the app is not listening (or explicitly
+     * unregistered) and no observation takes place.
+     */
+    @Volatile
+    private var appMessenger: BinaryMessenger? = null
+
+    private val observedUniqueNames = Collections.synchronizedSet(mutableSetOf<String>())
+
+    /**
+     * (Re)binds the app-facing messenger.
+     *
+     * Called when the app initializes the plugin and when it (un)registers a
+     * progress listener, always on the engine the app talks to.
+     */
+    fun setAppMessenger(
+        enabled: Boolean,
+        messenger: BinaryMessenger,
+    ) {
+        appMessenger = if (enabled) messenger else null
+    }
+
+    /**
+     * Called whenever a running task reports progress.
+     *
+     * Ensures the unique name's work info is observed and its progress is
+     * forwarded to the app. Without an app-facing messenger there is nobody
+     * to forward to, so nothing is registered (and [context] may be `null`
+     * in unit tests).
+     */
+    fun onProgressReported(
+        context: Context?,
+        uniqueName: String,
+    ) {
+        val messenger = appMessenger ?: return
+        if (!observedUniqueNames.add(uniqueName)) {
+            return
+        }
+
+        val workManager = WorkManager.getInstance(context?.applicationContext ?: return)
+
+        // LiveData observation must be registered on the main thread.
+        Handler(Looper.getMainLooper()).post {
+            workManager.getWorkInfosForUniqueWorkLiveData(uniqueName).observeForever { workInfos ->
+                val running = workInfos?.firstOrNull { it.state == WorkInfo.State.RUNNING } ?: return@observeForever
+                val progress = running.progress
+                if (progress.keyValueMap.isEmpty()) {
+                    return@observeForever
+                }
+
+                val currentMessenger = appMessenger ?: return@observeForever
+                val decodedProgress = decodePayload(progress.keyValueMap)
+                WorkmanagerFlutterApi(currentMessenger)
+                    .onProgressUpdate(uniqueName, decodedProgress as Map<String?, Any?>) {
+                        // The Dart side acknowledges or reports an error; there
+                        // is nothing to act on here.
+                    }
+            }
+        }
+    }
+}

--- a/workmanager_android/android/src/main/kotlin/dev/fluttercommunity/workmanager/WorkManagerUtils.kt
+++ b/workmanager_android/android/src/main/kotlin/dev/fluttercommunity/workmanager/WorkManagerUtils.kt
@@ -40,6 +40,7 @@ internal fun createPeriodicWorkRequest(
     taskName: String,
     inputData: Map<String, Any?>?,
     foregroundServiceConfig: dev.fluttercommunity.workmanager.pigeon.ForegroundServiceConfig? = null,
+    uniqueName: String? = null,
     frequencySeconds: Long,
     flexIntervalSeconds: Long?,
     initialDelaySeconds: Long?,
@@ -66,7 +67,7 @@ internal fun createPeriodicWorkRequest(
                 )
         }
     return builder
-        .setInputData(buildTaskInputData(taskName, inputData, foregroundServiceConfig))
+        .setInputData(buildTaskInputData(taskName, inputData, foregroundServiceConfig, uniqueName))
         .setInitialDelay(
             initialDelaySeconds ?: DEFAULT_INITIAL_DELAY_SECONDS,
             TimeUnit.SECONDS,
@@ -205,6 +206,7 @@ internal fun createOneOffWorkRequest(request: dev.fluttercommunity.workmanager.p
                     request.taskName,
                     request.inputData?.filterNotNullKeys(),
                     request.foregroundServiceConfig,
+                    request.uniqueName,
                 ),
             ).setInitialDelay(
                 request.initialDelaySeconds ?: DEFAULT_INITIAL_DELAY_SECONDS,
@@ -267,6 +269,7 @@ class WorkManagerWrapper(
                 taskName = request.taskName,
                 inputData = request.inputData?.filterNotNullKeys(),
                 foregroundServiceConfig = request.foregroundServiceConfig,
+                uniqueName = request.uniqueName,
                 frequencySeconds = request.frequencySeconds,
                 flexIntervalSeconds = request.flexIntervalSeconds,
                 initialDelaySeconds = request.initialDelaySeconds,

--- a/workmanager_android/android/src/main/kotlin/dev/fluttercommunity/workmanager/WorkmanagerPlugin.kt
+++ b/workmanager_android/android/src/main/kotlin/dev/fluttercommunity/workmanager/WorkmanagerPlugin.kt
@@ -241,6 +241,8 @@ class WorkmanagerPlugin :
         } catch (e: Exception) {
             callback(Result.failure(e))
         }
+    }
+
     override fun reportProgress(
         progress: Map<String?, Any?>?,
         callback: (Result<Unit>) -> Unit,
@@ -267,5 +269,6 @@ class WorkmanagerPlugin :
         pluginBinding?.let {
             ProgressUpdateCoordinator.setAppMessenger(enabled = enabled, messenger = it.binaryMessenger)
         }
-        callback(Result.success(Unit))    }
+        callback(Result.success(Unit))
+    }
 }

--- a/workmanager_android/android/src/main/kotlin/dev/fluttercommunity/workmanager/WorkmanagerPlugin.kt
+++ b/workmanager_android/android/src/main/kotlin/dev/fluttercommunity/workmanager/WorkmanagerPlugin.kt
@@ -26,7 +26,40 @@ class WorkmanagerPlugin :
 
     private var currentDispatcherHandle: Long = -1L
 
+    /**
+     * The binding of the engine this plugin is attached to. Used to resolve
+     * the app-facing messenger for progress updates.
+     */
+    private var pluginBinding: FlutterPlugin.FlutterPluginBinding? = null
+
+    /**
+     * The worker currently running on this plugin's engine, if any. Background
+     * workers bind themselves to the plugin instance attached to their own
+     * engine; the app-facing plugin instance stays unbound.
+     */
+    private var boundWorker: BackgroundWorker? = null
+
+    /**
+     * Binds a background worker to this plugin instance (see [boundWorker]).
+     */
+    internal fun bindWorker(worker: BackgroundWorker) {
+        boundWorker = worker
+    }
+
+    /**
+     * Unbinds a background worker from this plugin instance. Unbinding is
+     * idempotent and only clears the binding when [worker] is the bound one,
+     * so a worker that finishes after its replacement already bound itself
+     * never unbinds the replacement.
+     */
+    internal fun unbindWorker(worker: BackgroundWorker) {
+        if (boundWorker === worker) {
+            boundWorker = null
+        }
+    }
+
     override fun onAttachedToEngine(binding: FlutterPlugin.FlutterPluginBinding) {
+        pluginBinding = binding
         preferenceManager =
             SharedPreferenceHelper(
                 binding.applicationContext,
@@ -43,6 +76,7 @@ class WorkmanagerPlugin :
     override fun onDetachedFromEngine(binding: FlutterPlugin.FlutterPluginBinding) {
         WorkmanagerHostApi.setUp(binding.binaryMessenger, null)
         workManagerWrapper = null
+        pluginBinding = null
     }
 
     override fun initialize(
@@ -57,6 +91,12 @@ class WorkmanagerPlugin :
 
             // Update the local variable to match
             currentDispatcherHandle = handle
+
+            // The engine that initializes the plugin is the one the app talks
+            // to; progress updates are forwarded on this messenger.
+            pluginBinding?.let {
+                ProgressUpdateCoordinator.setAppMessenger(enabled = true, messenger = it.binaryMessenger)
+            }
 
             callback(Result.success(Unit))
         } catch (e: Exception) {
@@ -201,5 +241,31 @@ class WorkmanagerPlugin :
         } catch (e: Exception) {
             callback(Result.failure(e))
         }
+    override fun reportProgress(
+        progress: Map<String?, Any?>?,
+        callback: (Result<Unit>) -> Unit,
+    ) {
+        val worker = boundWorker
+        if (worker == null) {
+            // reportProgress outside of a running task (e.g. called from the
+            // app isolate) has nothing to attach to. Keep it a no-op so
+            // portable handlers that report progress unconditionally do not
+            // crash on Android either.
+            callback(Result.success(Unit))
+            return
+        }
+        worker.reportProgress(progress)
+        callback(Result.success(Unit))
     }
+
+    override fun setProgressListener(
+        enabled: Boolean,
+        callback: (Result<Unit>) -> Unit,
+    ) {
+        // (Re)bind the app-facing messenger for progress updates. This call
+        // always originates from the engine the app talks to.
+        pluginBinding?.let {
+            ProgressUpdateCoordinator.setAppMessenger(enabled = enabled, messenger = it.binaryMessenger)
+        }
+        callback(Result.success(Unit))    }
 }

--- a/workmanager_android/android/src/main/kotlin/dev/fluttercommunity/workmanager/pigeon/WorkmanagerApi.g.kt
+++ b/workmanager_android/android/src/main/kotlin/dev/fluttercommunity/workmanager/pigeon/WorkmanagerApi.g.kt
@@ -1291,6 +1291,25 @@ interface WorkmanagerHostApi {
    * null when the platform has no record of it.
    */
   fun getWorkInfoByUniqueName(uniqueName: String, callback: (Result<WorkInfoData?>) -> Unit)
+  /**
+   * Reports progress for the task that is currently running (Android only).
+   *
+   * Must be called from inside the background task handler; the native side
+   * resolves the running task's unique name from the calling context, so the
+   * [progress] map is the only argument. On platforms without progress
+   * support (iOS/macOS/web/desktop) the call is a no-op.
+   */
+  fun reportProgress(progress: Map<String?, Any?>?, callback: (Result<Unit>) -> Unit)
+  /**
+   * Enables or disables forwarding of progress updates to the app (Android
+   * only).
+   *
+   * When [enabled] is true the native side starts forwarding progress events
+   * (delivered through [WorkmanagerFlutterApi.onProgressUpdate]) to the
+   * messenger of the engine that made this call. On platforms without
+   * progress support the call is a no-op.
+   */
+  fun setProgressListener(enabled: Boolean, callback: (Result<Unit>) -> Unit)
 
   companion object {
     /** The codec used by WorkmanagerHostApi. */
@@ -1528,6 +1547,44 @@ interface WorkmanagerHostApi {
           channel.setMessageHandler(null)
         }
       }
+      run {
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.workmanager_platform_interface.WorkmanagerHostApi.reportProgress$separatedMessageChannelSuffix", codec)
+        if (api != null) {
+          channel.setMessageHandler { message, reply ->
+            val args = message as List<Any?>
+            val progressArg = args[0] as Map<String?, Any?>?
+            api.reportProgress(progressArg) { result: Result<Unit> ->
+              val error = result.exceptionOrNull()
+              if (error != null) {
+                reply.reply(WorkmanagerApiPigeonUtils.wrapError(error))
+              } else {
+                reply.reply(WorkmanagerApiPigeonUtils.wrapResult(null))
+              }
+            }
+          }
+        } else {
+          channel.setMessageHandler(null)
+        }
+      }
+      run {
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.workmanager_platform_interface.WorkmanagerHostApi.setProgressListener$separatedMessageChannelSuffix", codec)
+        if (api != null) {
+          channel.setMessageHandler { message, reply ->
+            val args = message as List<Any?>
+            val enabledArg = args[0] as Boolean
+            api.setProgressListener(enabledArg) { result: Result<Unit> ->
+              val error = result.exceptionOrNull()
+              if (error != null) {
+                reply.reply(WorkmanagerApiPigeonUtils.wrapError(error))
+              } else {
+                reply.reply(WorkmanagerApiPigeonUtils.wrapResult(null))
+              }
+            }
+          }
+        } else {
+          channel.setMessageHandler(null)
+        }
+      }
     }
   }
 }
@@ -1591,6 +1648,32 @@ class WorkmanagerFlutterApi(private val binaryMessenger: BinaryMessenger, privat
     val channelName = "dev.flutter.pigeon.workmanager_platform_interface.WorkmanagerFlutterApi.onTaskStopped$separatedMessageChannelSuffix"
     val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
     channel.send(listOf(taskNameArg, stopReasonArg)) {
+      if (it is List<*>) {
+        if (it.size > 1) {
+          callback(Result.failure(FlutterError(it[0] as String, it[1] as String, it[2] as String?)))
+        } else {
+          callback(Result.success(Unit))
+        }
+      } else {
+        callback(Result.failure(WorkmanagerApiPigeonUtils.createConnectionError(channelName)))
+      } 
+    }
+  }
+  /**
+   * Delivers a progress update for a running task to the app (Android only).
+   *
+   * [uniqueName] is the unique name the task was registered with. [progress]
+   * is the progress map the task handler reported via
+   * [WorkmanagerHostApi.reportProgress]. This is only invoked when the app
+   * registered a progress listener (see `Workmanager().setProgressListener`);
+   * on platforms without progress support it is never invoked.
+   */
+  fun onProgressUpdate(uniqueNameArg: String, progressArg: Map<String?, Any?>?, callback: (Result<Unit>) -> Unit)
+{
+    val separatedMessageChannelSuffix = if (messageChannelSuffix.isNotEmpty()) ".$messageChannelSuffix" else ""
+    val channelName = "dev.flutter.pigeon.workmanager_platform_interface.WorkmanagerFlutterApi.onProgressUpdate$separatedMessageChannelSuffix"
+    val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
+    channel.send(listOf(uniqueNameArg, progressArg)) {
       if (it is List<*>) {
         if (it.size > 1) {
           callback(Result.failure(FlutterError(it[0] as String, it[1] as String, it[2] as String?)))

--- a/workmanager_android/android/src/test/kotlin/dev/fluttercommunity/workmanager/ProgressUpdateTest.kt
+++ b/workmanager_android/android/src/test/kotlin/dev/fluttercommunity/workmanager/ProgressUpdateTest.kt
@@ -1,0 +1,139 @@
+package dev.fluttercommunity.workmanager
+
+import androidx.work.Data
+import androidx.work.ForegroundUpdater
+import androidx.work.ProgressUpdater
+import androidx.work.WorkerFactory
+import androidx.work.WorkerParameters
+import androidx.work.WorkerParameters.RuntimeExtras
+import androidx.work.impl.utils.taskexecutor.TaskExecutor
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+import java.util.UUID
+import java.util.concurrent.Executor
+import kotlin.coroutines.EmptyCoroutineContext
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [26])
+class ProgressUpdateTest {
+    @Test
+    fun `unique name is persisted in the worker data`() {
+        val data = buildTaskInputData("task", payload = null, uniqueName = "my-unique-task")
+
+        assertEquals("my-unique-task", data.getString(UNIQUE_NAME_KEY))
+    }
+
+    @Test
+    fun `unique name is absent when not provided`() {
+        val data = buildTaskInputData("task", payload = null)
+
+        assertNull(data.getString(UNIQUE_NAME_KEY))
+    }
+
+    @Test
+    fun `scalar progress values are stored natively`() {
+        val progress =
+            mapOf<String?, Any?>(
+                "progress" to 0.5,
+                "processed" to 12,
+                "stage" to "uploading",
+            )
+
+        val data = encodeProgressData(progress)
+
+        assertEquals(0.5, data.getDouble("payload_progress", 0.0), 0.0)
+        assertEquals(12, data.getInt("payload_processed", 0))
+        assertEquals("uploading", data.getString("payload_stage"))
+    }
+
+    @Test
+    fun `nested progress values are JSON-encoded and round-trip`() {
+        val progress =
+            mapOf<String?, Any?>(
+                "counts" to mapOf("done" to 3, "total" to 10),
+                "history" to listOf(1, 2, 3),
+            )
+
+        val data = encodeProgressData(progress)
+        val decoded = decodePayload(data.keyValueMap)
+
+        assertEquals(progress, decoded)
+    }
+
+    @Test
+    fun `progress round-trips through the payload encoding`() {
+        val progress =
+            mapOf<String?, Any?>(
+                "progress" to 0.25,
+                "message" to "downloading",
+                "tags" to listOf("a", "b"),
+            )
+
+        val decoded = decodePayload(encodeProgressData(progress).keyValueMap)
+
+        assertEquals(progress, decoded)
+    }
+
+    @Test
+    fun `null progress keys are skipped`() {
+        val data = encodeProgressData(mapOf<String?, Any?>(null to "dropped", "kept" to 1))
+
+        assertFalse(data.keyValueMap.containsKey("dropped"))
+        assertTrue(data.keyValueMap.containsKey("payload_kept"))
+        assertEquals(mapOf<String, Any?>("kept" to 1), decodePayload(data.keyValueMap))
+    }
+
+    @Test
+    fun `reportProgress persists the encoded progress data through WorkManager`() {
+        val progressUpdater = mock<ProgressUpdater>()
+        val worker =
+            BackgroundWorker(
+                RuntimeEnvironment.getApplication(),
+                workerParameters(
+                    inputData = mapOf(UNIQUE_NAME_KEY to "my-unique-task"),
+                    progressUpdater = progressUpdater,
+                ),
+            )
+
+        worker.reportProgress(mapOf("progress" to 0.75))
+
+        // setProgressAsync routes through the worker's ProgressUpdater; the
+        // Data it receives must be the encoded progress map.
+        val dataCaptor = argumentCaptor<Data>()
+        verify(progressUpdater).updateProgress(any(), any(), dataCaptor.capture())
+        assertEquals(0.75, dataCaptor.firstValue.getDouble("payload_progress", 0.0), 0.0)
+    }
+
+    private fun workerParameters(
+        inputData: Map<String, Any?>,
+        progressUpdater: ProgressUpdater,
+    ): WorkerParameters {
+        val dataBuilder = Data.Builder()
+        inputData.forEach { (key, value) -> dataBuilder.putString(key, value as String) }
+        return WorkerParameters(
+            UUID.randomUUID(),
+            dataBuilder.build(),
+            emptyList(),
+            RuntimeExtras(),
+            0,
+            0,
+            Executor { it.run() },
+            EmptyCoroutineContext,
+            mock<TaskExecutor>(),
+            mock<WorkerFactory>(),
+            progressUpdater,
+            mock<ForegroundUpdater>(),
+        )
+    }
+}

--- a/workmanager_android/lib/workmanager_android.dart
+++ b/workmanager_android/lib/workmanager_android.dart
@@ -167,7 +167,13 @@ class WorkmanagerAndroid extends WorkmanagerPlatform {
   Future<WorkInfo?> getWorkInfo(String uniqueName) async {
     final data = await _api.getWorkInfoByUniqueName(uniqueName);
     return data == null ? null : WorkInfo.fromData(data);
+  Future<void> reportProgress(Map<String, dynamic> progress) async {
+    await _api.reportProgress(progress.cast<String?, Object?>());
   }
+
+  @override
+  Future<void> setProgressListener(ProgressListener? listener) async {
+    await _api.setProgressListener(listener != null);  }
 }
 
 /// Defaults for the Android foreground service notification.

--- a/workmanager_android/lib/workmanager_android.dart
+++ b/workmanager_android/lib/workmanager_android.dart
@@ -167,13 +167,17 @@ class WorkmanagerAndroid extends WorkmanagerPlatform {
   Future<WorkInfo?> getWorkInfo(String uniqueName) async {
     final data = await _api.getWorkInfoByUniqueName(uniqueName);
     return data == null ? null : WorkInfo.fromData(data);
+  }
+
+  @override
   Future<void> reportProgress(Map<String, dynamic> progress) async {
     await _api.reportProgress(progress.cast<String?, Object?>());
   }
 
   @override
   Future<void> setProgressListener(ProgressListener? listener) async {
-    await _api.setProgressListener(listener != null);  }
+    await _api.setProgressListener(listener != null);
+  }
 }
 
 /// Defaults for the Android foreground service notification.

--- a/workmanager_android/test/workmanager_android_test.dart
+++ b/workmanager_android/test/workmanager_android_test.dart
@@ -477,7 +477,21 @@ void main() {
           final decoded = WorkmanagerHostApi.pigeonChannelCodec
               .decodeMessage(message) as List<Object?>;
           captured = decoded[0]! as OneOffTaskRequest;
-          return WorkmanagerHostApi.pigeonChannelCodec
+    group('Progress updates', () {
+      const reportProgressChannel =
+          'dev.flutter.pigeon.workmanager_platform_interface.WorkmanagerHostApi.reportProgress';
+      const setProgressListenerChannel =
+          'dev.flutter.pigeon.workmanager_platform_interface.WorkmanagerHostApi.setProgressListener';
+
+      test('reportProgress forwards the progress map through pigeon', () async {
+        late Map<String?, Object?> captured;
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMessageHandler(reportProgressChannel,
+                (ByteData? message) async {
+          final decoded = WorkmanagerHostApi.pigeonChannelCodec
+              .decodeMessage(message) as List<Object?>;
+          captured =
+              (decoded[0]! as Map<Object?, Object?>).cast<String?, Object?>();          return WorkmanagerHostApi.pigeonChannelCodec
               .encodeMessage(<Object?>[]);
         });
 
@@ -499,7 +513,51 @@ void main() {
         final captured = await captureRequest(expedited: false);
 
         expect(captured.expedited, isFalse);
+        await workmanager.reportProgress(<String, dynamic>{
+          'progress': 0.5,
+          'stage': 'uploading',
+        });
+
+        expect(captured, <String?, Object?>{
+          'progress': 0.5,
+          'stage': 'uploading',
+        });
       });
+
+      test('setProgressListener enables native forwarding with a listener',
+          () async {
+        late bool captured;
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMessageHandler(setProgressListenerChannel,
+                (ByteData? message) async {
+          final decoded = WorkmanagerHostApi.pigeonChannelCodec
+              .decodeMessage(message) as List<Object?>;
+          captured = decoded[0]! as bool;
+          return WorkmanagerHostApi.pigeonChannelCodec
+              .encodeMessage(<Object?>[]);
+        });
+
+        await workmanager.setProgressListener((uniqueName, progress) {});
+
+        expect(captured, isTrue);
+      });
+
+      test('setProgressListener disables native forwarding when unregistered',
+          () async {
+        late bool captured;
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMessageHandler(setProgressListenerChannel,
+                (ByteData? message) async {
+          final decoded = WorkmanagerHostApi.pigeonChannelCodec
+              .decodeMessage(message) as List<Object?>;
+          captured = decoded[0]! as bool;
+          return WorkmanagerHostApi.pigeonChannelCodec
+              .encodeMessage(<Object?>[]);
+        });
+
+        await workmanager.setProgressListener(null);
+
+        expect(captured, isFalse);      });
     });
   });
 }

--- a/workmanager_android/test/workmanager_android_test.dart
+++ b/workmanager_android/test/workmanager_android_test.dart
@@ -477,21 +477,7 @@ void main() {
           final decoded = WorkmanagerHostApi.pigeonChannelCodec
               .decodeMessage(message) as List<Object?>;
           captured = decoded[0]! as OneOffTaskRequest;
-    group('Progress updates', () {
-      const reportProgressChannel =
-          'dev.flutter.pigeon.workmanager_platform_interface.WorkmanagerHostApi.reportProgress';
-      const setProgressListenerChannel =
-          'dev.flutter.pigeon.workmanager_platform_interface.WorkmanagerHostApi.setProgressListener';
-
-      test('reportProgress forwards the progress map through pigeon', () async {
-        late Map<String?, Object?> captured;
-        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-            .setMockMessageHandler(reportProgressChannel,
-                (ByteData? message) async {
-          final decoded = WorkmanagerHostApi.pigeonChannelCodec
-              .decodeMessage(message) as List<Object?>;
-          captured =
-              (decoded[0]! as Map<Object?, Object?>).cast<String?, Object?>();          return WorkmanagerHostApi.pigeonChannelCodec
+          return WorkmanagerHostApi.pigeonChannelCodec
               .encodeMessage(<Object?>[]);
         });
 
@@ -513,6 +499,28 @@ void main() {
         final captured = await captureRequest(expedited: false);
 
         expect(captured.expedited, isFalse);
+      });
+    });
+
+    group('Progress updates', () {
+      const reportProgressChannel =
+          'dev.flutter.pigeon.workmanager_platform_interface.WorkmanagerHostApi.reportProgress';
+      const setProgressListenerChannel =
+          'dev.flutter.pigeon.workmanager_platform_interface.WorkmanagerHostApi.setProgressListener';
+
+      test('reportProgress forwards the progress map through pigeon', () async {
+        late Map<String?, Object?> captured;
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMessageHandler(reportProgressChannel,
+                (ByteData? message) async {
+          final decoded = WorkmanagerHostApi.pigeonChannelCodec
+              .decodeMessage(message) as List<Object?>;
+          captured =
+              (decoded[0]! as Map<Object?, Object?>).cast<String?, Object?>();
+          return WorkmanagerHostApi.pigeonChannelCodec
+              .encodeMessage(<Object?>[]);
+        });
+
         await workmanager.reportProgress(<String, dynamic>{
           'progress': 0.5,
           'stage': 'uploading',
@@ -557,7 +565,8 @@ void main() {
 
         await workmanager.setProgressListener(null);
 
-        expect(captured, isFalse);      });
+        expect(captured, isFalse);
+      });
     });
   });
 }

--- a/workmanager_apple/ios/workmanager_apple/Sources/workmanager_apple/WorkmanagerPlugin+Progress.swift
+++ b/workmanager_apple/ios/workmanager_apple/Sources/workmanager_apple/WorkmanagerPlugin+Progress.swift
@@ -1,0 +1,28 @@
+// WorkmanagerPlugin+Progress.swift
+//
+// Progress updates are Android-only (WorkManager `setProgress`); there is no
+// equivalent for BGTaskScheduler / NSBackgroundActivityScheduler, so the
+// pigeon host methods are documented no-ops here.
+import Foundation
+
+#if os(iOS)
+extension WorkmanagerPlugin {
+    func reportProgress(progress: [String?: Any?]?, completion: @escaping (Result<Void, Error>) -> Void) {
+        completion(.success(()))
+    }
+
+    func setProgressListener(enabled: Bool, completion: @escaping (Result<Void, Error>) -> Void) {
+        completion(.success(()))
+    }
+}
+#elseif os(macOS)
+extension WorkmanagerPlugin {
+    func reportProgress(progress: [String?: Any?]?, completion: @escaping (Result<Void, Error>) -> Void) {
+        completion(.success(()))
+    }
+
+    func setProgressListener(enabled: Bool, completion: @escaping (Result<Void, Error>) -> Void) {
+        completion(.success(()))
+    }
+}
+#endif

--- a/workmanager_apple/ios/workmanager_apple/Sources/workmanager_apple/WorkmanagerPlugin.swift
+++ b/workmanager_apple/ios/workmanager_apple/Sources/workmanager_apple/WorkmanagerPlugin.swift
@@ -289,16 +289,6 @@ public class WorkmanagerPlugin: WorkmanagerPluginBase, FlutterPlugin, Workmanage
         }
     }
 
-    func reportProgress(progress: [String?: Any?]?, completion: @escaping (Result<Void, Error>) -> Void) {
-        // Progress updates are Android-only (WorkManager `setProgress`); there
-        // is no equivalent for BGTaskScheduler, so this is a documented no-op.
-        completion(.success(()))
-    }
-
-    func setProgressListener(enabled: Bool, completion: @escaping (Result<Void, Error>) -> Void) {
-        // Progress updates are Android-only; no-op on iOS (see reportProgress).
-        completion(.success(()))
-    }
     #endif
 
     // MARK: - Helper methods
@@ -458,17 +448,6 @@ extension WorkmanagerPlugin {
 
     func printScheduledTasks(completion: @escaping (Result<String, Error>) -> Void) {
         completion(.success(MacOSActivityScheduler.shared.printScheduledActivities()))
-    }
-
-    func reportProgress(progress: [String?: Any?]?, completion: @escaping (Result<Void, Error>) -> Void) {
-        // Progress updates are Android-only; no-op on macOS (see the iOS
-        // section for the reasoning).
-        completion(.success(()))
-    }
-
-    func setProgressListener(enabled: Bool, completion: @escaping (Result<Void, Error>) -> Void) {
-        // Progress updates are Android-only; no-op on macOS.
-        completion(.success(()))
     }
 }
 #endif

--- a/workmanager_apple/ios/workmanager_apple/Sources/workmanager_apple/WorkmanagerPlugin.swift
+++ b/workmanager_apple/ios/workmanager_apple/Sources/workmanager_apple/WorkmanagerPlugin.swift
@@ -288,6 +288,17 @@ public class WorkmanagerPlugin: WorkmanagerPluginBase, FlutterPlugin, Workmanage
             )))
         }
     }
+
+    func reportProgress(progress: [String?: Any?]?, completion: @escaping (Result<Void, Error>) -> Void) {
+        // Progress updates are Android-only (WorkManager `setProgress`); there
+        // is no equivalent for BGTaskScheduler, so this is a documented no-op.
+        completion(.success(()))
+    }
+
+    func setProgressListener(enabled: Bool, completion: @escaping (Result<Void, Error>) -> Void) {
+        // Progress updates are Android-only; no-op on iOS (see reportProgress).
+        completion(.success(()))
+    }
     #endif
 
     // MARK: - Helper methods
@@ -447,6 +458,17 @@ extension WorkmanagerPlugin {
 
     func printScheduledTasks(completion: @escaping (Result<String, Error>) -> Void) {
         completion(.success(MacOSActivityScheduler.shared.printScheduledActivities()))
+    }
+
+    func reportProgress(progress: [String?: Any?]?, completion: @escaping (Result<Void, Error>) -> Void) {
+        // Progress updates are Android-only; no-op on macOS (see the iOS
+        // section for the reasoning).
+        completion(.success(()))
+    }
+
+    func setProgressListener(enabled: Bool, completion: @escaping (Result<Void, Error>) -> Void) {
+        // Progress updates are Android-only; no-op on macOS.
+        completion(.success(()))
     }
 }
 #endif

--- a/workmanager_apple/ios/workmanager_apple/Sources/workmanager_apple/pigeon/WorkmanagerApi.g.swift
+++ b/workmanager_apple/ios/workmanager_apple/Sources/workmanager_apple/pigeon/WorkmanagerApi.g.swift
@@ -1163,6 +1163,21 @@ protocol WorkmanagerHostApi {
   /// Returns the current state of the task registered under [uniqueName], or
   /// null when the platform has no record of it.
   func getWorkInfoByUniqueName(uniqueName: String, completion: @escaping (Result<WorkInfoData?, Error>) -> Void)
+  /// Reports progress for the task that is currently running (Android only).
+  ///
+  /// Must be called from inside the background task handler; the native side
+  /// resolves the running task's unique name from the calling context, so the
+  /// [progress] map is the only argument. On platforms without progress
+  /// support (iOS/macOS/web/desktop) the call is a no-op.
+  func reportProgress(progress: [String?: Any?]?, completion: @escaping (Result<Void, Error>) -> Void)
+  /// Enables or disables forwarding of progress updates to the app (Android
+  /// only).
+  ///
+  /// When [enabled] is true the native side starts forwarding progress events
+  /// (delivered through [WorkmanagerFlutterApi.onProgressUpdate]) to the
+  /// messenger of the engine that made this call. On platforms without
+  /// progress support the call is a no-op.
+  func setProgressListener(enabled: Bool, completion: @escaping (Result<Void, Error>) -> Void)
 }
 
 /// Generated setup class from Pigeon to handle messages through the `binaryMessenger`.
@@ -1373,6 +1388,53 @@ class WorkmanagerHostApiSetup {
     } else {
       getWorkInfoByUniqueNameChannel.setMessageHandler(nil)
     }
+    /// Reports progress for the task that is currently running (Android only).
+    ///
+    /// Must be called from inside the background task handler; the native side
+    /// resolves the running task's unique name from the calling context, so the
+    /// [progress] map is the only argument. On platforms without progress
+    /// support (iOS/macOS/web/desktop) the call is a no-op.
+    let reportProgressChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.workmanager_platform_interface.WorkmanagerHostApi.reportProgress\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
+    if let api = api {
+      reportProgressChannel.setMessageHandler { message, reply in
+        let args = message as! [Any?]
+        let progressArg: [String?: Any?]? = nilOrValue(args[0])
+        api.reportProgress(progress: progressArg) { result in
+          switch result {
+          case .success:
+            reply(wrapResult(nil))
+          case .failure(let error):
+            reply(wrapError(error))
+          }
+        }
+      }
+    } else {
+      reportProgressChannel.setMessageHandler(nil)
+    }
+    /// Enables or disables forwarding of progress updates to the app (Android
+    /// only).
+    ///
+    /// When [enabled] is true the native side starts forwarding progress events
+    /// (delivered through [WorkmanagerFlutterApi.onProgressUpdate]) to the
+    /// messenger of the engine that made this call. On platforms without
+    /// progress support the call is a no-op.
+    let setProgressListenerChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.workmanager_platform_interface.WorkmanagerHostApi.setProgressListener\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
+    if let api = api {
+      setProgressListenerChannel.setMessageHandler { message, reply in
+        let args = message as! [Any?]
+        let enabledArg = args[0] as! Bool
+        api.setProgressListener(enabled: enabledArg) { result in
+          switch result {
+          case .success:
+            reply(wrapResult(nil))
+          case .failure(let error):
+            reply(wrapError(error))
+          }
+        }
+      }
+    } else {
+      setProgressListenerChannel.setMessageHandler(nil)
+    }
   }
 }
 /// Generated protocol from Pigeon that represents Flutter messages that can be called from Swift.
@@ -1387,6 +1449,14 @@ protocol WorkmanagerFlutterApiProtocol {
   /// It is `0` (unknown) on Android versions before 12 (API 31) and on
   /// platforms without an equivalent concept.
   func onTaskStopped(taskName taskNameArg: String, stopReason stopReasonArg: Int64, completion: @escaping (Result<Void, PigeonError>) -> Void)
+  /// Delivers a progress update for a running task to the app (Android only).
+  ///
+  /// [uniqueName] is the unique name the task was registered with. [progress]
+  /// is the progress map the task handler reported via
+  /// [WorkmanagerHostApi.reportProgress]. This is only invoked when the app
+  /// registered a progress listener (see `Workmanager().setProgressListener`);
+  /// on platforms without progress support it is never invoked.
+  func onProgressUpdate(uniqueName uniqueNameArg: String, progress progressArg: [String?: Any?]?, completion: @escaping (Result<Void, PigeonError>) -> Void)
 }
 class WorkmanagerFlutterApi: WorkmanagerFlutterApiProtocol {
   private let binaryMessenger: FlutterBinaryMessenger
@@ -1448,6 +1518,31 @@ class WorkmanagerFlutterApi: WorkmanagerFlutterApiProtocol {
     let channelName: String = "dev.flutter.pigeon.workmanager_platform_interface.WorkmanagerFlutterApi.onTaskStopped\(messageChannelSuffix)"
     let channel = FlutterBasicMessageChannel(name: channelName, binaryMessenger: binaryMessenger, codec: codec)
     channel.sendMessage([taskNameArg, stopReasonArg] as [Any?]) { response in
+      guard let listResponse = response as? [Any?] else {
+        completion(.failure(createConnectionError(withChannelName: channelName)))
+        return
+      }
+      if listResponse.count > 1 {
+        let code: String = listResponse[0] as! String
+        let message: String? = nilOrValue(listResponse[1])
+        let details: String? = nilOrValue(listResponse[2])
+        completion(.failure(PigeonError(code: code, message: message, details: details)))
+      } else {
+        completion(.success(()))
+      }
+    }
+  }
+  /// Delivers a progress update for a running task to the app (Android only).
+  ///
+  /// [uniqueName] is the unique name the task was registered with. [progress]
+  /// is the progress map the task handler reported via
+  /// [WorkmanagerHostApi.reportProgress]. This is only invoked when the app
+  /// registered a progress listener (see `Workmanager().setProgressListener`);
+  /// on platforms without progress support it is never invoked.
+  func onProgressUpdate(uniqueName uniqueNameArg: String, progress progressArg: [String?: Any?]?, completion: @escaping (Result<Void, PigeonError>) -> Void) {
+    let channelName: String = "dev.flutter.pigeon.workmanager_platform_interface.WorkmanagerFlutterApi.onProgressUpdate\(messageChannelSuffix)"
+    let channel = FlutterBasicMessageChannel(name: channelName, binaryMessenger: binaryMessenger, codec: codec)
+    channel.sendMessage([uniqueNameArg, progressArg] as [Any?]) { response in
       guard let listResponse = response as? [Any?] else {
         completion(.failure(createConnectionError(withChannelName: channelName)))
         return

--- a/workmanager_apple/macos/workmanager_apple/Sources/workmanager_apple/WorkmanagerPlugin+Progress.swift
+++ b/workmanager_apple/macos/workmanager_apple/Sources/workmanager_apple/WorkmanagerPlugin+Progress.swift
@@ -1,0 +1,1 @@
+../../../../ios/workmanager_apple/Sources/workmanager_apple/WorkmanagerPlugin+Progress.swift

--- a/workmanager_platform_interface/lib/src/pigeon/workmanager_api.g.dart
+++ b/workmanager_platform_interface/lib/src/pigeon/workmanager_api.g.dart
@@ -1371,6 +1371,55 @@ class WorkmanagerHostApi {
     ;
     return pigeonVar_replyValue as WorkInfoData?;
   }
+
+  /// Reports progress for the task that is currently running (Android only).
+  ///
+  /// Must be called from inside the background task handler; the native side
+  /// resolves the running task's unique name from the calling context, so the
+  /// [progress] map is the only argument. On platforms without progress
+  /// support (iOS/macOS/web/desktop) the call is a no-op.
+  Future<void> reportProgress(Map<String?, Object?>? progress) async {
+    final pigeonVar_channelName = 'dev.flutter.pigeon.workmanager_platform_interface.WorkmanagerHostApi.reportProgress$pigeonVar_messageChannelSuffix';
+    final pigeonVar_channel = BasicMessageChannel<Object?>(
+      pigeonVar_channelName,
+      pigeonChannelCodec,
+      binaryMessenger: pigeonVar_binaryMessenger,
+    );
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[progress]);
+    final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
+
+    _extractReplyValueOrThrow(
+        pigeonVar_replyList,
+        pigeonVar_channelName,
+        isNullValid: true,
+    )
+    ;
+  }
+
+  /// Enables or disables forwarding of progress updates to the app (Android
+  /// only).
+  ///
+  /// When [enabled] is true the native side starts forwarding progress events
+  /// (delivered through [WorkmanagerFlutterApi.onProgressUpdate]) to the
+  /// messenger of the engine that made this call. On platforms without
+  /// progress support the call is a no-op.
+  Future<void> setProgressListener(bool enabled) async {
+    final pigeonVar_channelName = 'dev.flutter.pigeon.workmanager_platform_interface.WorkmanagerHostApi.setProgressListener$pigeonVar_messageChannelSuffix';
+    final pigeonVar_channel = BasicMessageChannel<Object?>(
+      pigeonVar_channelName,
+      pigeonChannelCodec,
+      binaryMessenger: pigeonVar_binaryMessenger,
+    );
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[enabled]);
+    final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
+
+    _extractReplyValueOrThrow(
+        pigeonVar_replyList,
+        pigeonVar_channelName,
+        isNullValid: true,
+    )
+    ;
+  }
 }
 
 abstract class WorkmanagerFlutterApi {
@@ -1388,6 +1437,15 @@ abstract class WorkmanagerFlutterApi {
   /// It is `0` (unknown) on Android versions before 12 (API 31) and on
   /// platforms without an equivalent concept.
   Future<void> onTaskStopped(String taskName, int stopReason);
+
+  /// Delivers a progress update for a running task to the app (Android only).
+  ///
+  /// [uniqueName] is the unique name the task was registered with. [progress]
+  /// is the progress map the task handler reported via
+  /// [WorkmanagerHostApi.reportProgress]. This is only invoked when the app
+  /// registered a progress listener (see `Workmanager().setProgressListener`);
+  /// on platforms without progress support it is never invoked.
+  Future<void> onProgressUpdate(String uniqueName, Map<String?, Object?>? progress);
 
   static void setUp(WorkmanagerFlutterApi? api, {BinaryMessenger? binaryMessenger, String messageChannelSuffix = '',}) {
     messageChannelSuffix = messageChannelSuffix.isNotEmpty ? '.$messageChannelSuffix' : '';
@@ -1445,6 +1503,28 @@ abstract class WorkmanagerFlutterApi {
           final int arg_stopReason = args[1]! as int;
           try {
             await api.onTaskStopped(arg_taskName, arg_stopReason);
+            return wrapResponse(empty: true);
+          } on PlatformException catch (e) {
+            return wrapResponse(error: e);
+          }          catch (e) {
+            return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
+          }
+        });
+      }
+    }
+    {
+      final pigeonVar_channel = BasicMessageChannel<Object?>(
+          'dev.flutter.pigeon.workmanager_platform_interface.WorkmanagerFlutterApi.onProgressUpdate$messageChannelSuffix', pigeonChannelCodec,
+          binaryMessenger: binaryMessenger);
+      if (api == null) {
+        pigeonVar_channel.setMessageHandler(null);
+      } else {
+        pigeonVar_channel.setMessageHandler((Object? message) async {
+          final List<Object?> args = message! as List<Object?>;
+          final String arg_uniqueName = args[0]! as String;
+          final Map<String?, Object?>? arg_progress = (args[1] as Map<Object?, Object?>?)?.cast<String?, Object?>();
+          try {
+            await api.onProgressUpdate(arg_uniqueName, arg_progress);
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);

--- a/workmanager_platform_interface/lib/src/workmanager_platform_interface.dart
+++ b/workmanager_platform_interface/lib/src/workmanager_platform_interface.dart
@@ -199,14 +199,14 @@ abstract class WorkmanagerPlatform extends PlatformInterface {
     throw UnimplementedError('printScheduledTasks() has not been implemented.');
   }
 
-<<<<<<< HEAD
   /// Queries the current state of the task registered under [uniqueName].
   ///
   /// Returns `null` when the platform has no record of the task. See [WorkInfo]
   /// for the per-platform truthfulness of the result.
   Future<WorkInfo?> getWorkInfo(String uniqueName) {
     throw UnimplementedError('getWorkInfo() has not been implemented.');
-=======
+  }
+
   /// Reports progress for the currently running task (Android only).
   ///
   /// Must be called from inside the background task handler; the platform
@@ -226,7 +226,6 @@ abstract class WorkmanagerPlatform extends PlatformInterface {
   /// support the listener is never invoked and this call is a no-op.
   Future<void> setProgressListener(ProgressListener? listener) async {
     // No-op: progress observation is Android-only.
->>>>>>> ab45b65 (feat(android): progress updates for long-running tasks)
   }
 }
 

--- a/workmanager_platform_interface/lib/src/workmanager_platform_interface.dart
+++ b/workmanager_platform_interface/lib/src/workmanager_platform_interface.dart
@@ -3,6 +3,15 @@ import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 import 'pigeon/workmanager_api.g.dart';
 import 'work_info.dart';
 
+/// Signature for a listener that receives progress updates from running
+/// background tasks.
+///
+/// [uniqueName] is the unique name the task was registered with and
+/// [progress] the progress map the task handler reported. Android only: on
+/// platforms without an equivalent the listener is never invoked.
+typedef ProgressListener = void Function(
+    String uniqueName, Map<String, dynamic> progress);
+
 /// The interface that implementations of workmanager must implement.
 ///
 /// Platform implementations should extend this class rather than implement it as `workmanager`
@@ -190,12 +199,34 @@ abstract class WorkmanagerPlatform extends PlatformInterface {
     throw UnimplementedError('printScheduledTasks() has not been implemented.');
   }
 
+<<<<<<< HEAD
   /// Queries the current state of the task registered under [uniqueName].
   ///
   /// Returns `null` when the platform has no record of the task. See [WorkInfo]
   /// for the per-platform truthfulness of the result.
   Future<WorkInfo?> getWorkInfo(String uniqueName) {
     throw UnimplementedError('getWorkInfo() has not been implemented.');
+=======
+  /// Reports progress for the currently running task (Android only).
+  ///
+  /// Must be called from inside the background task handler; the platform
+  /// resolves the running task's unique name from the calling context.
+  ///
+  /// On platforms without progress support (iOS/macOS/web/desktop) this is a
+  /// documented no-op: background task handlers are shared across platforms,
+  /// and throwing would fail tasks on platforms where the call is meaningless.
+  Future<void> reportProgress(Map<String, dynamic> progress) async {
+    // No-op: progress reporting is Android-only.
+  }
+
+  /// Registers a listener that receives progress updates from running
+  /// background tasks (Android only).
+  ///
+  /// Pass `null` to stop receiving updates. On platforms without progress
+  /// support the listener is never invoked and this call is a no-op.
+  Future<void> setProgressListener(ProgressListener? listener) async {
+    // No-op: progress observation is Android-only.
+>>>>>>> ab45b65 (feat(android): progress updates for long-running tasks)
   }
 }
 

--- a/workmanager_platform_interface/pigeons/workmanager_api.dart
+++ b/workmanager_platform_interface/pigeons/workmanager_api.dart
@@ -503,12 +503,11 @@ abstract class WorkmanagerHostApi {
   @async
   String printScheduledTasks();
 
-<<<<<<< HEAD
   /// Returns the current state of the task registered under [uniqueName], or
   /// null when the platform has no record of it.
   @async
   WorkInfoData? getWorkInfoByUniqueName(String uniqueName);
-=======
+
   /// Reports progress for the task that is currently running (Android only).
   ///
   /// Must be called from inside the background task handler; the native side
@@ -527,7 +526,6 @@ abstract class WorkmanagerHostApi {
   /// progress support the call is a no-op.
   @async
   void setProgressListener(bool enabled);
->>>>>>> ab45b65 (feat(android): progress updates for long-running tasks)
 }
 
 // Flutter API (Native calls Flutter)

--- a/workmanager_platform_interface/pigeons/workmanager_api.dart
+++ b/workmanager_platform_interface/pigeons/workmanager_api.dart
@@ -503,10 +503,31 @@ abstract class WorkmanagerHostApi {
   @async
   String printScheduledTasks();
 
+<<<<<<< HEAD
   /// Returns the current state of the task registered under [uniqueName], or
   /// null when the platform has no record of it.
   @async
   WorkInfoData? getWorkInfoByUniqueName(String uniqueName);
+=======
+  /// Reports progress for the task that is currently running (Android only).
+  ///
+  /// Must be called from inside the background task handler; the native side
+  /// resolves the running task's unique name from the calling context, so the
+  /// [progress] map is the only argument. On platforms without progress
+  /// support (iOS/macOS/web/desktop) the call is a no-op.
+  @async
+  void reportProgress(Map<String?, Object?>? progress);
+
+  /// Enables or disables forwarding of progress updates to the app (Android
+  /// only).
+  ///
+  /// When [enabled] is true the native side starts forwarding progress events
+  /// (delivered through [WorkmanagerFlutterApi.onProgressUpdate]) to the
+  /// messenger of the engine that made this call. On platforms without
+  /// progress support the call is a no-op.
+  @async
+  void setProgressListener(bool enabled);
+>>>>>>> ab45b65 (feat(android): progress updates for long-running tasks)
 }
 
 // Flutter API (Native calls Flutter)
@@ -527,4 +548,14 @@ abstract class WorkmanagerFlutterApi {
   /// platforms without an equivalent concept.
   @async
   void onTaskStopped(String taskName, int stopReason);
+
+  /// Delivers a progress update for a running task to the app (Android only).
+  ///
+  /// [uniqueName] is the unique name the task was registered with. [progress]
+  /// is the progress map the task handler reported via
+  /// [WorkmanagerHostApi.reportProgress]. This is only invoked when the app
+  /// registered a progress listener (see `Workmanager().setProgressListener`);
+  /// on platforms without progress support it is never invoked.
+  @async
+  void onProgressUpdate(String uniqueName, Map<String?, Object?>? progress);
 }


### PR DESCRIPTION
## Summary

Adds the missing half of the existing foreground-service support (gap #2 from the Android audit): long-running tasks can now report progress, and the app can observe it.

Two new calls on `Workmanager()`:

```dart
// Inside the task handler (Android):
await Workmanager().reportProgress({'progress': 0.5, 'uploadedBytes': 42});

// In the app, once, right after initialize():
Workmanager().setProgressListener((uniqueName, progress) { ... });
```

## Chosen API shape — and why

**Reporting side: `reportProgress(Map<String, dynamic>)` with no uniqueName argument.**

The unique name is threaded through the *execution context* on the native side instead of being passed by the caller: each `BackgroundWorker` persists its unique name in WorkManager `Data` at enqueue time, reads it back when it runs, and binds itself to the plugin instance attached to its own (headless) engine. The Dart→native `reportProgress` call therefore needs no identifier — the plugin resolves the running worker from the calling engine. This keeps the handler API clean (the handler receives only `(taskName, inputData)` today; forcing the caller to remember its uniqueName would be error-prone), and it avoids changing the shared `executeTask` FlutterApi signature, which would have rippled into the iOS Swift implementation for a purely Android feature.

**Observing side: a registered listener, `setProgressListener(...)`, rather than a stream.**

- A listener matches the plugin's existing callback style (`executeTask`, `onTaskStopped`) and needs no subscription lifecycle or broadcast-group semantics.
- Progress is inherently per-task and event-like; a `Stream<ProgressUpdate>` would mostly be a thin wrapper over the same callback with extra plumbing (subscription management, broadcast controllers).
- One listener is enough: updates carry the `uniqueName`, so a single listener can route to any number of tasks (exactly like `onTaskStopped`).
- `setProgressListener(null)` unregisters; passing a listener re-registers. Android-only, documented no-op elsewhere.

**Native observation via WorkManager itself.** The task's progress is written with WorkManager's `setProgressAsync`, and the native side observes `getWorkInfosForUniqueWorkLiveData(uniqueName)` and forwards changes to Dart (`onProgressUpdate`). Because delivery is driven by WorkManager's own work-info database, the app receives exactly what WorkManager stores, and the first observation delivers the latest progress even when a task was already running before the app (re)started.

## Value case

Progress reporting only makes sense for long-running work — in practice, work that runs as an Android foreground service via `foregroundServiceConfig` (regular workers finish too fast for progress to be useful, and the app will likely miss the updates). The concrete scenario this targets:

- A foreground-service task uploads a large file / downloads media / syncs a database over minutes.
- Today the UI only learns the task started (debug `TaskStatus.started`) and eventually finished.
- With this PR the UI can show a real progress indicator, "3 of 12 files uploaded", or a live sync counter, keyed by `uniqueName` (correlatable with `isScheduledByUniqueName` / `cancelByUniqueName`).
- Progress is also persisted in the task's `WorkInfo`, so it is visible to anything else observing the task.

## Where it does NOT help

- **Short-lived workers** — nothing useful to report, and the app will likely miss the updates.
- **Periodic tasks** — progress is delivered per run while the run is active.
- **Reporting *to the OS notification*:** this PR surfaces progress to your Dart app; it does not update the foreground-service notification itself (the notification text is static, configured at registration). That stays as-is.

## Android-only

There is no equivalent of WorkManager's progress API on iOS/macOS (BGTaskScheduler has no progress concept exposed here), web, or desktop. Both calls are **documented no-ops** on those platforms rather than throwing `UnsupportedError`:

- `reportProgress` is called from inside task handlers, which are shared across platforms. Throwing would fail tasks on platforms where the call is meaningless.
- `setProgressListener` never fires on other platforms.

The native iOS/macOS implementations are explicit no-op stubs; the platform-interface defaults are no-ops; `onProgressUpdate` is never emitted outside Android.

## Compatibility

New API only — nothing existing changes:

- Backward compatible: the new pigeon channels are additive; `executeTask` and all other messages are untouched.
- `UNIQUE_NAME_KEY` is a new, additive Data key; tasks enqueued by older plugin versions simply have no unique name stored and their `reportProgress` calls are dropped (logged via the debug handler).
- Android 8+ (WorkManager 2.11.2) unchanged; progress needs no extra permissions (the existing foreground-service permissions already ship in the plugin manifest).

## Tests

- Dart: progress round-trips through the Android pigeon channel; listener fires on `onProgressUpdate` and stops firing after unregister; reportProgress delegates to the platform.
- Kotlin (Robolectric): `encodeProgressData` encodes scalars natively and nested values as JSON (round-trip); unique name persisted in worker data; a real `BackgroundWorker` reports progress and the encoded `Data` reaches `setProgressAsync` (via a mocked `ProgressUpdater`).
- Example: "Register Foreground Progress Task (Android)" runs a 10-step foreground-service task reporting progress every second; the app-side listener prints each update.

Note: this is a draft — the value framing and API naming are open for review, and the maintainer should weigh in before this is considered final.
