### PR TITLE
chore(release): publish packages — workmanager 0.10.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,39 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 2026-08-19
+
+### Changes
+
+---
+
+Packages with breaking changes:
+
+ - There are no breaking changes in this release.
+
+Packages with other changes:
+
+ - [`workmanager` - `v0.10.8`](#workmanager---v0108)
+ - [`workmanager_android` - `v0.10.7`](#workmanager_android---v0107)
+
+Packages with dependency updates only:
+
+> Packages listed below depend on other packages in this workspace that have had changes. Their versions have been incremented to bump the minimum dependency versions of the packages they depend upon in this project.
+
+ - `workmanager` - `v0.10.8`
+
+---
+
+#### `workmanager` - `v0.10.8`
+
+ - **FIX**(android): expedited work no longer fails when Android 16 revokes a foreground-service permission at runtime (#731).
+
+#### `workmanager_android` - `v0.10.7`
+
+ - **FIX**(android): expedited work no longer fails when Android 16 revokes a foreground-service permission at runtime (#731).
+
+---
+
 ## 2026-08-04
 
 ### Changes

--- a/workmanager/CHANGELOG.md
+++ b/workmanager/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.10.8
+
+ - **FIX**(android): expedited work no longer fails when Android 16 revokes a foreground-service permission at runtime (#731).
+
 ## 0.10.7
 
  - **FEAT**(web): bidirectional message channel between page and background worker (#708).

--- a/workmanager/pubspec.yaml
+++ b/workmanager/pubspec.yaml
@@ -1,6 +1,6 @@
 name: workmanager
 description: Flutter Workmanager. This plugin allows you to schedule background work on Android and iOS.
-version: 0.10.7
+version: 0.10.8
 # publish_to: none
 homepage: https://github.com/fluttercommunity/flutter_workmanager
 repository: https://github.com/fluttercommunity/flutter_workmanager
@@ -14,7 +14,7 @@ dependencies:
   flutter:
     sdk: flutter
   workmanager_platform_interface: ^0.10.4
-  workmanager_android: ^0.10.6
+  workmanager_android: ^0.10.7
   workmanager_apple: ^0.9.10
   workmanager_web: ^0.2.0
   workmanager_linux: ^0.1.1

--- a/workmanager_android/CHANGELOG.md
+++ b/workmanager_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.10.7
+
+ - **FIX**(android): expedited work no longer fails when Android 16 revokes a foreground-service permission at runtime (#731).
+
 ## 0.10.6
 
  - **FIX**(android): make FOREGROUND_SERVICE_DATA_SYNC opt-in (#725).

--- a/workmanager_android/pubspec.yaml
+++ b/workmanager_android/pubspec.yaml
@@ -1,6 +1,6 @@
 name: workmanager_android
 description: Android implementation of the workmanager plugin.
-version: 0.10.6
+version: 0.10.7
 # publish_to: none
 homepage: https://github.com/fluttercommunity/flutter_workmanager
 repository: https://github.com/fluttercommunity/flutter_workmanager


### PR DESCRIPTION
Release bump for the #733 fix (workmanager_android 0.10.7, workmanager 0.10.8).

- workmanager_android: 0.10.6 → 0.10.7 — expedited work no longer fails when Android 16 revokes a foreground-service permission at runtime (#731)
- workmanager: 0.10.7 → 0.10.8 — depends on workmanager_android ^0.10.7