### PR TITLE
chore(release): publish packages — workmanager 0.10.7

### DIFF
--- a/.github/workflows/pages-demo.yml
+++ b/.github/workflows/pages-demo.yml
@@ -2,7 +2,7 @@ name: pages-demo
 
 on:
   push:
-    branches: [feat/web-worker-messaging]
+    branches: [main]
   workflow_dispatch:
 
 permissions:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,46 @@ Packages with breaking changes:
 
 Packages with other changes:
 
+ - [`workmanager` - `v0.10.7`](#workmanager---v0107)
+ - [`workmanager_android` - `v0.10.6`](#workmanager_android---v0106)
+ - [`workmanager_web` - `v0.2.0`](#workmanager_web---v020)
+
+Packages with dependency updates only:
+
+> Packages listed below depend on other packages in this workspace that have had changes. Their versions have been incremented to bump the minimum dependency versions of the packages they depend upon in this project.
+
+ - `workmanager` - `v0.10.7`
+
+---
+
+#### `workmanager` - `v0.10.7`
+
+ - **FEAT**(web): bidirectional message channel between page and background worker (#708).
+ - **FIX**(android): make FOREGROUND_SERVICE_DATA_SYNC opt-in (#725).
+
+#### `workmanager_android` - `v0.10.6`
+
+ - **FIX**(android): make FOREGROUND_SERVICE_DATA_SYNC opt-in (#725).
+ - **FEAT**(android): fail loudly when a foreground service permission is missing from the merged manifest.
+
+#### `workmanager_web` - `v0.2.0`
+
+ - **FEAT**(web): bidirectional message channel between page and background worker (#708).
+
+---
+
+## 2026-08-04
+
+### Changes
+
+---
+
+Packages with breaking changes:
+
+ - There are no breaking changes in this release.
+
+Packages with other changes:
+
  - [`workmanager` - `v0.10.6`](#workmanager---v0106)
  - [`workmanager_android` - `v0.10.5`](#workmanager_android---v0105)
 

--- a/docs/troubleshooting.mdx
+++ b/docs/troubleshooting.mdx
@@ -165,6 +165,29 @@ Make sure the basics are right before debugging further:
 - Prefer processing tasks for work that needs minutes; one-off and refresh
   tasks get only seconds of budget.
 
+## Android: Play Console asks for FOREGROUND_SERVICE_DATA_SYNC
+
+If Play Console demands a **foreground-service declaration** and a
+demonstration video for `FOREGROUND_SERVICE_DATA_SYNC` (or the type
+`dataSync`), even though your app only runs plain periodic background tasks:
+
+- The plugin only declares `FOREGROUND_SERVICE_DATA_SYNC` when you opt in.
+  It is a Play Console "special type" with a declaration + video requirement,
+  so the default merged manifest deliberately leaves it out.
+- **You did not opt in** → the merged manifest has no `dataSync` permission.
+  Nothing to do; if Play still lists it, check your own manifest or other
+  dependencies.
+- **You did opt in** → you set `workmanager.enableDataSyncForegroundService=true`
+  in `gradle.properties` (or `-P` on the CLI) to run long-running workers
+  with the `dataSync` foreground service type. Play then asks for the
+  declaration + video — that is expected; complete them.
+
+If your worker requests `foregroundServiceType=dataSync` without the opt-in
+property, the plugin **throws at registration** with instructions (instead of
+failing silently later). The `shortService` type used by expedited work is
+always declared and needs no Play declaration. See
+[issue #725](https://github.com/fluttercommunity/flutter_workmanager/issues/725).
+
 ## Reporting a genuine bug
 
 If you believe the plugin itself is broken, the issue must include:

--- a/docs/web.mdx
+++ b/docs/web.mdx
@@ -23,6 +23,34 @@ closed") is approximated as honestly as browsers allow.
 
 Results are replayed into the app's log on the next page load.
 
+## Messaging with the background worker
+
+Beyond task results, the page and the worker can exchange free-form messages
+while the page is open:
+
+```dart
+// Page side — send a message, listen for replies.
+WorkmanagerWeb().workerMessages.listen((payload) {
+  print('worker says: $payload');
+});
+WorkmanagerWeb().sendMessageToWorker({'op': 'watch', 'city': 'cardiff', 'threshold': 5.0});
+```
+
+```dart
+// Dispatcher side (Flutter-free bundle) — receive and reply.
+WorkmanagerExecution.instance.messageHandler = handleWorkerMessage;
+// …inside the handler, send back:
+WorkmanagerExecution.instance.sendToPage?.call(reply);
+```
+
+## Live demo
+
+A self-contained demo (landing page + worker chat + persistent background
+task queue + Service Worker notifications) is hosted at
+<https://fluttercommunity.github.io/flutter_workmanager/> and lives in the
+repo's `example/` folder. The demo's Guide tab walks through the "install the
+PWA, close the tab, trigger periodic sync, reopen" flow step by step.
+
 ## Honest limitations
 
 - **No exact scheduling** — there is no "run at 15:00" on the web.

--- a/docs/work-info.mdx
+++ b/docs/work-info.mdx
@@ -33,8 +33,8 @@ if (info == null) {
 
 The state mapping is deliberately small: it is the intersection of what
 Android WorkManager and the plugin's own Apple-side state can truthfully
-report. There is no `runAttemptCount` (the maintainer explicitly declined to
-surface it) and no streaming/observation API — this is a one-shot query.
+report. There is deliberately no `runAttemptCount` and no
+streaming/observation API — this is a one-shot query.
 
 ## Per-platform truthfulness
 

--- a/workmanager/CHANGELOG.md
+++ b/workmanager/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.10.7
+
+ - **FEAT**(web): bidirectional message channel between page and background worker (#708).
+ - **FIX**(android): make FOREGROUND_SERVICE_DATA_SYNC opt-in (#725).
+
 ## 0.10.6
 
  - **FIX**(android): build with AGP 9 and android.builtInKotlin=false (#722).

--- a/workmanager/lib/src/workmanager_impl.dart
+++ b/workmanager/lib/src/workmanager_impl.dart
@@ -257,7 +257,11 @@ class Workmanager {
   ///   runs as an Android foreground service for the whole duration of the
   ///   task. This allows work to keep running beyond the usual background
   ///   execution limits, in exchange for a persistent notification. See
-  ///   [ForegroundServiceConfig] for the available options.
+  ///   [ForegroundServiceConfig] for the available options. Note: using the
+  ///   `dataSync` service type requires the
+  ///   `workmanager.enableDataSyncForegroundService=true` gradle property —
+  ///   see the troubleshooting guide:
+  ///   https://docs.page/fluttercommunity/flutter_workmanager/troubleshooting
   Future<void> registerOneOffTask(
     String uniqueName,
     String taskName, {

--- a/workmanager/pubspec.yaml
+++ b/workmanager/pubspec.yaml
@@ -1,6 +1,6 @@
 name: workmanager
 description: Flutter Workmanager. This plugin allows you to schedule background work on Android and iOS.
-version: 0.10.6
+version: 0.10.7
 # publish_to: none
 homepage: https://github.com/fluttercommunity/flutter_workmanager
 repository: https://github.com/fluttercommunity/flutter_workmanager
@@ -14,9 +14,9 @@ dependencies:
   flutter:
     sdk: flutter
   workmanager_platform_interface: ^0.10.4
-  workmanager_android: ^0.10.5
+  workmanager_android: ^0.10.6
   workmanager_apple: ^0.9.10
-  workmanager_web: ^0.1.3+1
+  workmanager_web: ^0.2.0
   workmanager_linux: ^0.1.1
 
 dev_dependencies:

--- a/workmanager_android/CHANGELOG.md
+++ b/workmanager_android/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.10.6
+
+ - **FIX**(android): make FOREGROUND_SERVICE_DATA_SYNC opt-in (#725).
+ - **FEAT**(android): fail loudly when a foreground service permission is missing from the merged manifest.
+
 ## 0.10.5
 
  - **FIX**(android): build with AGP 9 and android.builtInKotlin=false (#722).

--- a/workmanager_android/pubspec.yaml
+++ b/workmanager_android/pubspec.yaml
@@ -1,6 +1,6 @@
 name: workmanager_android
 description: Android implementation of the workmanager plugin.
-version: 0.10.5
+version: 0.10.6
 # publish_to: none
 homepage: https://github.com/fluttercommunity/flutter_workmanager
 repository: https://github.com/fluttercommunity/flutter_workmanager

--- a/workmanager_web/CHANGELOG.md
+++ b/workmanager_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.0
+
+ - **FEAT**(web): bidirectional message channel between page and background worker (#708).
+
 ## 0.1.3+1
 
  - Update a dependency to the latest release.

--- a/workmanager_web/pubspec.yaml
+++ b/workmanager_web/pubspec.yaml
@@ -1,6 +1,6 @@
 name: workmanager_web
 description: Web (experimental) implementation of workmanager using a Service Worker and Web Worker for background task execution.
-version: 0.1.3+1
+version: 0.2.0
 # publish_to: none
 homepage: https://github.com/fluttercommunity/flutter_workmanager
 repository: https://github.com/fluttercommunity/flutter_workmanager


### PR DESCRIPTION
Release: web messaging feature (#708) + FOREGROUND_SERVICE_DATA_SYNC opt-in fix (#725).

- `workmanager` 0.10.6 → **0.10.7**
- `workmanager_android` 0.10.5 → **0.10.6** — dataSync FGS opt-in + loud-failure guard
- `workmanager_web` 0.1.3+1 → **0.2.0** — bidirectional page↔worker messaging

Also: Pages demo workflow now deploys on pushes to `main`.