### PR TITLE
feat(android): Migrate Plugin to Built-in Kotlin

### DIFF
--- a/workmanager_android/android/build.gradle
+++ b/workmanager_android/android/build.gradle
@@ -10,12 +10,12 @@ rootProject.allprojects {
 
 apply plugin: 'com.android.library'
 
-// AGP 9+ ships built-in Kotlin support; older versions need the Kotlin Gradle
-// Plugin (KGP) applied explicitly. Do NOT apply KGP on AGP 9+: it is a no-op
-// there for library modules (and deprecated), so Kotlin sources only compile
-// via AGP's built-in Kotlin (see flutter/flutter#183910 and #710). Apps that
-// still set `android.builtInKotlin=false` on AGP 9 must migrate to built-in
-// Kotlin — with that flag no Kotlin plugin compiles at all.
+// AGP 9+ ships built-in Kotlin support and enables it by default; older
+// versions need the Kotlin Gradle Plugin (KGP) applied explicitly. Flutter
+// apps set `android.builtInKotlin=false` in gradle.properties
+// (flutter/flutter#183910) to keep the legacy KGP path working for
+// unmigrated plugins, so this module must apply KGP itself unless built-in
+// Kotlin is active. See #710 and #722.
 def agpMajor = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0] as int
 def builtInKotlin = agpMajor >= 9 &&
     project.findProperty('android.builtInKotlin')?.toString() != 'false'

--- a/workmanager_android/android/build.gradle
+++ b/workmanager_android/android/build.gradle
@@ -17,7 +17,9 @@ apply plugin: 'com.android.library'
 // still set `android.builtInKotlin=false` on AGP 9 must migrate to built-in
 // Kotlin — with that flag no Kotlin plugin compiles at all.
 def agpMajor = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0] as int
-if (agpMajor < 9) {
+def builtInKotlin = agpMajor >= 9 &&
+    project.findProperty('android.builtInKotlin')?.toString() != 'false'
+if (!builtInKotlin) {
     apply plugin: 'kotlin-android'
 }
 


### PR DESCRIPTION
Following https://github.com/fluttercommunity/flutter_workmanager/issues/710 this fixes the use of AGP+9 and also when using `android.builtInKotlin=false` in `gradle.properties` (while android.builtInKotlin=false is discouraged to use in AGP9 it can still be false in this version until the migration is complete)

- Apply kotlin-android whenever built-in Kotlin is not active