### PR TITLE
fix(android): bound Dart engine init and stop workers on the main thread (fixes #732)

### DIFF
--- a/workmanager_android/android/src/main/kotlin/dev/fluttercommunity/workmanager/BackgroundWorker.kt
+++ b/workmanager_android/android/src/main/kotlin/dev/fluttercommunity/workmanager/BackgroundWorker.kt
@@ -34,6 +34,17 @@ class BackgroundWorker(
     companion object {
         const val PAYLOAD_KEY = "dev.fluttercommunity.workmanager.INPUT_DATA"
         const val DART_TASK_KEY = "dev.fluttercommunity.workmanager.DART_TASK"
+
+        /**
+         * How long the Dart engine may take to acknowledge the background
+         * channel initialization after the worker started. A cold engine
+         * start takes well under a second on release builds and a few seconds
+         * on debug builds, so this is generous; its purpose is to turn a dead
+         * Dart engine (failed isolate start, lost acknowledgement) into a
+         * visible worker failure instead of a task stuck in the RUNNING state
+         * forever (see #732).
+         */
+        const val DART_INITIALIZATION_TIMEOUT_MILLIS = 30_000L
     }
 
     private val payload
@@ -52,7 +63,20 @@ class BackgroundWorker(
 
     private val runAttemptCount = workerParams.runAttemptCount
     private val randomThreadIdentifier = SecureRandom().nextInt()
+
+    /**
+     * All interaction with the Flutter engine (channel sends included) must
+     * happen on the main thread: engine methods are annotated `@UiThread` and
+     * throw on any other thread. WorkManager may invoke [onStopped] from one
+     * of its executor threads, so this handler is used to hop back to the
+     * main looper.
+     */
+    private val mainHandler = Handler(Looper.getMainLooper())
+
+    @Volatile
     private var engine: FlutterEngine? = null
+
+    private var initializationWatchdog: DartInitializationWatchdog? = null
 
     /**
      * The plugin instance attached to this worker's engine. The Dart task
@@ -152,9 +176,34 @@ class BackgroundWorker(
                     ),
                 )
 
+                // The worker's result future is only resolved once the Dart
+                // side acknowledges the initialized background channel. If
+                // the engine fails to start the Dart isolate, or the
+                // acknowledgement is lost, the worker would otherwise stay
+                // in the RUNNING state forever (see #732). Arm a watchdog
+                // that fails the worker when the acknowledgement does not
+                // arrive in time; it is disarmed on acknowledgement and on
+                // stop.
+                val watchdog =
+                    DartInitializationWatchdog(
+                        handler = mainHandler,
+                        timeoutMillis = DART_INITIALIZATION_TIMEOUT_MILLIS,
+                    ) {
+                        if (!isStopped) {
+                            stopEngine(
+                                Result.failure(),
+                                "Dart engine did not initialize the background channel " +
+                                    "within $DART_INITIALIZATION_TIMEOUT_MILLIS ms",
+                            )
+                        }
+                    }
+                initializationWatchdog = watchdog
+                watchdog.arm()
+
                 // Initialize the background channel
                 flutterApi.backgroundChannelInitialized {
                     // Channel is initialized, now execute the task
+                    watchdog.disarm()
                     executeBackgroundTask()
                 }
             }
@@ -201,28 +250,37 @@ class BackgroundWorker(
         val localDartTask = dartTask
         val stopReason = workerStopReason()
 
-        // Notify the running Dart callback that WorkManager stopped the worker
-        // (cancelled, timed out, preempted, ...) so it can persist state or
-        // release resources before the engine is torn down.
-        if (localDartTask != null && ::flutterApi.isInitialized && engine != null) {
-            try {
-                flutterApi.onTaskStopped(localDartTask, stopReason.toLong()) {
-                    stopEngine(null, stopReason = stopReason)
+        // WorkManager invokes onStopped() from one of its executor threads
+        // (e.g. "WM.task-N"), and the Flutter engine only allows @UiThread
+        // methods (channel sends included) on the main thread — calling the
+        // Pigeon API directly here throws IllegalStateException on modern
+        // engines (see #732). Notify the Dart callback that WorkManager
+        // stopped the worker (cancelled, timed out, preempted, ...) so it can
+        // persist state or release resources before the engine is torn down;
+        // onStopped() itself returns immediately.
+        mainHandler.post {
+            initializationWatchdog?.disarm()
+
+            if (localDartTask != null && ::flutterApi.isInitialized && engine != null) {
+                try {
+                    flutterApi.onTaskStopped(localDartTask, stopReason.toLong()) {
+                        stopEngine(null, stopReason = stopReason)
+                    }
+                    return@post
+                } catch (e: Exception) {
+                    WorkmanagerDebug.onExceptionEncountered(
+                        applicationContext,
+                        TaskDebugInfo(
+                            taskName = localDartTask,
+                            inputData = payload,
+                            startTime = startTime,
+                        ),
+                        e,
+                    )
                 }
-                return
-            } catch (e: Exception) {
-                WorkmanagerDebug.onExceptionEncountered(
-                    applicationContext,
-                    TaskDebugInfo(
-                        taskName = localDartTask,
-                        inputData = payload,
-                        startTime = startTime,
-                    ),
-                    e,
-                )
             }
+            stopEngine(null, stopReason = stopReason)
         }
-        stopEngine(null, stopReason = stopReason)
     }
 
     /**
@@ -304,10 +362,15 @@ class BackgroundWorker(
         boundPlugin?.unbindWorker(this)
         boundPlugin = null
 
-        // If stopEngine is called from `onStopped`, it may not be from the main thread.
-        Handler(Looper.getMainLooper()).post {
-            engine?.destroy()
-            engine = null
+        // Teardown is idempotent: engine is cleared synchronously (stopEngine
+        // may be invoked from the watchdog, the task result callback and the
+        // stop path) and destroyed on the main thread.
+        val engineToDestroy = engine
+        engine = null
+        if (engineToDestroy != null) {
+            mainHandler.post {
+                engineToDestroy.destroy()
+            }
         }
     }
 

--- a/workmanager_android/android/src/main/kotlin/dev/fluttercommunity/workmanager/DartInitializationWatchdog.kt
+++ b/workmanager_android/android/src/main/kotlin/dev/fluttercommunity/workmanager/DartInitializationWatchdog.kt
@@ -1,0 +1,44 @@
+package dev.fluttercommunity.workmanager
+
+import android.os.Handler
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * Bounds the Dart engine initialization handshake of a [BackgroundWorker].
+ *
+ * The worker's result future is only resolved once the Dart side acknowledges
+ * `backgroundChannelInitialized`. If the engine fails to start the Dart
+ * isolate, or the acknowledgement is lost, the worker would otherwise stay in
+ * the RUNNING state forever (see #732). This watchdog fires [timeoutAction]
+ * when the acknowledgement does not arrive within [timeoutMillis].
+ *
+ * [arm] and [disarm] are idempotent and safe to call from any thread: the
+ * action fires at most once, and only while the watchdog is armed.
+ */
+internal class DartInitializationWatchdog(
+    private val handler: Handler,
+    private val timeoutMillis: Long,
+    private val timeoutAction: () -> Unit,
+) {
+    private val armed = AtomicBoolean(false)
+    private val timeoutRunnable =
+        Runnable {
+            if (armed.compareAndSet(true, false)) {
+                timeoutAction()
+            }
+        }
+
+    /** Starts the countdown. No-op if already armed or already fired. */
+    fun arm() {
+        if (armed.compareAndSet(false, true)) {
+            handler.postDelayed(timeoutRunnable, timeoutMillis)
+        }
+    }
+
+    /** Cancels the countdown. No-op if not armed or already fired. */
+    fun disarm() {
+        if (armed.compareAndSet(true, false)) {
+            handler.removeCallbacks(timeoutRunnable)
+        }
+    }
+}

--- a/workmanager_android/android/src/test/kotlin/dev/fluttercommunity/workmanager/DartInitializationWatchdogTest.kt
+++ b/workmanager_android/android/src/test/kotlin/dev/fluttercommunity/workmanager/DartInitializationWatchdogTest.kt
@@ -1,0 +1,122 @@
+package dev.fluttercommunity.workmanager
+
+import android.os.Handler
+import android.os.Looper
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+import java.time.Duration
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class DartInitializationWatchdogTest {
+    private val mainLooper = Looper.getMainLooper()
+
+    private fun createWatchdog(onTimeout: () -> Unit): DartInitializationWatchdog =
+        DartInitializationWatchdog(
+            handler = Handler(mainLooper),
+            timeoutMillis = TIMEOUT_MILLIS,
+            timeoutAction = onTimeout,
+        )
+
+    private fun advance(millis: Long) {
+        shadowOf(mainLooper).idleFor(Duration.ofMillis(millis))
+    }
+
+    @Test
+    fun `timeout action fires when the acknowledgement does not arrive`() {
+        var fired = 0
+        val watchdog = createWatchdog { fired++ }
+
+        watchdog.arm()
+
+        advance(TIMEOUT_MILLIS - 1)
+        assertEquals(0, fired)
+
+        advance(1)
+        assertEquals(1, fired)
+    }
+
+    @Test
+    fun `disarm before the timeout prevents the action`() {
+        var fired = 0
+        val watchdog = createWatchdog { fired++ }
+
+        watchdog.arm()
+        watchdog.disarm()
+
+        advance(TIMEOUT_MILLIS + 1)
+        assertEquals(0, fired)
+    }
+
+    @Test
+    fun `action fires at most once`() {
+        var fired = 0
+        val watchdog = createWatchdog { fired++ }
+
+        watchdog.arm()
+        advance(TIMEOUT_MILLIS + 1)
+        advance(TIMEOUT_MILLIS + 1)
+        assertEquals(1, fired)
+    }
+
+    @Test
+    fun `double arm does not schedule a second countdown`() {
+        var fired = 0
+        val watchdog = createWatchdog { fired++ }
+
+        watchdog.arm()
+        watchdog.arm()
+        advance(TIMEOUT_MILLIS + 1)
+        assertEquals(1, fired)
+    }
+
+    @Test
+    fun `disarm after the timeout fired is a no-op`() {
+        var fired = 0
+        val watchdog = createWatchdog { fired++ }
+
+        watchdog.arm()
+        advance(TIMEOUT_MILLIS + 1)
+        watchdog.disarm()
+        assertEquals(1, fired)
+    }
+
+    @Test
+    fun `re-arming after a timeout restarts the countdown`() {
+        var fired = 0
+        val watchdog = createWatchdog { fired++ }
+
+        watchdog.arm()
+        advance(TIMEOUT_MILLIS + 1)
+        assertEquals(1, fired)
+
+        // The watchdog is one-shot per arm; a fresh arm (e.g. a retried
+        // startWork) must observe the timeout again.
+        watchdog.arm()
+        advance(TIMEOUT_MILLIS - 1)
+        assertEquals(1, fired)
+        advance(1)
+        assertEquals(2, fired)
+    }
+
+    @Test
+    fun `timeout action is invoked on the handler thread`() {
+        val threadName = mutableListOf<String>()
+        val watchdog = createWatchdog { threadName.add(Thread.currentThread().name) }
+
+        watchdog.arm()
+        advance(TIMEOUT_MILLIS + 1)
+
+        assertTrue(threadName.isNotEmpty())
+        assertEquals(Looper.getMainLooper().thread.name, threadName.single())
+    }
+
+    private companion object {
+        const val TIMEOUT_MILLIS = 30_000L
+    }
+}


### PR DESCRIPTION
## Summary

One-off tasks on Android 16 often stop executing: the worker starts (`Starting work for ...`), WorkManager logs `Work WorkGenerationalId(...) is already enqueued for processing` (benign duplicate start — see below), the Dart callback never fires, and the work stays **RUNNING forever** until "Cancel all". The issue's screenshot shows the smoking gun: a debug **"Exception"** notification with `Methods marked with @UiThread must be executed on the main thread. Current thread: WM.task-3`.

**Root cause (two plugin defects):**

1. **`BackgroundWorker.onStopped()` called the Pigeon API from WorkManager's executor thread.** WorkManager invokes `ListenableWorker.stop()` from `WM.task-N`; the Flutter engine only allows `@UiThread` methods (channel sends included) on the main thread, so `flutterApi.onTaskStopped(...)` threw `IllegalStateException` on every stop. Consequences: the Dart `onTaskStopped` callback never fired (the #705 feature was broken in practice), the debug handler reported a spurious exception notification (exactly what the issue shows), and the stop path degraded.
2. **The worker's result future is resolved only when the Dart task completes — with no bound.** If the worker engine's Dart isolate fails to start or the `backgroundChannelInitialized` acknowledgement is lost, nothing ever resolves the future and the work hangs in RUNNING forever (the reported 222s+ wait).

The `already enqueued for processing` log itself is **expected** on Android 15/16: while the app is in the foreground, WorkManager starts a fresh one-off job through both the GreedyScheduler and SystemJobService (JobScheduler delivers the job immediately); the second start is dropped (WorkManager's documented behavior, b/123211993). It reproduces in every run, including fully successful ones.

## Changes

- **`BackgroundWorker`**: the whole stop sequence (`onTaskStopped` + engine teardown) is now dispatched on the main looper; `onStopped()` itself returns immediately.
- **New `DartInitializationWatchdog`**: bounds the Dart engine initialization handshake — if `backgroundChannelInitialized` is not acknowledged within 30 s the worker fails with a visible `Result.failure()` (and the engine is torn down) instead of staying RUNNING forever. Disarmed on acknowledgement and on stop.
- `stopEngine` teardown made idempotent (safe when invoked from the watchdog, the task-result callback and the stop path).

## Verification

- **Android 16 emulator (API 36), repo example app, Flutter 3.44.8:**
  - Before: cancelling a running worker produced the exact `@UiThread ... WM.task-N` "Exception" notification from the issue (confirmed via notification UI dump).
  - After: no exception; the worker cancels cleanly; plain one-off runs are unaffected and complete with SUCCESS.
- **Unit tests**: new `DartInitializationWatchdogTest` (arm/disarm/one-shot/threading semantics); full suite `./gradlew :workmanager_android:testDebugUnitTest` — 63 tests, 0 failures.
- `dart analyze`, `ktlint -F .`, `dart format`, `melos run test` all clean.

Fixes #732