### PR TITLE
ci: skip heavy matrix for release-only changes

### DIFF
--- a/.github/actions/check-changes/action.yml
+++ b/.github/actions/check-changes/action.yml
@@ -26,6 +26,7 @@ runs:
             - 'docs/**'
             - 'README.md'
             - '**/*.md'
+            - '!**/CHANGELOG.md'
           android:
             - 'workmanager_android/**'
             - 'example/android/**'
@@ -36,6 +37,8 @@ runs:
             - 'pubspec.yaml'
             - '.github/workflows/**'
             - '.github/actions/**'
+            - '!**/CHANGELOG.md'
+            - '!**/pubspec.yaml'
           ios:
             - 'workmanager_apple/**'
             - 'example/ios/**'
@@ -46,3 +49,5 @@ runs:
             - 'pubspec.yaml'
             - '.github/workflows/**'
             - '.github/actions/**'
+            - '!**/CHANGELOG.md'
+            - '!**/pubspec.yaml'


### PR DESCRIPTION
Release PRs (like #736) touch only `CHANGELOG.md` and `pubspec.yaml`, but the `check-changes` path filter counted those as both Android **and** iOS changes:

- `docs`: `**/*.md` → every CHANGELOG
- `android`: `workmanager_android/**` + `workmanager/**` → version bumps
- `ios`: `workmanager/**` → same

So every release bump burned ~15 min of macOS runners (native iOS tests, drive_ios) verifying zero code changes.

Adds `!**/CHANGELOG.md` / `!**/pubspec.yaml` negations (supported by dorny/paths-filter) to the android/ios/docs filters. Release-only PRs now run just the fast checks: format, test, package-analysis, publishable, ktlint, check-generated-files. Real code PRs are unaffected — any actual source change still trips the matrix.