### PR TITLE
chore(release): publish packages — workmanager 0.10.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,49 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 2026-09-07
+
+### Changes
+
+---
+
+Packages with breaking changes:
+
+ - There are no breaking changes in this release.
+
+Packages with other changes:
+
+ - [`workmanager` - `v0.10.10`](#workmanager---v01010)
+ - [`workmanager_android` - `v0.10.9`](#workmanager_android---v0109)
+ - [`workmanager_apple` - `v0.9.11`](#workmanager_apple---v0911)
+ - [`workmanager_platform_interface` - `v0.10.5`](#workmanager_platform_interface---v0105)
+
+Packages with dependency updates only:
+
+> Packages listed below depend on other packages in this workspace that have had changes. Their versions have been incremented to bump the minimum dependency versions of the packages they depend upon in this project.
+
+ - `workmanager` - `v0.10.10`
+
+---
+
+#### `workmanager` - `v0.10.10`
+
+ - **FIX**(android): background tasks no longer fail ~30 seconds after start on Android 16 when the Dart isolate boots slowly — the background handshake is Dart-initiated again (#738).
+
+#### `workmanager_android` - `v0.10.9`
+
+ - **FIX**(android): background tasks no longer fail ~30 seconds after start on Android 16 when the Dart isolate boots slowly — the worker now waits for a Dart readiness signal instead of sending the task before the isolate is ready (#738).
+
+#### `workmanager_apple` - `v0.9.11`
+
+ - **FIX**: the plugin accepts the new Dart background-channel readiness signal (parity with the Android handshake fix, #738); no user-facing behavior change yet.
+
+#### `workmanager_platform_interface` - `v0.10.5`
+
+ - **FIX**: added the `notifyBackgroundChannelInitialized` host signal backing the Android handshake fix (#738).
+
+---
+
 ## 2026-08-20
 
 ### Changes

--- a/workmanager/CHANGELOG.md
+++ b/workmanager/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.10.10
+
+ - **FIX**(android): background tasks no longer fail ~30 seconds after start on Android 16 when the Dart isolate boots slowly — the background handshake is Dart-initiated again (#738).
+
 ## 0.10.9
 
  - **FIX**(android): one-off work no longer stays RUNNING forever on Android 16 when the app is backgrounded during task execution (#732).

--- a/workmanager/pubspec.yaml
+++ b/workmanager/pubspec.yaml
@@ -1,6 +1,6 @@
 name: workmanager
 description: Flutter Workmanager. This plugin allows you to schedule background work on Android and iOS.
-version: 0.10.9
+version: 0.10.10
 # publish_to: none
 homepage: https://github.com/fluttercommunity/flutter_workmanager
 repository: https://github.com/fluttercommunity/flutter_workmanager
@@ -13,9 +13,9 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  workmanager_platform_interface: ^0.10.4
-  workmanager_android: ^0.10.8
-  workmanager_apple: ^0.9.10
+  workmanager_platform_interface: ^0.10.5
+  workmanager_android: ^0.10.9
+  workmanager_apple: ^0.9.11
   workmanager_web: ^0.2.0
   workmanager_linux: ^0.1.1
 

--- a/workmanager_android/CHANGELOG.md
+++ b/workmanager_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.10.9
+
+ - **FIX**(android): background tasks no longer fail ~30 seconds after start on Android 16 when the Dart isolate boots slowly — the worker now waits for a Dart readiness signal instead of sending the task before the isolate is ready (#738).
+
 ## 0.10.8
 
  - **FIX**(android): one-off work no longer stays RUNNING forever on Android 16 when the app is backgrounded during task execution (#732).

--- a/workmanager_android/pubspec.yaml
+++ b/workmanager_android/pubspec.yaml
@@ -1,6 +1,6 @@
 name: workmanager_android
 description: Android implementation of the workmanager plugin.
-version: 0.10.8
+version: 0.10.9
 # publish_to: none
 homepage: https://github.com/fluttercommunity/flutter_workmanager
 repository: https://github.com/fluttercommunity/flutter_workmanager

--- a/workmanager_apple/CHANGELOG.md
+++ b/workmanager_apple/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.9.11
+
+ - **FIX**: the plugin accepts the new Dart background-channel readiness signal (parity with the Android handshake fix, #738); no user-facing behavior change yet.
+
 ## 0.9.10
 
  - **FEAT**(android): progress updates for long-running tasks (#720).

--- a/workmanager_apple/pubspec.yaml
+++ b/workmanager_apple/pubspec.yaml
@@ -1,6 +1,6 @@
 name: workmanager_apple
 description: Apple platform (iOS/macOS) implementation of the workmanager plugin.
-version: 0.9.10
+version: 0.9.11
 # publish_to: none
 homepage: https://github.com/fluttercommunity/flutter_workmanager
 repository: https://github.com/fluttercommunity/flutter_workmanager

--- a/workmanager_platform_interface/CHANGELOG.md
+++ b/workmanager_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.10.5
+
+ - **FIX**: added the `notifyBackgroundChannelInitialized` host signal backing the Android handshake fix (#738).
+
 ## 0.10.4
 
  - **FEAT**(android): progress updates for long-running tasks (#720).

--- a/workmanager_platform_interface/pubspec.yaml
+++ b/workmanager_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: workmanager_platform_interface
 description: A common platform interface for the workmanager plugin.
-version: 0.10.4
+version: 0.10.5
 # publish_to: none
 homepage: https://github.com/fluttercommunity/flutter_workmanager
 repository: https://github.com/fluttercommunity/flutter_workmanager


### PR DESCRIPTION
Release for the #738 fix (Dart-initiated background handshake, merged in #739).

- workmanager 0.10.9 → 0.10.10
- workmanager_android 0.10.8 → 0.10.9
- workmanager_apple 0.9.10 → 0.9.11
- workmanager_platform_interface 0.10.4 → 0.10.5