### PR TITLE
fix(android): check manifest declaration instead of grant state for FGS permission (fixes #731)

### DIFF
--- a/workmanager_android/android/src/main/kotlin/dev/fluttercommunity/workmanager/ForegroundServiceUtils.kt
+++ b/workmanager_android/android/src/main/kotlin/dev/fluttercommunity/workmanager/ForegroundServiceUtils.kt
@@ -78,19 +78,28 @@ private fun createNotificationChannel(
 
 /**
  * Fails loudly when a foreground-service feature is used without the manifest
- * declaration it needs (see issue #725). Normal permissions are granted at
- * install when declared, so a missing declaration surfaces as DENIED here.
+ * declaration it needs (see issues #725 and #731).
+ *
+ * The merged manifest declaration is the contract to check: on Android 16+ a
+ * foreground-service permission can be revoked or denied at runtime even when
+ * it is declared, so [PackageManager.checkPermission] (which reports the
+ * runtime grant state) false-positives and rejects valid declarations. See
+ * #731.
  */
+@Suppress("DEPRECATION") // GET_PERMISSIONS is deprecated on API 33+; the PackageInfoFlags overload needs API 33 at runtime (minSdk 23).
 internal fun requireForegroundServicePermission(
     context: Context,
     permission: String,
     featureDescription: String,
     fixHint: String,
 ) {
-    val granted =
-        context.packageManager.checkPermission(permission, context.packageName) ==
-            PackageManager.PERMISSION_GRANTED
-    if (!granted) {
+    val declared =
+        context
+            .packageManager
+            .getPackageInfo(context.packageName, PackageManager.GET_PERMISSIONS)
+            .requestedPermissions
+            ?.contains(permission) == true
+    if (!declared) {
         throw IllegalStateException(
             "workmanager_android: $featureDescription requires the '$permission' permission " +
                 "in the merged manifest, but it is missing. $fixHint",

--- a/workmanager_android/android/src/test/kotlin/dev/fluttercommunity/workmanager/ForegroundServicePermissionTest.kt
+++ b/workmanager_android/android/src/test/kotlin/dev/fluttercommunity/workmanager/ForegroundServicePermissionTest.kt
@@ -1,12 +1,18 @@
 package dev.fluttercommunity.workmanager
 
+import android.content.Context
+import android.content.pm.PackageInfo
+import android.content.pm.PackageManager
 import android.content.pm.ServiceInfo
 import dev.fluttercommunity.workmanager.pigeon.ForegroundServiceConfig
 import dev.fluttercommunity.workmanager.pigeon.ForegroundServiceType
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.RuntimeEnvironment
 import org.robolectric.annotation.Config
@@ -17,8 +23,9 @@ class ForegroundServicePermissionTest {
     @Test
     fun `dataSync foreground service throws when the permission is not declared`() {
         // The default plugin manifest does not declare
-        // FOREGROUND_SERVICE_DATA_SYNC (it is opt-in, see issue #725), so
-        // checkPermission reports DENIED and the guard fails loudly.
+        // FOREGROUND_SERVICE_DATA_SYNC (it is opt-in, see issue #725), so the
+        // merged-manifest check reports the permission as missing and the
+        // guard fails loudly.
         val config =
             ForegroundServiceConfig(
                 notificationTitle = "Syncing",
@@ -47,5 +54,115 @@ class ForegroundServicePermissionTest {
             ServiceInfo.FOREGROUND_SERVICE_TYPE_SHORT_SERVICE.toLong(),
             info.foregroundServiceType.toLong(),
         )
+    }
+
+    @Test
+    fun `permission check passes when the shortService permission is declared`() {
+        // The #731 regression: the plugin's default manifest always declares
+        // FOREGROUND_SERVICE_SHORT_SERVICE, so the expedited-work path must
+        // pass based on that declaration alone — even when the runtime grant
+        // state would report DENIED (Android 16+ can revoke foreground-service
+        // permissions). The runtime grant state must not matter.
+        val context =
+            contextWithRequestedPermissions(
+                "android.permission.FOREGROUND_SERVICE",
+                "android.permission.FOREGROUND_SERVICE_SHORT_SERVICE",
+            )
+
+        // Must not throw.
+        requireForegroundServicePermission(
+            context,
+            "android.permission.FOREGROUND_SERVICE_SHORT_SERVICE",
+            "expedited work (setExpedited)",
+            "FOREGROUND_SERVICE_SHORT_SERVICE is declared by the plugin by default; " +
+                "keep it if you use expedited work (see the workmanager_android " +
+                "README, issue #725).",
+        )
+    }
+
+    @Test
+    fun `permission check passes when the dataSync permission is declared`() {
+        // Simulates the opt-in manifest swapped in when
+        // workmanager.enableDataSyncForegroundService=true declares
+        // FOREGROUND_SERVICE_DATA_SYNC.
+        val context =
+            contextWithRequestedPermissions(
+                "android.permission.FOREGROUND_SERVICE",
+                "android.permission.FOREGROUND_SERVICE_DATA_SYNC",
+                "android.permission.FOREGROUND_SERVICE_SHORT_SERVICE",
+            )
+
+        // Must not throw.
+        requireForegroundServicePermission(
+            context,
+            "android.permission.FOREGROUND_SERVICE_DATA_SYNC",
+            "foregroundServiceType=dataSync",
+            "Add 'workmanager.enableDataSyncForegroundService=true' to your " +
+                "gradle.properties (see the workmanager_android README, issue #725).",
+        )
+    }
+
+    @Test
+    fun `permission check throws when the permission is not declared`() {
+        // The default plugin manifest does not declare
+        // FOREGROUND_SERVICE_DATA_SYNC (it is opt-in, see issue #725), so the
+        // guard must fail loudly.
+        val context =
+            contextWithRequestedPermissions(
+                "android.permission.FOREGROUND_SERVICE",
+                "android.permission.FOREGROUND_SERVICE_SHORT_SERVICE",
+            )
+
+        val exception =
+            assertThrows(IllegalStateException::class.java) {
+                requireForegroundServicePermission(
+                    context,
+                    "android.permission.FOREGROUND_SERVICE_DATA_SYNC",
+                    "foregroundServiceType=dataSync",
+                    "Add 'workmanager.enableDataSyncForegroundService=true' to your " +
+                        "gradle.properties (see the workmanager_android README, issue #725).",
+                )
+            }
+        assertTrue(exception.message!!.contains("android.permission.FOREGROUND_SERVICE_DATA_SYNC"))
+    }
+
+    @Test
+    fun `permission check throws when the permission list is unavailable`() {
+        // Defensive edge case: a PackageInfo without requestedPermissions
+        // (e.g. from a package manager that did not surface the list) must be
+        // treated as "not declared" and fail loudly instead of crashing.
+        val context = contextWithRequestedPermissions()
+
+        assertThrows(IllegalStateException::class.java) {
+            requireForegroundServicePermission(
+                context,
+                "android.permission.FOREGROUND_SERVICE_SHORT_SERVICE",
+                "expedited work (setExpedited)",
+                "FOREGROUND_SERVICE_SHORT_SERVICE is declared by the plugin by default; " +
+                    "keep it if you use expedited work (see the workmanager_android " +
+                    "README, issue #725).",
+            )
+        }
+    }
+
+    /**
+     * Returns a mocked [Context] whose package manager reports the given
+     * permissions as the manifest's requestedPermissions. Mirrors what
+     * [requireForegroundServicePermission] reads via
+     * `getPackageInfo(packageName, GET_PERMISSIONS)`.
+     */
+    private fun contextWithRequestedPermissions(vararg permissions: String): Context {
+        val packageInfo =
+            PackageInfo().apply {
+                packageName = "com.example.app"
+                requestedPermissions = if (permissions.isEmpty()) null else permissions
+            }
+        val packageManager = mock<PackageManager>()
+        whenever(packageManager.getPackageInfo("com.example.app", PackageManager.GET_PERMISSIONS))
+            .thenReturn(packageInfo)
+        val context = mock<Context>()
+        whenever(context.packageName).thenReturn("com.example.app")
+        whenever(context.packageManager).thenReturn(packageManager)
+        return context
     }
 }


### PR DESCRIPTION
## Summary

`requireForegroundServicePermission()` in `ForegroundServiceUtils.kt` used `PackageManager.checkPermission()`, which reports the **runtime grant state** — not the manifest declaration. On Android 16+, foreground-service permissions can be revoked/denied at runtime even when declared, so the guard false-positived and threw:

> expedited work (setExpedited) requires the 'android.permission.FOREGROUND_SERVICE_SHORT_SERVICE' permission in the merged manifest, but it is missing

…even though the merged manifest clearly declares it (see #731).

The guard now checks the **merged manifest declaration** instead: `packageManager.getPackageInfo(packageName, PackageManager.GET_PERMISSIONS).requestedPermissions` (the set of declared permissions). The loud `IllegalStateException` with the same fix hint is kept for genuinely missing declarations.

Behavior matrix after the fix:

| Path | Manifest state | Result |
| --- | --- | --- |
| Expedited / shortService | `FOREGROUND_SERVICE_SHORT_SERVICE` declared (plugin default) | passes — even if the runtime grant state is DENIED (Android 16+) |
| dataSync | `workmanager.enableDataSyncForegroundService=true` set (permission declared) | passes |
| dataSync | flag not set (permission absent) | still throws with the #725 fix hint |

## Verification

- `./gradlew :workmanager_android:testDebugUnitTest` (via example app, JDK 17): **56 tests, 0 failures** — including new tests covering both the declared case (shortService and dataSync) and the missing-declaration case, plus a null-`requestedPermissions` edge case.
- `-Pworkmanager.enableDataSyncForegroundService=true` build: confirmed the plugin swaps in the opt-in manifest and `processDebugManifest` output then contains `FOREGROUND_SERVICE_DATA_SYNC`.
- `flutter build apk --debug` (example app): builds clean.
- `ktlint 1.7.1` (CI version) on the repo: clean. `dart analyze`: no issues.

Fixes #731
