### PR TITLE
fix(android): build with AGP 9 and android.builtInKotlin=false (fixes #722)

### DIFF
--- a/workmanager_android/android/build.gradle
+++ b/workmanager_android/android/build.gradle
@@ -10,14 +10,14 @@ rootProject.allprojects {
 
 apply plugin: 'com.android.library'
 
-// AGP 9+ ships built-in Kotlin support; older versions need the Kotlin Gradle
-// Plugin (KGP) applied explicitly. Do NOT apply KGP on AGP 9+: it is a no-op
-// there for library modules (and deprecated), so Kotlin sources only compile
-// via AGP's built-in Kotlin (see flutter/flutter#183910 and #710). Apps that
-// still set `android.builtInKotlin=false` on AGP 9 must migrate to built-in
-// Kotlin — with that flag no Kotlin plugin compiles at all.
+// AGP 9+ ships built-in Kotlin support, but only when the app opts in via
+// `android.builtInKotlin=true` in gradle.properties. Flutter writes
+// `android.builtInKotlin=false` by default (flutter/flutter#183910), so on
+// AGP 9 the plugin must apply KGP itself unless built-in Kotlin is enabled.
+// AGP < 9 always needs KGP. See #710 and #722.
 def agpMajor = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0] as int
-if (agpMajor < 9) {
+def builtInKotlinEnabled = project.findProperty('android.builtInKotlin')?.toString() == 'true'
+if (agpMajor < 9 || !builtInKotlinEnabled) {
     apply plugin: 'kotlin-android'
 }
 


### PR DESCRIPTION
Fixes #722 — `workmanager_android` fails to evaluate on AGP 9 when `android.builtInKotlin=false` (Flutter's default, written by the Android migrator).

## Root cause
The AGP 9 handling from #710 branched on the AGP major version alone:

```groovy
if (agpMajor < 9) { apply plugin: 'kotlin-android' }
...
if (agpMajor >= 9) { kotlin { compilerOptions { ... } } }
```

AGP 9 only provides the `kotlin` extension when `android.builtInKotlin=true`. With the flag `false` (what `flutter create` writes on Flutter 3.44+), neither KGP nor built-in Kotlin is active → `Could not find method kotlin()` at evaluation time. On the previous release (0.9.3) the same guard meant no Kotlin plugin was applied at all and the plugin class was missing at registration.

## Fix
Condition on both axes, the same pattern flutter_timezone 5.1.0 ships:

```groovy
def builtInKotlinEnabled = project.findProperty('android.builtInKotlin')?.toString() == 'true'
if (agpMajor < 9 || !builtInKotlinEnabled) {
    apply plugin: 'kotlin-android'
}
```

- AGP < 9: KGP applied as before (unchanged behavior).
- AGP 9 + `builtInKotlin=true`: no KGP, built-in Kotlin provides the `kotlin` extension (unchanged behavior).
- AGP 9 + `builtInKotlin=false` (Flutter default): KGP applied → extension present → module builds. This is the case that was broken.

`android.builtInKotlin=true` remains a valid app-level choice — no plugin change forces it.

## Verification (local, exact issue environment)
Standalone Gradle project with AGP 9.0.1 / KGP 2.3.20 / Gradle 9.2 / `android.newDsl=false` + `android.builtInKotlin=false`, building the module directly:

| Config | Before | After |
| --- | --- | --- |
| AGP 9, `builtInKotlin=false` | `Could not find method kotlin()` (reproduced, line 60) | BUILD SUCCESSFUL, AAR contains 74 classes incl. `WorkmanagerPlugin`/`BackgroundWorker` |
| AGP 9, `builtInKotlin=true` | — | BUILD SUCCESSFUL, classes present |

Regression on the legacy path (example app, AGP 8.11): `:workmanager_android:testDebugUnitTest` → 50 tests, 0 failures.

One file changed, 7+/7−, no behavior change for already-migrated projects.